### PR TITLE
HWKMETRICS-25 ptrans might wait an arbitrary amount of time before forwarding metrics

### DIFF
--- a/clients/ptranslator/ptrans.conf
+++ b/clients/ptranslator/ptrans.conf
@@ -48,5 +48,7 @@ rest.close-after=200
 # Maximum number of metrics to spool if the server is not reachable
 spool.size=10000
 
-# Minimum batch size of metrics to be forwarded (from one source)
-batch.size=5
+# Ganglia, statsd and collectd services batch incoming metrics before forwarding
+# Batches are forwarded when they reach 'batch.size' or no metric was added for 'batch.delay' (in seconds)
+batch.size=50
+batch.delay=1

--- a/clients/ptranslator/src/assembly/dist/assets/ptrans.conf
+++ b/clients/ptranslator/src/assembly/dist/assets/ptrans.conf
@@ -48,5 +48,7 @@ rest.close-after=200
 # Maximum number of metrics to spool if the server is not reachable
 spool.size=10000
 
-# Minimum batch size of metrics to be forwarded (from one source)
-batch.size=5
+# Ganglia, statsd and collectd services batch incoming metrics before forwarding
+# Batches are forwarded when they reach 'batch.size' or no metric was added for 'batch.delay' (in seconds)
+batch.size=50
+batch.delay=1

--- a/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/Configuration.java
+++ b/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/Configuration.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.metrics.clients.ptrans;
 
+import static org.hawkular.metrics.clients.ptrans.ConfigurationKey.BATCH_DELAY;
 import static org.hawkular.metrics.clients.ptrans.ConfigurationKey.BATCH_SIZE;
 import static org.hawkular.metrics.clients.ptrans.ConfigurationKey.COLLECTD_PORT;
 import static org.hawkular.metrics.clients.ptrans.ConfigurationKey.GANGLIA_GROUP;
