### PR TITLE
Slim down UI Console WAR

### DIFF
--- a/ui/console/pom.xml
+++ b/ui/console/pom.xml
@@ -25,17 +25,8 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
-                    <webResources>
-                        <resource>
-                            <!-- this is relative to the pom.xml directory -->
-                            <directory>src/main/webapp</directory>
-                            <excludes>
-                                <exclude>*.js</exclude>
-                                <exclude>*.json</exclude>
-                                <exclude>test/**</exclude>
-                            </excludes>
-                        </resource>
-                    </webResources>
+                    <warSourceExcludes>test/**/*,vendor/**/*,node_modules/**/*,**/.*,*.js,*.json,</warSourceExcludes>
+                    <packagingExcludes>WEB-INF/classes</packagingExcludes>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
From 43MB to 8MB

The proper way to exclude webapp resources when copying them to
the target directory is to use the 'warSourceExcludes' tag

Besides, now all resources useless at runtime are listed.

Also, don't pollute the WEB-INF directory with an empty classes directory.
