### PR TITLE
add support for data retention in REST API

### DIFF
--- a/core-api/src/main/java/org/rhq/metrics/core/Metric.java
+++ b/core-api/src/main/java/org/rhq/metrics/core/Metric.java
@@ -47,7 +47,11 @@ public abstract class Metric<T extends MetricData> {
         // If the data_retention column is not set, the driver returns zero instead of null.
         // We are (at least for now) using null to indicate that the metric does not have
         // the data retention set.
-        this.dataRetention = dataRetention == 0 ? null : dataRetention;
+        if (dataRetention == null || dataRetention == 0) {
+            this.dataRetention = null;
+        } else {
+            this.dataRetention = dataRetention;
+        }
     }
 
     public abstract MetricType getType();

--- a/metrics-core/src/main/java/org/rhq/metrics/impl/cassandra/MetricsServiceCassandra.java
+++ b/metrics-core/src/main/java/org/rhq/metrics/impl/cassandra/MetricsServiceCassandra.java
@@ -385,7 +385,8 @@ public class MetricsServiceCassandra implements MetricsService {
                 if (type == MetricType.NUMERIC) {
                     return new NumericMetric2(tenantId, id, row.getMap(5, String.class, String.class), row.getInt(6));
                 } else {
-                    return new AvailabilityMetric(tenantId, id, row.getMap(5, String.class, String.class));
+                    return new AvailabilityMetric(tenantId, id, row.getMap(5, String.class, String.class),
+                        row.getInt(6));
                 }
             }
         }, metricsTasks);

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/MetricOut.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/MetricOut.java
@@ -23,6 +23,9 @@ public class MetricOut {
     @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
     private List<DataPointOut> data = new ArrayList<>();
 
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+    private Integer dataRetention;
+
     public MetricOut() {
     }
 
@@ -30,6 +33,13 @@ public class MetricOut {
         this.tenantId = tenantId;
         this.name = name;
         this.metadata = metadata;
+    }
+
+    public MetricOut(String tenantId, String name, Map<String, String> metadata, Integer dataRetention) {
+        this.tenantId = tenantId;
+        this.name = name;
+        this.metadata = metadata;
+        this.dataRetention = dataRetention;
     }
 
     public String getTenantId() {
@@ -62,5 +72,13 @@ public class MetricOut {
 
     public void setData(List<DataPointOut> data) {
         this.data = data;
+    }
+
+    public Integer getDataRetention() {
+        return dataRetention;
+    }
+
+    public void setDataRetention(Integer dataRetention) {
+        this.dataRetention = dataRetention;
     }
 }

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/MetricParams.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/MetricParams.java
@@ -12,6 +12,8 @@ public class MetricParams {
 
     private Map<String, String> metadata = new HashMap<>();
 
+    private Integer dataRetention;
+
     public String getName() {
         return name;
     }
@@ -26,5 +28,13 @@ public class MetricParams {
 
     public void setMetadata(Map<String, String> metadata) {
         this.metadata = metadata;
+    }
+
+    public Integer getDataRetention() {
+        return dataRetention;
+    }
+
+    public void setDataRetention(Integer dataRetention) {
+        this.dataRetention = dataRetention;
     }
 }


### PR DESCRIPTION
This PR adds support for including data retention when creating metrics. The JSON responses have also been updated to include a `dataRetenion` field when it is set.
