### PR TITLE
Fixes #62 : do not delete the npm_modules directory when the clean goal ...

### DIFF
--- a/ui/console/pom.xml
+++ b/ui/console/pom.xml
@@ -71,9 +71,6 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>src/main/webapp/node_modules</directory>
-                        </fileset>
-                        <fileset>
                             <directory>src/main/webapp/bower_components</directory>
                         </fileset>
                     </filesets>


### PR DESCRIPTION
...is executed

-> Much, much faster build of the UI console
