### PR TITLE
Rest test: don't rebuild rest war over and over again when Arquillian @D...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
         <version>16.0.1</version>
       </dependency>
       <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>1.7.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.11</version>

--- a/rest-test/pom.xml
+++ b/rest-test/pom.xml
@@ -102,6 +102,10 @@
           <systemPropertyVariables>
             <arquillian.launch>wildfly-as-managed</arquillian.launch>
             <arquillian.jboss_home>${project.build.directory}/wildfly-${version.wildfly}</arquillian.jboss_home>
+            <deployment.groupId>${project.parent.groupId}</deployment.groupId>
+            <deployment.artifactId>rest-servlet</deployment.artifactId>
+            <deployment.packaging>war</deployment.packaging>
+            <deployment.version>${project.parent.version}</deployment.version>
           </systemPropertyVariables>
           <environmentVariables>
             <JBOSS_HOME>${project.build.directory}/wildfly-${version.wildfly}</JBOSS_HOME>
@@ -218,6 +222,11 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>${joda.time.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
...eployment method is executed

The following code:
        WebArchive archive =
        ShrinkWrap.create(MavenImporter.class)
            .offline()
            .loadPomFromFile(pomFile)
            .importBuildOutput()
            .as(WebArchive.class);

internally rebuilds the rest-servlet project from source.

Now the rest-servlet artifact in the local Maven repo is used.

Also, introduced assert-j which provides very nice fluent assertion API.
