### PR TITLE
Use build.finalName = ptrans

### DIFF
--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -50,6 +50,7 @@
   </dependencies>
 
   <build>
+    <finalName>ptrans</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/clients/ptranslator/start.sh
+++ b/clients/ptranslator/start.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-echo "Checking project version..."
-VERSION=`mvn  help:evaluate -Dexpression=project.version | grep -vF "[INFO]"`
-echo "Project version is ${VERSION}"
-
 echo "(Re)building the commons library"
 cd ../common
 mvn install
@@ -12,4 +8,4 @@ cd -
 echo "(Re)building ptrans"
 mvn install
 
-java -Djava.net.preferIPv4Stack=true -jar target/ptrans-${VERSION}-jar-with-dependencies.jar $*
+java -Djava.net.preferIPv4Stack=true -jar target/ptrans-jar-with-dependencies.jar $*


### PR DESCRIPTION
Then you can run the program with:
 java -jar path/to/ptrans-jar-with-dependencies.jar

It simplifies start.sh as well (no need to resolve pom version anymore)
