### PR TITLE
The C* session can be managed externally

### DIFF
--- a/core-api/pom.xml
+++ b/core-api/pom.xml
@@ -31,6 +31,13 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
+
+      <dependency>
+          <groupId>com.datastax.cassandra</groupId>
+          <artifactId>cassandra-driver-core</artifactId>
+          <version>${datastax.driver.version}</version>
+      </dependency>
+
   </dependencies>
 
   <profiles>

--- a/core-api/src/main/java/org/rhq/metrics/core/MetricsService.java
+++ b/core-api/src/main/java/org/rhq/metrics/core/MetricsService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.datastax.driver.core.Session;
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
@@ -15,6 +16,12 @@ public interface MetricsService {
     /** called to start the service up if needed
      * @param params from e.g. servlet context */
     void startUp(Map<String, String> params);
+
+    /**
+     * Startup with a given cassandra session
+     * @param session
+     */
+    void startUp(Session session);
 
     void shutdown();
 
@@ -42,4 +49,6 @@ public interface MetricsService {
     //
     // jsanda
     List<String> listMetrics();
+
+
 }

--- a/metrics-core/src/main/java/org/rhq/metrics/impl/memory/MemoryMetricsService.java
+++ b/metrics-core/src/main/java/org/rhq/metrics/impl/memory/MemoryMetricsService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.datastax.driver.core.Session;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -27,8 +28,13 @@ public class MemoryMetricsService implements MetricsService {
     private Map<String,TLongDoubleMap> storage = new HashMap<>();
 
     @Override
+    public void startUp(Session session) {
+        throw new IllegalArgumentException("Not supported");
+    }
+
+    @Override
     public void startUp(Map<String, String> params) {
-        // Nothing to do for now.
+
     }
 
     @Override

--- a/metrics-core/src/test/java/org/rhq/metrics/core/MetricsServiceTest.java
+++ b/metrics-core/src/test/java/org/rhq/metrics/core/MetricsServiceTest.java
@@ -23,17 +23,13 @@ public class MetricsServiceTest extends MetricsTest {
 
     private MetricsServiceCassandra metricsService;
 
-    private DataAccess dataAccess;
-
     private RawMetricMapper rawMapper = new RawMetricMapper();
 
     @BeforeClass
     public void initClass() {
         initSession();
-        dataAccess = new DataAccess(session);
-
         metricsService = new MetricsServiceCassandra();
-        metricsService.setDataAccess(dataAccess);
+        metricsService.startUp(session);
     }
 
     @BeforeMethod

--- a/metrics-server/src/main/java/org/rhq/metrics/Server.java
+++ b/metrics-server/src/main/java/org/rhq/metrics/Server.java
@@ -57,7 +57,7 @@ public class Server extends Verticle {
             final DataAccess dataAccess = new DataAccess(session);
 
             final MetricsServiceCassandra metricsService = new MetricsServiceCassandra();
-            metricsService.setDataAccess(dataAccess);
+            metricsService.startUp(session);
 
             vertx.eventBus().registerHandler("rhq.metrics.get", new Handler<Message<JsonObject>>() {
                 @Override


### PR DESCRIPTION
With this change the C\* session can be managed externally but the DataAccess implementation remains an internal construct. Previously this was the other way around.
