### PR TITLE
Fixing build and start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -13,59 +13,18 @@ fi
 
 WFLY_VERSION=`grep "<version.wildfly>" pom.xml | sed -E 's/^.*y>(8.*l)<.*$/\1/'`
 
-if [ ! -e metrics-core/target/rhq-metrics-core*.jar ]
-then
-    cd metrics-core
-    mvn install -DskipTests
-    cd ..
-fi
-
-
-if [ ! -e core-api/target/rhq-metrics-api*.jar ]
-then
-    cd core-api
-    mvn install
-    cd ..
-fi
-
-if [ ! -e metrics-core/target/rhq-metrics-core*.jar ]
-then
-    cd metrics-core
-    mvn install
-    cd ..
-fi
-
-if [ ! -e metrics-core/target/rhq-metrics-core*.jar ]
-then
-    cd metrics-core
-    mvn install
-    cd ..
-fi
-
-if [ ! -e rest-servlet/target/rhq-metric-rest*.war ]
-then
-    cd rest-servlet
-    mvn install
-    cd ..
-fi
-
-if [ ! -e ui/console/target/metrics-console*.war ]
-then
-    cd ui/console
-    mvn install
-    cd ../..
-fi
+mvn install -DskipTests
 
 if [ ! -e target ]
 then
     mkdir target
 fi
 
-if [ ! -e $HOME/.m2/repository/org/wildfly/wildfly-dist/$WFLY_VERSION/wildfly-dist-$WFLY_VERSION.zip ]
-then
-    echo "Downloading WildFly $WFLY_VERSION into local maven repository"
-    mvn -P download_wildfly -DskipTests install
-fi
+#if [ ! -e $HOME/.m2/repository/org/wildfly/wildfly-dist/$WFLY_VERSION/wildfly-dist-$WFLY_VERSION.zip ]
+#then
+#    echo "Downloading WildFly $WFLY_VERSION into local maven repository"
+#    mvn -P download_wildfly -DskipTests install
+#fi
 
 if [ ! -e target/wild* ]
 then

--- a/ui/console/pom.xml
+++ b/ui/console/pom.xml
@@ -5,6 +5,7 @@
         <artifactId>rhq-metrics-parent</artifactId>
         <groupId>org.rhq.metrics</groupId>
         <version>0.2.3-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ui/dummy-ui/pom.xml
+++ b/ui/dummy-ui/pom.xml
@@ -5,6 +5,7 @@
     <artifactId>rhq-metrics-parent</artifactId>
     <groupId>org.rhq.metrics</groupId>
     <version>0.2.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ui/explorer/pom.xml
+++ b/ui/explorer/pom.xml
@@ -5,6 +5,7 @@
         <artifactId>rhq-metrics-parent</artifactId>
         <groupId>org.rhq.metrics</groupId>
         <version>0.2.3-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
I removed all the individual builds in start.sh and replaced with "mvn install" at the root because:
  1 - It is not maintained and usually needs to be fixed before having the script working
  2 - The parent pom doesn't get installed so the build would fail unless it was previously installed or available on a public repo
