### PR TITLE
Require JDK 8 for building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,8 +352,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <showWarnings>true</showWarnings>
         </configuration>
       </plugin>


### PR DESCRIPTION
Tiny little change, but no pushing to master straight so that everyone gets time to read announcement on the mailing list.

So JDK8 is required for building but Java7 only constructs are allowed by default.

After this PR is merged, we can start to discuss changing animal sniffer config for a selection of projects.