@@ -56,15 +57,27 @@ public class Configuration {
     private final int collectdPort;
     private final String multicastIfOverride;
     private final int minimumBatchSize;
+    private final int maximumBatchDelay;
     private final URI restUrl;
     private final int restCloseAfterRequests;
     private final int spoolSize;
     private final Set<String> validationMessages;
 
     private Configuration(
-            Set<Service> services, int udpPort, int tcpPort, int gangliaPort, String gangliaGroup, int statsDport,
-            int collectdPort, String multicastIfOverride, int minimumBatchSize, URI restUrl, int restCloseAfterRequests,
-            int spoolSize, Set<String> validationMessages
+            Set<Service> services,
+            int udpPort,
+            int tcpPort,
+            int gangliaPort,
+            String gangliaGroup,
+            int statsDport,
+            int collectdPort,
+            String multicastIfOverride,
+            int minimumBatchSize,
+            int maximumBatchDelay,
+            URI restUrl,
+            int restCloseAfterRequests,
+            int spoolSize,
+            Set<String> validationMessages
     ) {
         this.services = services;
         this.udpPort = udpPort;
@@ -75,6 +88,7 @@ public class Configuration {
         this.gangliaGroup = gangliaGroup;
         this.multicastIfOverride = multicastIfOverride;
         this.minimumBatchSize = minimumBatchSize;
+        this.maximumBatchDelay = maximumBatchDelay;
         this.restUrl = restUrl;
         this.restCloseAfterRequests = restCloseAfterRequests;
         this.spoolSize = spoolSize;
@@ -91,15 +105,27 @@ public class Configuration {
         String multicastIfOverride = properties.getProperty(GANGLIA_MULTICAST_INTERFACE.getExternalForm());
         int statsDport = getIntProperty(properties, STATSD_PORT, 8125);
         int collectdPort = getIntProperty(properties, COLLECTD_PORT, 25826);
-        int minimumBatchSize = getIntProperty(properties, BATCH_SIZE, 5);
+        int minimumBatchSize = getIntProperty(properties, BATCH_SIZE, 50);
+        int maximumBatchDelay = getIntProperty(properties, BATCH_DELAY, 1);
         URI restUrl = URI.create(properties.getProperty(REST_URL.getExternalForm(),
             "http://localhost:8080/hawkular-metrics/metrics"));
         int restCloseAfterRequests = getIntProperty(properties, REST_CLOSE_AFTER_REQUESTS, 200);
         int spoolSize = getIntProperty(properties, SPOOL_SIZE, 10000);
         return new Configuration(
-                services, udpPort, tcpPort, gangliaPort, gangliaGroup, statsDport,
-                collectdPort, multicastIfOverride, minimumBatchSize, restUrl, restCloseAfterRequests,
-                spoolSize, validationMessages
+                services,
+                udpPort,
+                tcpPort,
+                gangliaPort,
+                gangliaGroup,
+                statsDport,
+                collectdPort,
+                multicastIfOverride,
+                minimumBatchSize,
+                maximumBatchDelay,
+                restUrl,
+                restCloseAfterRequests,
+                spoolSize,
+                validationMessages
         );
     }
 
@@ -185,6 +211,10 @@ public class Configuration {
 
     public int getMinimumBatchSize() {
         return minimumBatchSize;
+    }
+
+    public int getMaximumBatchDelay() {
+        return maximumBatchDelay;
     }
 
     public URI getRestUrl() {

--- a/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/ConfigurationKey.java
+++ b/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/ConfigurationKey.java
@@ -42,6 +42,8 @@ public enum ConfigurationKey {
     COLLECTD_PORT("collectd.port"),
     /** Minimum batch size of metrics to be forwarded (from one source) **/
     BATCH_SIZE("batch.size"),
+    /** Maximum time (in seconds) a batch of metrics can stay unchanged before it is forwarded (from one source) **/
+    BATCH_DELAY("batch.delay"),
     /** REST endpoint **/
     REST_URL("rest.url"),
     /** Close connection to rest-server after this many requests **/

--- a/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/collectd/CollectdChannelInitializer.java
+++ b/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/collectd/CollectdChannelInitializer.java
@@ -25,6 +25,7 @@ import org.hawkular.metrics.clients.ptrans.collectd.packet.CollectdPacketDecoder
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.timeout.IdleStateHandler;
 
 /**
  * Channel initializer to be used when bootstrapping a collectd server.
@@ -46,6 +47,7 @@ public class CollectdChannelInitializer extends ChannelInitializer<Channel> {
         pipeline.addLast(new CollectdPacketDecoder());
         pipeline.addLast(new CollectdEventsDecoder());
         pipeline.addLast(new CollectdEventHandler());
+        pipeline.addLast(new IdleStateHandler(configuration.getMaximumBatchDelay(), 0, 0));
         pipeline.addLast(new MetricBatcher("collectd", configuration.getMinimumBatchSize()));
         pipeline.addLast(forwardingHandler);
     }

--- a/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/ganglia/GangliaChannelInitializer.java
+++ b/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/ganglia/GangliaChannelInitializer.java
@@ -23,6 +23,7 @@ import org.hawkular.metrics.clients.ptrans.backend.RestForwardingHandler;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.timeout.IdleStateHandler;
 
 /**
  * Channel initializer to be used when bootstrapping a Ganglia server.
@@ -42,6 +43,7 @@ public class GangliaChannelInitializer extends ChannelInitializer<Channel> {
     public void initChannel(Channel socketChannel) throws Exception {
         ChannelPipeline pipeline = socketChannel.pipeline();
         pipeline.addLast(new UdpGangliaDecoder());
+        pipeline.addLast(new IdleStateHandler(configuration.getMaximumBatchDelay(), 0, 0));
         pipeline.addLast(new MetricBatcher("ganglia", configuration.getMinimumBatchSize()));
         pipeline.addLast(forwardingHandler);
     }

--- a/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/statsd/StatsdChannelInitializer.java
+++ b/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/statsd/StatsdChannelInitializer.java
@@ -23,6 +23,7 @@ import org.hawkular.metrics.clients.ptrans.backend.RestForwardingHandler;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.timeout.IdleStateHandler;
 
 /**
  * Channel initializer to be used when bootstrapping a statsd server.
@@ -42,6 +43,7 @@ public class StatsdChannelInitializer extends ChannelInitializer<Channel> {
     public void initChannel(Channel socketChannel) throws Exception {
         ChannelPipeline pipeline = socketChannel.pipeline();
         pipeline.addLast(new StatsdDecoder());
+        pipeline.addLast(new IdleStateHandler(configuration.getMaximumBatchDelay(), 0, 0));
         pipeline.addLast(new MetricBatcher("statsd", configuration.getMinimumBatchSize()));
         pipeline.addLast(forwardingHandler);
     }

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/MetricBatcherTest.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/MetricBatcherTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.clients.ptrans;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import org.hawkular.metrics.client.common.SingleMetric;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.Timeout;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.timeout.IdleStateEvent;
+
+/**
+ * @author Thomas Segismont
+ */
+public class MetricBatcherTest {
+
+    @Rule
+    public final Timeout globalTimeout = new Timeout(1, MINUTES);
+    @Rule
+    public final TestName testName = new TestName();
+
+    @Test
+    public void batcherShouldNotForwardMetricsIfSizeIsNotReachedAndChannelNotIdle() {
+        int batchSize = 10;
+        MetricBatcher metricBatcher = new MetricBatcher(testName.getMethodName(), batchSize);
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(metricBatcher);
+
+        int metricsCount = batchSize - 5;
+        for (int i = 0; i < metricsCount; i++) {
+            embeddedChannel.writeInbound(
+                    new SingleMetric(
+                            testName.getMethodName(),
+                            System.currentTimeMillis() - i,
+                            13.0d + i
+                    )
+            );
+        }
+
+        assertNull("No batch should be forwarded", embeddedChannel.readInbound());
+    }
+
+    @Test
+    public void batcherShouldForwardMetricsIfSizeIsReached() {
+        int batchSize = 10;
+        MetricBatcher metricBatcher = new MetricBatcher(testName.getMethodName(), batchSize);
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(metricBatcher);
+
+        int expectedBatchesCount = 2;
+        int metricsCount = expectedBatchesCount * batchSize + 5;
+        for (int i = 0; i < metricsCount; i++) {
+            embeddedChannel.writeInbound(
+                    new SingleMetric(
+                            testName.getMethodName(),
+                            System.currentTimeMillis() - i,
+                            13.0d + i
+                    )
+            );
+        }
+
+        for (int i = 0; i < expectedBatchesCount; i++) {
+            checkBatchOutput(embeddedChannel, batchSize);
+        }
+        assertNull("Unexpected batch forwarded", embeddedChannel.readInbound());
+    }
+
+    private void checkBatchOutput(EmbeddedChannel embeddedChannel, int batchSize) {
+        Object object = embeddedChannel.readInbound();
+        assertNotNull("Expected a forwarded batch", object);
+        assertThat(object).isInstanceOf(List.class);
+        List<?> list = (List<?>) object;
+        assertEquals("Unexpected batch size", batchSize, list.size());
+        for (Object item : list) {
+            assertThat(item).isInstanceOf(SingleMetric.class);
+        }
+    }
+
+    @Test
+    public void batcherShouldForwardMetricsIfSizeIsNotReachedButChannelIsIdle() {
+        int batchSize = 10;
+        MetricBatcher metricBatcher = new MetricBatcher(testName.getMethodName(), batchSize);
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(metricBatcher);
+
+        int metricsCount = batchSize - 5;
+        for (int i = 0; i < metricsCount; i++) {
+            embeddedChannel.writeInbound(
+                    new SingleMetric(
+                            testName.getMethodName(),
+                            System.currentTimeMillis() - i,
+                            13.0d + i
+                    )
+            );
+        }
+
+        embeddedChannel.pipeline().fireUserEventTriggered(IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT);
+
+        checkBatchOutput(embeddedChannel, metricsCount);
+        assertNull("Unexpected batch forwarded", embeddedChannel.readInbound());
+    }
+}

--- a/clients/ptranslator/src/test/resources/ptrans.conf
+++ b/clients/ptranslator/src/test/resources/ptrans.conf
@@ -48,5 +48,7 @@ rest.close-after=200
 # Maximum number of metrics to spool if the server is not reachable
 spool.size=10000
 
-# Minimum batch size of metrics to be forwarded (from one source)
-batch.size=5
+# Ganglia, statsd and collectd services batch incoming metrics before forwarding
+# Batches are forwarded when they reach 'batch.size' or no metric was added for 'batch.delay' (in seconds)
+batch.size=50
+batch.delay=1


### PR DESCRIPTION
Ganglia, statsd and collectd sources use a metric batcher. If the data incoming rate is low and the batch size high, then ptrans might wait an arbitrary amount of time before forwarding metrics.

For example:
* collectd sending only 1 metric, one value per minute
* batch size set to 5
-> then ptrans will wait 5 minutes before sending a batch of 5 metrics

This PR introduces a batch.delay parameter in ptrans configuration file.
Now MetricBatcher class will output a list of metrics when batch.size is reached or no metric was added since (batch.delay) seconds. 