### PR TITLE
Change Charting as a Service from CaaS to ChaaS. 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,4 +3,4 @@
 Project to implement a MaaS and CaaS
 
 * MaaS: Metrics as a Service
-* CaaS: Charts as a Service
+* ChaaS: Charts as a Service


### PR DESCRIPTION
I'm submitting a documentation/project term name change from CaaS to ChaaS because its catchier, more unique (SEO) and has a nicer roll off the tongue as it is pronounced 'Chaz'.

What do you think?
