### PR TITLE
Use testable=false to avoid Package enrichment

### DIFF
--- a/rest-test/src/test/java/org/rhq/metrics/rest/BaseTest.java
+++ b/rest-test/src/test/java/org/rhq/metrics/rest/BaseTest.java
@@ -31,7 +31,7 @@ public class BaseTest {
 
     private static final int HTTP_PORT = 58080;
 
-    @Deployment
+    @Deployment(testable=false)
     public static WebArchive createDeployment() {
         File pomFile = new File("../rest-servlet/pom.xml");
         System.out.println("pomfile " + pomFile.getAbsolutePath());
@@ -49,7 +49,6 @@ public class BaseTest {
     }
 
     @Test
-    @RunAsClient
     public void pingTest() throws Exception {
         Response jsonp = given()
                 .port(HTTP_PORT)
@@ -74,7 +73,6 @@ public class BaseTest {
     }
 
     @Test
-    @RunAsClient
     public void testAddGetValue() throws Exception {
 
         Map<String,Object> data = new HashMap<>();


### PR DESCRIPTION
As long as the TestClass is only doing ClientSide tests, it's faster
to use testable=false and by pass the Package Enrichment phase.

With testable=false, @RunAsClient is implied as no InContainer enrichment
is prepared.
