### PR TITLE
[HWKMETRICS-27] Swagger annotations

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -101,7 +101,6 @@
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-core_2.10</artifactId>
       <version>${swagger.version}</version>
-      <!--<scope>provided</scope>-->
     </dependency>
 
     <!-- test -->

--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -35,7 +35,7 @@
   <description>The REST-api of Hawkular-Metrics implemented via JAXRS archive</description>
 
   <properties>
-    <swagger-annotations.version>1.3.12</swagger-annotations.version>
+    <swagger.version>1.3.12</swagger.version>
     <rest-docs-generator.version>4.11.0</rest-docs-generator.version>
   </properties>
 
@@ -94,8 +94,14 @@
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>${swagger-annotations.version}</version>
+      <version>${swagger.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.wordnik</groupId>
+      <artifactId>swagger-core_2.10</artifactId>
+      <version>${swagger.version}</version>
+      <!--<scope>provided</scope>-->
     </dependency>
 
     <!-- test -->
@@ -162,6 +168,33 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <version>2.3.3</version>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <locations>org.hawkular.metrics.api.jaxrs</locations>
+              <apiVersion>1.0</apiVersion>
+              <basePath>http://localhost:8080/rhq-metrics/</basePath>
+              <outputTemplate>src/main/resources/rest-doc/asciidoc.mustache</outputTemplate>
+              <swaggerDirectory>generated/swagger-ui</swaggerDirectory>
+              <swaggerInternalFilter>org.hawkular.metrics.api.jaxrs.swagger.filter.JaxRsFilter</swaggerInternalFilter>
+              <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
+              <outputPath>${basedir}/generated/rest-api-doc.adoc</outputPath>
+            </apiSource>
+          </apiSources>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -174,159 +207,35 @@
         </property>
       </activation>
 
-      <dependencies>
-        <dependency>
-          <groupId>org.rhq.helpers</groupId>
-          <artifactId>rest-docs-generator</artifactId>
-          <version>${rest-docs-generator.version}</version>
-          <scope>provided</scope>
-        </dependency>
-      </dependencies>
-
       <build>
         <!-- Document generation from the Annotations on the REST-API. -->
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
+            <groupId>com.github.kongchen</groupId>
+            <artifactId>swagger-maven-plugin</artifactId>
+            <version>2.3.3</version>
             <configuration>
-              <annotationProcessors>
-                <processor>org.rhq.helpers.rest_docs_generator.ClassLevelProcessor</processor>
-              </annotationProcessors>
-              <proc>only</proc>
-              <compilerArguments>
-                <AtargetDirectory>${project.build.directory}/docs/xml</AtargetDirectory>
-                <AmodelPkg>org.hawkular.metrics.restServlet</AmodelPkg>
-                <!--<AskipPkg>org.rhq.enterprise.server.rest.reporting</AskipPkg> -->
-                <!-- enable the next line to have the output of the processor
-                  shown on console -->
-                <!--<Averbose>true</Averbose> -->
-              </compilerArguments>
-              <!-- set the next to true to enable verbose output of the compiler
-                plugin; default from the evn is true, but this is too noisy -->
-              <verbose>false</verbose>
+              <apiSources>
+                <apiSource>
+                  <locations>org.hawkular.metrics.api.jaxrs</locations>
+                  <apiVersion>1.0</apiVersion>
+                  <basePath>http://localhost:8080/rhq-metrics/</basePath>
+                  <outputTemplate>src/main/resources/rest-doc/asciidoc.mustache</outputTemplate>
+                  <swaggerDirectory>generated/swagger-ui</swaggerDirectory>
+                  <swaggerInternalFilter>org.hawkular.metrics.api.jaxrs.swagger.filter.JaxRsFilter</swaggerInternalFilter>
+                  <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
+                  <outputPath>${basedir}/generated/rest-api-doc.adoc</outputPath>
+                </apiSource>
+              </apiSources>
             </configuration>
             <executions>
               <execution>
-                <id>create-rest-api-reports</id>
-                <phase>process-classes</phase>
+                <phase>compile</phase>
                 <goals>
-                  <!-- We want to process the classes in src/ -->
-                  <goal>compile</goal>
+                  <goal>generate</goal>
                 </goals>
               </execution>
             </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>xml-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>process-classes</phase>
-                <goals>
-                  <goal>transform</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <transformationSets>
-                <transformationSet>
-                  <!-- Generate a html rendering -->
-                  <!-- org.rhq.helpers.rest_docs_generator.test plugin wrote
-                    to target/docs/xml (see -AtargetDirectory above) -->
-                  <dir>target/docs/xml</dir>
-                  <includes>
-                    <include>rest-api-out.xml</include>
-                  </includes>
-                  <stylesheet>src/main/xsl/apiout2html.xsl</stylesheet>
-                  <parameters>
-                    <parameter>
-                      <name>basePath</name>
-                      <value>http://localhost:8080/hawkular-metrics</value>
-                    </parameter>
-                  </parameters>
-                  <outputDir>${project.build.directory}/docs/html</outputDir>
-                  <fileMappers>
-                    <fileMapper
-                      implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
-                      <targetExtension>.html</targetExtension>
-                    </fileMapper>
-                  </fileMappers>
-                </transformationSet>
-                <transformationSet>
-                  <!-- Generate a html rendering of a short form -->
-                  <!-- org.rhq.helpers.rest_docs_generator.test plugin wrote
-                    to target/docs/xml (see -AtargetDirectory above) -->
-                  <dir>target/docs/xml</dir>
-                  <includes>
-                    <include>rest-api-out.xml</include>
-                  </includes>
-                  <stylesheet>src/main/xsl/apiout2html_overview.xsl</stylesheet>
-                  <parameters>
-                    <parameter>
-                      <name>basePath</name>
-                      <value>http://localhost:8080/hawkular-metrics</value>
-                    </parameter>
-                  </parameters>
-                  <outputDir>${project.build.directory}/docs/html</outputDir>
-                  <fileMappers>
-                    <fileMapper
-                      implementation="org.codehaus.plexus.components.io.filemappers.MergeFileMapper">
-                      <targetName>rest-api-overview</targetName>
-                    </fileMapper>
-                    <fileMapper
-                      implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
-                      <targetExtension>.html</targetExtension>
-                    </fileMapper>
-                  </fileMappers>
-                </transformationSet>
-                <transformationSet>
-                  <!-- Generate a docbook file as input to fop -->
-                  <!-- org.rhq.helpers.rest_docs_generator.test plugin wrote
-                    to target/docs/xml (see -AtargetDirectory above) -->
-                  <dir>target/docs/xml</dir>
-                  <includes>
-                    <include>rest-api-out.xml</include>
-                  </includes>
-                  <stylesheet>src/main/xsl/apiout2docbook.xsl</stylesheet>
-                  <parameters>
-                    <parameter>
-                      <name>basePath</name>
-                      <value>http://localhost:8080/hawkular-metrics</value>
-                    </parameter>
-                  </parameters>
-                  <outputDir>${project.build.directory}/docs/xml</outputDir>
-                  <fileMappers>
-                    <fileMapper
-                      implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
-                      <targetExtension>.dbx.xml</targetExtension>
-                    </fileMapper>
-                  </fileMappers>
-                </transformationSet>
-              </transformationSets>
-            </configuration>
-          </plugin>
-
-          <plugin>
-            <groupId>com.agilejava.docbkx</groupId>
-            <artifactId>docbkx-maven-plugin</artifactId>
-            <version>2.0.14</version>
-            <executions>
-              <execution>
-                <phase>process-classes</phase>
-                <goals>
-                  <goal>generate-pdf</goal>
-                  <goal>generate-html</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <sourceDirectory>target/docs/xml</sourceDirectory> <!-- from previous plugin, 2nd transformation set -->
-              <includes>rest-api-out.dbx.xml</includes>
-              <hyphenate>true</hyphenate>
-              <generateToc>true</generateToc>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -167,48 +167,15 @@
             -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</jvmArgs>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>com.github.kongchen</groupId>
-        <artifactId>swagger-maven-plugin</artifactId>
-        <version>2.3.3</version>
-        <configuration>
-          <apiSources>
-            <apiSource>
-              <locations>org.hawkular.metrics.api.jaxrs</locations>
-              <apiVersion>1.0</apiVersion>
-              <basePath>http://localhost:8080/rhq-metrics/</basePath>
-              <outputTemplate>src/main/resources/rest-doc/asciidoc.mustache</outputTemplate>
-              <swaggerDirectory>generated/swagger-ui</swaggerDirectory>
-              <swaggerInternalFilter>org.hawkular.metrics.api.jaxrs.swagger.filter.JaxRsFilter</swaggerInternalFilter>
-              <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
-              <outputPath>${basedir}/generated/rest-api-doc.adoc</outputPath>
-            </apiSource>
-          </apiSources>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>compile</phase>
-            <goals>
-              <goal>generate</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
   <profiles>
     <profile>
-      <id>REST doc generation</id>
-      <activation>
-        <property>
-          <name>docgen</name>
-        </property>
-      </activation>
+      <id>docgen</id>
 
       <build>
-        <!-- Document generation from the Annotations on the REST-API. -->
+        <!-- Document generation from the Swagger annotations on the REST-API. -->
         <plugins>
           <plugin>
             <groupId>com.github.kongchen</groupId>

--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -35,7 +35,7 @@
   <description>The REST-api of Hawkular-Metrics implemented via JAXRS archive</description>
 
   <properties>
-    <swagger-annotations.version>1.2.3</swagger-annotations.version>
+    <swagger-annotations.version>1.3.12</swagger-annotations.version>
     <rest-docs-generator.version>4.11.0</rest-docs-generator.version>
   </properties>
 
@@ -93,7 +93,7 @@
     <!-- documentation -->
     <dependency>
       <groupId>com.wordnik</groupId>
-      <artifactId>swagger-annotations_2.9.1</artifactId>
+      <artifactId>swagger-annotations</artifactId>
       <version>${swagger-annotations.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AvailabilityDataParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AvailabilityDataParams.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.google.common.base.Objects;
 import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * @author John Sanda
@@ -34,6 +35,7 @@ public class AvailabilityDataParams extends MetricDataParams {
 
     private List<AvailabilityDataPoint> data = new ArrayList<>();
 
+    @ApiModelProperty(required = true, value = "Event timestamp in POSIX format")
     public Long getTimestamp() {
         return timestamp;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AvailabilityDataParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AvailabilityDataParams.java
@@ -20,10 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Objects;
+import com.wordnik.swagger.annotations.ApiModel;
 
 /**
  * @author John Sanda
  */
+@ApiModel
 public class AvailabilityDataParams extends MetricDataParams {
 
     private Long timestamp;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AvailabilityDataPoint.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AvailabilityDataPoint.java
@@ -21,10 +21,12 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
+import com.wordnik.swagger.annotations.ApiModel;
 
 /**
  * @author John Sanda
  */
+@ApiModel
 public class AvailabilityDataPoint {
 
     private long timestamp;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AvailabilityDataPoint.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AvailabilityDataPoint.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * @author John Sanda
@@ -36,6 +37,7 @@ public class AvailabilityDataPoint {
     @JsonInclude(Include.NON_EMPTY)
     private Set<String> tags;
 
+    @ApiModelProperty(required = true, value = "Event timestamp in POSIX format")
     public long getTimestamp() {
         return timestamp;
     }
@@ -52,6 +54,7 @@ public class AvailabilityDataPoint {
         this.value = value;
     }
 
+    @ApiModelProperty(required = false, value = "Set of tags associated with this metric")
     public Set<String> getTags() {
         return tags;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/BucketDataPoint.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/BucketDataPoint.java
@@ -18,15 +18,15 @@ package org.hawkular.metrics.api.jaxrs;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.wordnik.swagger.annotations.ApiClass;
-import com.wordnik.swagger.annotations.ApiProperty;
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * A point in time with some data for min/avg/max to express
  * that at this point in time multiple values were recorded.
  * @author Heiko W. Rupp
  */
-@ApiClass(description = "A bucket is a time range with multiple data items represented by min/avg/max values" +
+@ApiModel(value = "A bucket is a time range with multiple data items represented by min/avg/max values" +
     "for that time span.")
 @XmlRootElement
 public class BucketDataPoint extends IdDataPoint {
@@ -47,7 +47,7 @@ public class BucketDataPoint extends IdDataPoint {
         this.avg = avg;
     }
 
-    @ApiProperty("Minimum value during the time span of the bucket.")
+    @ApiModelProperty(value = "Minimum value during the time span of the bucket.")
     public double getMin() {
         return min;
     }
@@ -56,7 +56,7 @@ public class BucketDataPoint extends IdDataPoint {
         this.min = min;
     }
 
-    @ApiProperty("Maximum value during the time span of the bucket.")
+    @ApiModelProperty(value = "Maximum value during the time span of the bucket.")
     public double getMax() {
         return max;
     }
@@ -65,7 +65,7 @@ public class BucketDataPoint extends IdDataPoint {
         this.max = max;
     }
 
-    @ApiProperty("Average value during the time span of the bucket.")
+    @ApiModelProperty(value = "Average value during the time span of the bucket.")
     public double getAvg() {
         return avg;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DataPoint.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DataPoint.java
@@ -18,14 +18,14 @@ package org.hawkular.metrics.api.jaxrs;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.wordnik.swagger.annotations.ApiClass;
-import com.wordnik.swagger.annotations.ApiProperty;
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * One single data point
  * @author Heiko W. Rupp
  */
-@ApiClass("A data point for collections where each data point has the same id.")
+@ApiModel(value = "A data point for collections where each data point has the same id.")
 @XmlRootElement
 public class DataPoint {
 
@@ -40,7 +40,7 @@ public class DataPoint {
         this.value = value;
     }
 
-    @ApiProperty("Time when the value was obtained in milliseconds since epoch")
+    @ApiModelProperty(value = "Time when the value was obtained in milliseconds since epoch")
     public long getTimestamp() {
         return timestamp;
     }
@@ -49,7 +49,7 @@ public class DataPoint {
         this.timestamp = timestamp;
     }
 
-    @ApiProperty("The value of this data point")
+    @ApiModelProperty(value = "The value of this data point")
     public double getValue() {
         return value;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DataPointOut.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DataPointOut.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * @author John Sanda
@@ -49,6 +50,7 @@ public class DataPointOut {
         this.tags = tags;
     }
 
+    @ApiModelProperty(required = true, value = "Event timestamp in POSIX format")
     public long getTimestamp() {
         return timestamp;
     }
@@ -61,6 +63,7 @@ public class DataPointOut {
         return value;
     }
 
+    @ApiModelProperty(required = true)
     public void setValue(Object value) {
         this.value = value;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DataPointOut.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DataPointOut.java
@@ -21,10 +21,12 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.wordnik.swagger.annotations.ApiModel;
 
 /**
  * @author John Sanda
  */
+@ApiModel
 public class DataPointOut {
 
     private long timestamp;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/IdDataPoint.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/IdDataPoint.java
@@ -18,14 +18,14 @@ package org.hawkular.metrics.api.jaxrs;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.wordnik.swagger.annotations.ApiClass;
-import com.wordnik.swagger.annotations.ApiProperty;
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * A data point with an Id
  * @author Heiko W. Rupp
  */
-@ApiClass("One data point for a metric with id, timestamp and value. Inherits from DataPoint.")
+@ApiModel(value = "One data point for a metric with id, timestamp and value. Inherits from DataPoint.")
 @XmlRootElement
 public class IdDataPoint extends DataPoint {
 
@@ -39,7 +39,7 @@ public class IdDataPoint extends DataPoint {
         this.id = id;
     }
 
-    @ApiProperty("Id of the metric")
+    @ApiModelProperty(value = "Id of the metric")
     public String getId() {
         return id;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricDataParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricDataParams.java
@@ -19,15 +19,20 @@ package org.hawkular.metrics.api.jaxrs;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
 /**
  * @author John Sanda
  */
+@ApiModel
 public class MetricDataParams {
 
     protected String tenantId;
     protected String name;
     protected Map<String, String> tags = new HashMap<>();
 
+    @ApiModelProperty(required = true, value = "Tenant's unique identifier")
     public String getTenantId() {
         return tenantId;
     }
@@ -36,6 +41,7 @@ public class MetricDataParams {
         this.tenantId = tenantId;
     }
 
+    @ApiModelProperty(required = true, value = "Metric's identifier")
     public String getName() {
         return name;
     }
@@ -44,6 +50,7 @@ public class MetricDataParams {
         this.name = name;
     }
 
+    @ApiModelProperty(required = false, value = "Set of tags associated with this metric")
     public Map<String, String> getTags() {
         return tags;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
@@ -96,8 +96,9 @@ public class MetricHandler {
 
     @POST
     @Path("/{tenantId}/metrics/numeric")
-    @ApiOperation(value = "Create numeric metric definition.",
-            notes = "Clients are not required to explicitly create a metric before storing data. Doing so however allows clients to prevent naming collisions and to specify tags and data retention.")
+    @ApiOperation(value = "Create numeric metric definition.", notes = "Clients are not required to explicitly create "
+            + "a metric before storing data. Doing so however allows clients to prevent naming collisions and to "
+            + "specify tags and data retention.")
     @ApiResponses(value = { @ApiResponse(code = 400, message = "Metric with given id already exists"),
             @ApiResponse(code = 200, message = "Metric definition created successfully"),
             @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error")})
@@ -262,9 +263,10 @@ public class MetricHandler {
     @ApiOperation(value = "Add data for a single numeric metric.")
     @ApiResponses(value = { @ApiResponse(code = 500, message = "Unexpected error happened while storing the data")})
     @Consumes(APPLICATION_JSON)
-    public void addDataForMetric(@Suspended
-    final AsyncResponse asyncResponse, @PathParam("tenantId") final String tenantId, @PathParam("id") String id,
-        @ApiParam(value = "List of datapoints containing timestamp and value", required = true) List<NumericDataPoint> dataPoints) {
+    public void addDataForMetric(@Suspended final AsyncResponse asyncResponse,
+                                 @PathParam("tenantId") final String tenantId, @PathParam("id") String id,
+                                 @ApiParam(value = "List of datapoints containing timestamp and value", required = true)
+                                 List<NumericDataPoint> dataPoints) {
 
         NumericMetric metric = new NumericMetric(tenantId, new MetricId(id));
         for (NumericDataPoint p : dataPoints) {
@@ -345,14 +347,15 @@ public class MetricHandler {
     }
 
     @GET
-    @ApiOperation(value = "Find numeric metrics data by their tags.", response = MetricOut.class, responseContainer = "List")
-    // See HWKMETRICS-26 for details to improve error coding, there should be at least 400 here, and :value should be optional. E
+    @ApiOperation(value = "Find numeric metrics data by their tags.", response = MetricOut.class,
+            responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 200, message = ""),
             @ApiResponse(code = 500, message = "Any error in the query.")})
     @Path("/{tenantId}/numeric")
     public void findNumericDataByTags(@Suspended final AsyncResponse asyncResponse,
         @PathParam("tenantId") String tenantId,
-        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value") @QueryParam("tags") String encodedTags) {
+        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value")
+        @QueryParam("tags") String encodedTags) {
         ListenableFuture<Map<MetricId, Set<NumericData>>> queryFuture = metricsService.findNumericDataByTags(
             tenantId, MetricUtils.decodeTags(encodedTags));
         Futures.addCallback(queryFuture, new FutureCallback<Map<MetricId, Set<NumericData>>>() {
@@ -383,7 +386,8 @@ public class MetricHandler {
     }
 
     @GET
-    @ApiOperation(value = "Find availabilities metrics data by their tags.", response = MetricOut.class, responseContainer = "List")
+    @ApiOperation(value = "Find availabilities metrics data by their tags.", response = MetricOut.class,
+            responseContainer = "List")
     // See above method and HWKMETRICS-26 for fixes.
     @ApiResponses(value = { @ApiResponse(code = 200, message = ""),
             @ApiResponse(code = 204, message = "No matching availability metrics were found."),
@@ -391,7 +395,8 @@ public class MetricHandler {
     @Path("/{tenantId}/availability")
     public void findAvailabilityDataByTags(@Suspended final AsyncResponse asyncResponse,
         @PathParam("tenantId") String tenantId,
-        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value") @QueryParam("tags") String encodedTags) {
+        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value")
+        @QueryParam("tags") String encodedTags) {
         ListenableFuture<Map<MetricId, Set<Availability>>> queryFuture = metricsService.findAvailabilityByTags(
             tenantId, MetricUtils.decodeTags(encodedTags));
         Futures.addCallback(queryFuture, new FutureCallback<Map<MetricId, Set<Availability>>>() {
@@ -438,7 +443,9 @@ public class MetricHandler {
         @PathParam("id") final String id,
         @ApiParam(value = "Defaults to now - 8 hours", required = false) @QueryParam("start") Long start,
         @ApiParam(value = "Defaults to now", required = false) @QueryParam("end") Long end,
-        @ApiParam(value = "The number of buckets or intervals in which to divide the time range. A value of 60 for example will return 60 equally spaced buckets for the time period between start and end times, having max/min/avg calculated for each bucket.") @QueryParam("buckets") final int numberOfBuckets,
+        @ApiParam(value = "The number of buckets or intervals in which to divide the time range. A value of 60 for "
+                + "example will return 60 equally spaced buckets for the time period between start and end times, "
+                + "having max/min/avg calculated for each bucket.") @QueryParam("buckets") final int numberOfBuckets,
         @QueryParam("bucketWidthSeconds") final int bucketWidthSeconds,
         @QueryParam("skipEmpty") @DefaultValue("false") final boolean skipEmpty,
         @QueryParam("bucketCluster") @DefaultValue("true") final boolean bucketCluster) {
@@ -770,7 +777,8 @@ public class MetricHandler {
     }
 
     @GET
-    @ApiOperation(value = "Find numeric metric data with given tags.", response = MetricOut.class, responseContainer = "List")
+    @ApiOperation(value = "Find numeric metric data with given tags.", response = MetricOut.class,
+            responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Numeric values fetched successfully"),
             @ApiResponse(code = 500, message = "Any error while fetching data.")})
     @Path("/{tenantId}/tags/numeric/{tag}")
@@ -817,7 +825,8 @@ public class MetricHandler {
     }
 
     @GET
-    @ApiOperation(value = "Find availability metric data with given tags.", response = MetricOut.class, responseContainer = "List")
+    @ApiOperation(value = "Find availability metric data with given tags.", response = MetricOut.class,
+            responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Availability values fetched successfully"),
             @ApiResponse(code = 500, message = "Any error while fetching data.")})
     @Path("/{tenantId}/tags/availability/{tag}")
@@ -927,7 +936,8 @@ public class MetricHandler {
     }
 
     @GET
-    @ApiOperation(value = "Retrieve a list of counter values in this group", hidden = true, response = Counter.class, responseContainer = "List")
+    @ApiOperation(value = "Retrieve a list of counter values in this group", hidden = true, response = Counter.class,
+            responseContainer = "List")
     @Path("/counters/{group}")
     @Produces({APPLICATION_JSON,APPLICATION_VND_HAWKULAR_WRAPPED_JSON})
     public void getCountersForGroup(@Suspended final AsyncResponse asyncResponse, @PathParam("group") String group) {
@@ -947,7 +957,8 @@ public class MetricHandler {
     }
 
     @GET
-    @ApiOperation(value = "Retrieve value of a counter", hidden = true, response = Counter.class, responseContainer = "List")
+    @ApiOperation(value = "Retrieve value of a counter", hidden = true, response = Counter.class,
+            responseContainer = "List")
     @Path("/counters/{group}/{counter}")
     @Produces({APPLICATION_JSON,APPLICATION_VND_HAWKULAR_WRAPPED_JSON})
     public void getCounter(@Suspended final AsyncResponse asyncResponse, @PathParam("group") final String group,
@@ -975,13 +986,16 @@ public class MetricHandler {
     @GET
     @Path("/{tenantId}/metrics")
     @Produces(APPLICATION_JSON)
-    @ApiOperation(value = "Find tenant's metric definitions.", notes = "Does not include any metric values. ", response = MetricOut.class, responseContainer = "List")
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully retrieved at least one metric definition."),
+    @ApiOperation(value = "Find tenant's metric definitions.", notes = "Does not include any metric values. ",
+            response = MetricOut.class, responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully retrieved at least one metric "
+            + "definition."),
             @ApiResponse(code = 204, message = "No metrics found."),
             @ApiResponse(code = 400, message = "Given type is not a valid type."),
             @ApiResponse(code = 500, message = "Failed to retrieve metrics due to unexpected error.")})
     public void findMetrics(@Suspended final AsyncResponse response, @PathParam("tenantId") final String tenantId,
-        @ApiParam(value = "Queried metric type", required = true, allowableValues = "[num, avail, log]") @QueryParam("type") String type) {
+        @ApiParam(value = "Queried metric type", required = true, allowableValues = "[num, avail, log]")
+        @QueryParam("type") String type) {
         MetricType metricType = null;
         try {
             metricType = MetricType.fromTextCode(type);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
@@ -99,12 +99,12 @@ public class MetricHandler {
     @ApiOperation(value = "Create numeric metric definition.", notes = "Clients are not required to explicitly create "
             + "a metric before storing data. Doing so however allows clients to prevent naming collisions and to "
             + "specify tags and data retention.")
-    @ApiResponses(value = { @ApiResponse(code = 400, message = "Metric with given id already exists"),
-            @ApiResponse(code = 200, message = "Metric definition created successfully"),
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric definition created successfully"),
+            @ApiResponse(code = 400, message = "Metric with given id already exists or request is otherwise incorrect"),
             @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error")})
     @Consumes(APPLICATION_JSON)
     public void createNumericMetric(@Suspended AsyncResponse asyncResponse, @PathParam("tenantId") String tenantId,
-        MetricParams params) {
+                                    @ApiParam(required = true) MetricParams params) {
         NumericMetric metric = new NumericMetric(tenantId, new MetricId(params.getName()), MetricUtils.getTags(
             params.getTags()), params.getDataRetention());
         ListenableFuture<Void> future = metricsService.createMetric(metric);
@@ -119,7 +119,7 @@ public class MetricHandler {
             @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error")})
     @Consumes(APPLICATION_JSON)
     public void createAvailabilityMetric(@Suspended AsyncResponse asyncResponse, @PathParam("tenantId") String tenantId,
-        MetricParams params) {
+                                         @ApiParam(required = true) MetricParams params) {
         AvailabilityMetric metric = new AvailabilityMetric(tenantId, new MetricId(params.getName()),
             MetricUtils.getTags(params.getTags()), params.getDataRetention());
         ListenableFuture<Void> future = metricsService.createMetric(metric);
@@ -175,7 +175,8 @@ public class MetricHandler {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully updated."),
             @ApiResponse(code = 500, message = "Unexpected error occurred while updating metric's tags.")})
     public void updateNumericMetricTags(@Suspended final AsyncResponse response,
-        @PathParam("tenantId") String tenantId, @PathParam("id") String id, Map<String, String> tags) {
+                                        @PathParam("tenantId") String tenantId, @PathParam("id") String id,
+                                        @ApiParam(required = true) Map<String, String> tags) {
         NumericMetric metric = new NumericMetric(tenantId, new MetricId(id));
         ListenableFuture<Void> future = metricsService.addTags(metric, MetricUtils.getTags(tags));
         Futures.addCallback(future, new DataInsertedCallback(response, "Failed to update tags"));
@@ -187,7 +188,9 @@ public class MetricHandler {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully deleted."),
             @ApiResponse(code = 500, message = "Unexpected error occurred while trying to delete metric's tags.")})
     public void deleteNumericMetricTags(@Suspended final AsyncResponse response,
-        @PathParam("tenantId") String tenantId, @PathParam("id") String id, @PathParam("tags") String encodedTags) {
+        @PathParam("tenantId") String tenantId, @PathParam("id") String id,
+        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value")
+        @PathParam("tags") String encodedTags) {
         NumericMetric metric = new NumericMetric(tenantId, new MetricId(id));
         ListenableFuture<Void> future = metricsService.deleteTags(metric, MetricUtils.decodeTags(encodedTags));
         Futures.addCallback(future, new DataInsertedCallback(response, "Failed to delete tags"));
@@ -212,7 +215,8 @@ public class MetricHandler {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully updated."),
             @ApiResponse(code = 500, message = "Unexpected error occurred while updating metric's tags.")})
     public void updateAvailabilityMetricTags(@Suspended final AsyncResponse response,
-        @PathParam("tenantId") String tenantId, @PathParam("id") String id, Map<String, String> tags) {
+        @PathParam("tenantId") String tenantId, @PathParam("id") String id,
+        @ApiParam(required = true) Map<String, String> tags) {
         AvailabilityMetric metric = new AvailabilityMetric(tenantId, new MetricId(id));
         ListenableFuture<Void> future = metricsService.addTags(metric, MetricUtils.getTags(tags));
         Futures.addCallback(future, new DataInsertedCallback(response, "Failed to update tags"));
@@ -224,7 +228,9 @@ public class MetricHandler {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully deleted."),
             @ApiResponse(code = 500, message = "Unexpected error occurred while trying to delete metric's tags.")})
     public void deleteAvailabilityMetricTags(@Suspended final AsyncResponse response,
-        @PathParam("tenantId") String tenantId, @PathParam("id") String id, @PathParam("tags") String encodedTags) {
+        @PathParam("tenantId") String tenantId, @PathParam("id") String id,
+        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value")
+        @PathParam("tags") String encodedTags) {
         AvailabilityMetric metric = new AvailabilityMetric(tenantId, new MetricId(id));
         ListenableFuture<Void> future = metricsService.deleteTags(metric, MetricUtils.decodeTags(encodedTags));
         Futures.addCallback(future, new DataInsertedCallback(response, "Failed to delete tags"));
@@ -729,7 +735,7 @@ public class MetricHandler {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Tags were modified successfully.")})
     @Path("/{tenantId}/tags/numeric")
     public void tagNumericData(@Suspended final AsyncResponse asyncResponse, @PathParam("tenantId") String tenantId,
-        TagParams params) {
+        @ApiParam(required = true) TagParams params) {
         ListenableFuture<List<NumericData>> future;
         NumericMetric metric = new NumericMetric(tenantId, new MetricId(params.getMetric()));
         if (params.getTimestamp() != null) {
@@ -757,7 +763,7 @@ public class MetricHandler {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Tags were modified successfully.")})
     @Path("/{tenantId}/tags/availability")
     public void tagAvailabilityData(@Suspended final AsyncResponse asyncResponse,
-        @PathParam("tenantId") String tenantId, TagParams params) {
+        @PathParam("tenantId") String tenantId, @ApiParam(required = true) TagParams params) {
         ListenableFuture<List<Availability>> future;
         AvailabilityMetric metric = new AvailabilityMetric(tenantId, new MetricId(params.getMetric()));
         if (params.getTimestamp() != null) {
@@ -787,7 +793,9 @@ public class MetricHandler {
             @ApiResponse(code = 500, message = "Any error while fetching data.")})
     @Path("/{tenantId}/tags/numeric/{tag}")
     public void findTaggedNumericData(@Suspended final AsyncResponse asyncResponse,
-        @PathParam("tenantId") String tenantId, @PathParam("tag") String encodedTag) {
+        @PathParam("tenantId") String tenantId,
+        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value")
+        @PathParam("tag") String encodedTag) {
         ListenableFuture<Map<MetricId, Set<NumericData>>> future = metricsService.findNumericDataByTags(
                 tenantId, MetricUtils.decodeTags(encodedTag));
         Futures.addCallback(future, new FutureCallback<Map<MetricId, Set<NumericData>>>() {
@@ -835,7 +843,9 @@ public class MetricHandler {
             @ApiResponse(code = 500, message = "Any error while fetching data.")})
     @Path("/{tenantId}/tags/availability/{tag}")
     public void findTaggedAvailabilityData(@Suspended final AsyncResponse asyncResponse,
-        @PathParam("tenantId") String tenantId, @PathParam("tag") String encodedTag) {
+        @PathParam("tenantId") String tenantId,
+        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value")
+        @PathParam("tag") String encodedTag) {
         ListenableFuture<Map<MetricId, Set<Availability>>> future = metricsService.findAvailabilityByTags(tenantId,
             MetricUtils.decodeTags(encodedTag));
         Futures.addCallback(future, new FutureCallback<Map<MetricId, Set<Availability>>>() {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
@@ -67,6 +67,9 @@ import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
 
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
+
 import org.hawkular.metrics.core.api.Availability;
 import org.hawkular.metrics.core.api.AvailabilityMetric;
 import org.hawkular.metrics.core.api.Counter;
@@ -78,9 +81,6 @@ import org.hawkular.metrics.core.api.MetricsService;
 import org.hawkular.metrics.core.api.NumericData;
 import org.hawkular.metrics.core.api.NumericMetric;
 import org.hawkular.metrics.core.impl.cassandra.MetricUtils;
-
-import gnu.trove.map.TLongObjectMap;
-import gnu.trove.map.hash.TLongObjectHashMap;
 
 /**
  * Interface to deal with metrics
@@ -283,7 +283,8 @@ public class MetricHandler {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Adding data succeeded."),
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data")})
     public void addAvailabilityForMetric(@Suspended final AsyncResponse asyncResponse,
-        @PathParam("tenantId") final String tenantId, @PathParam("id") String id, List<AvailabilityDataPoint> data) {
+        @PathParam("tenantId") final String tenantId, @PathParam("id") String id,
+        @ApiParam(value = "List of availability datapoints", required = true) List<AvailabilityDataPoint> data) {
         AvailabilityMetric metric = new AvailabilityMetric(tenantId, new MetricId(id));
 
         for (AvailabilityDataPoint p : data) {
@@ -300,8 +301,10 @@ public class MetricHandler {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Adding data succeeded."),
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data")})
     @Consumes(APPLICATION_JSON)
-    public void addNumericData(@Suspended final AsyncResponse asyncResponse, @PathParam("tenantId") String tenantId,
-        List<NumericDataParams> paramsList) {
+    public void addNumericData(@ApiParam(access = "internal") @Suspended final AsyncResponse asyncResponse,
+                               @PathParam("tenantId") String tenantId,
+                               @ApiParam(value = "List of metrics", required = true)
+                               List<NumericDataParams> paramsList) {
         if (paramsList.isEmpty()) {
             asyncResponse.resume(Response.ok().type(APPLICATION_JSON_TYPE).build());
         }
@@ -327,7 +330,8 @@ public class MetricHandler {
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data")})
     @Consumes(APPLICATION_JSON)
     public void addAvailabilityData(@Suspended final AsyncResponse asyncResponse,
-        @PathParam("tenantId") String tenantId, List<AvailabilityDataParams> paramsList) {
+        @PathParam("tenantId") String tenantId, @ApiParam(value = "List of availability metrics", required = true)
+        List<AvailabilityDataParams> paramsList) {
         if (paramsList.isEmpty()) {
             asyncResponse.resume(Response.ok().type(APPLICATION_JSON_TYPE).build());
         }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
@@ -858,6 +858,7 @@ public class MetricHandler {
     }
 
     @POST
+    @ApiOperation(value = "List of counter definitions", hidden = true)
     @Path("/counters")
     @Produces({APPLICATION_JSON})
     public void updateCountersForGroups(@Suspended final AsyncResponse asyncResponse, Collection<Counter> counters) {
@@ -865,6 +866,7 @@ public class MetricHandler {
     }
 
     @POST
+    @ApiOperation(value = "Update multiple counters in a single counter group", hidden = true)
     @Path("/counters/{group}")
     @Produces(APPLICATION_JSON)
     public void updateCounterForGroup(@Suspended final AsyncResponse asyncResponse, @PathParam("group") String group,
@@ -892,6 +894,7 @@ public class MetricHandler {
     }
 
     @POST
+    @ApiOperation(value = "Increase value of a counter", hidden = true)
     @Path("/counters/{group}/{counter}")
     public void updateCounter(@Suspended final AsyncResponse asyncResponse, @PathParam("group") String group,
         @PathParam("counter") String counter) {
@@ -899,6 +902,7 @@ public class MetricHandler {
     }
 
     @POST
+    @ApiOperation(value = "Update value of a counter", hidden = true)
     @Path("/counters/{group}/{counter}/{value}")
     public void updateCounter(@Suspended final AsyncResponse asyncResponse, @PathParam("group") String group,
         @PathParam("counter") String counter, @PathParam("value") Long value) {
@@ -923,6 +927,7 @@ public class MetricHandler {
     }
 
     @GET
+    @ApiOperation(value = "Retrieve a list of counter values in this group", hidden = true, response = Counter.class, responseContainer = "List")
     @Path("/counters/{group}")
     @Produces({APPLICATION_JSON,APPLICATION_VND_HAWKULAR_WRAPPED_JSON})
     public void getCountersForGroup(@Suspended final AsyncResponse asyncResponse, @PathParam("group") String group) {
@@ -942,6 +947,7 @@ public class MetricHandler {
     }
 
     @GET
+    @ApiOperation(value = "Retrieve value of a counter", hidden = true, response = Counter.class, responseContainer = "List")
     @Path("/counters/{group}/{counter}")
     @Produces({APPLICATION_JSON,APPLICATION_VND_HAWKULAR_WRAPPED_JSON})
     public void getCounter(@Suspended final AsyncResponse asyncResponse, @PathParam("group") final String group,

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricHandler.java
@@ -62,6 +62,10 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 
 import org.hawkular.metrics.core.api.Availability;
 import org.hawkular.metrics.core.api.AvailabilityMetric;
@@ -82,7 +86,7 @@ import gnu.trove.map.hash.TLongObjectHashMap;
  * Interface to deal with metrics
  * @author Heiko W. Rupp
  */
-@Api(value = "Related to metrics")
+@Api(value = "/", description = "Metrics related REST interface")
 @Path("/")
 public class MetricHandler {
     private static final long EIGHT_HOURS = MILLISECONDS.convert(8, HOURS);
@@ -92,6 +96,11 @@ public class MetricHandler {
 
     @POST
     @Path("/{tenantId}/metrics/numeric")
+    @ApiOperation(value = "Create numeric metric definition.",
+            notes = "Clients are not required to explicitly create a metric before storing data. Doing so however allows clients to prevent naming collisions and to specify tags and data retention.")
+    @ApiResponses(value = { @ApiResponse(code = 400, message = "Metric with given id already exists"),
+            @ApiResponse(code = 200, message = "Metric definition created successfully"),
+            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error")})
     @Consumes(APPLICATION_JSON)
     public void createNumericMetric(@Suspended AsyncResponse asyncResponse, @PathParam("tenantId") String tenantId,
         MetricParams params) {
@@ -103,6 +112,10 @@ public class MetricHandler {
 
     @POST
     @Path("/{tenantId}/metrics/availability")
+    @ApiOperation(value = "Create availability metric definition. Same notes as creating numeric metric apply.")
+    @ApiResponses(value = { @ApiResponse(code = 400, message = "Metric with given id already exists"),
+            @ApiResponse(code = 200, message = "Metric definition created successfully"),
+            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error")})
     @Consumes(APPLICATION_JSON)
     public void createAvailabilityMetric(@Suspended AsyncResponse asyncResponse, @PathParam("tenantId") String tenantId,
         MetricParams params) {
@@ -144,6 +157,10 @@ public class MetricHandler {
 
     @GET
     @Path("/{tenantId}/metrics/numeric/{id}/tags")
+    @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = MetricOut.class)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully retrieved."),
+            @ApiResponse(code = 204, message = "Query was successful, but no metrics were found."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric's tags.")})
     public void getNumericMetricTags(@Suspended AsyncResponse response, @PathParam("tenantId") String tenantId,
         @PathParam("id") String id) {
         ListenableFuture<Metric> future = metricsService.findMetric(tenantId, MetricType.NUMERIC,
@@ -153,6 +170,9 @@ public class MetricHandler {
 
     @PUT
     @Path("/{tenantId}/metrics/numeric/{id}/tags")
+    @ApiOperation(value = "Update tags associated with the metric definition.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully updated."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while updating metric's tags.")})
     public void updateNumericMetricTags(@Suspended final AsyncResponse response,
         @PathParam("tenantId") String tenantId, @PathParam("id") String id, Map<String, String> tags) {
         NumericMetric metric = new NumericMetric(tenantId, new MetricId(id));
@@ -162,6 +182,9 @@ public class MetricHandler {
 
     @DELETE
     @Path("/{tenantId}/metrics/numeric/{id}/tags/{tags}")
+    @ApiOperation(value = "Delete tags associated with the metric definition.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully deleted."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while trying to delete metric's tags.")})
     public void deleteNumericMetricTags(@Suspended final AsyncResponse response,
         @PathParam("tenantId") String tenantId, @PathParam("id") String id, @PathParam("tags") String encodedTags) {
         NumericMetric metric = new NumericMetric(tenantId, new MetricId(id));
@@ -171,6 +194,10 @@ public class MetricHandler {
 
     @GET
     @Path("/{tenantId}/metrics/availability/{id}/tags")
+    @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = MetricOut.class)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully retrieved."),
+            @ApiResponse(code = 204, message = "Query was successful, but no metrics were found."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric's tags.")})
     public void getAvailabilityMetricTags(@Suspended AsyncResponse response,
         @PathParam("tenantId") String tenantId, @PathParam("id") String id) {
         ListenableFuture<Metric> future = metricsService.findMetric(tenantId, MetricType.AVAILABILITY,
@@ -180,6 +207,9 @@ public class MetricHandler {
 
     @PUT
     @Path("/{tenantId}/metrics/availability/{id}/tags")
+    @ApiOperation(value = "Update tags associated with the metric definition.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully updated."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while updating metric's tags.")})
     public void updateAvailabilityMetricTags(@Suspended final AsyncResponse response,
         @PathParam("tenantId") String tenantId, @PathParam("id") String id, Map<String, String> tags) {
         AvailabilityMetric metric = new AvailabilityMetric(tenantId, new MetricId(id));
@@ -189,6 +219,9 @@ public class MetricHandler {
 
     @DELETE
     @Path("/{tenantId}/metrics/availability/{id}/tags/{tags}")
+    @ApiOperation(value = "Delete tags associated with the metric definition.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Metric's tags were successfully deleted."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while trying to delete metric's tags.")})
     public void deleteAvailabilityMetricTags(@Suspended final AsyncResponse response,
         @PathParam("tenantId") String tenantId, @PathParam("id") String id, @PathParam("tags") String encodedTags) {
         AvailabilityMetric metric = new AvailabilityMetric(tenantId, new MetricId(id));
@@ -226,9 +259,12 @@ public class MetricHandler {
 
     @POST
     @Path("/{tenantId}/metrics/numeric/{id}/data")
+    @ApiOperation(value = "Add data for a single numeric metric.")
+    @ApiResponses(value = { @ApiResponse(code = 500, message = "Unexpected error happened while storing the data")})
     @Consumes(APPLICATION_JSON)
-    public void addDataForMetric(@Suspended final AsyncResponse asyncResponse,
-        @PathParam("tenantId") final String tenantId, @PathParam("id") String id, List<NumericDataPoint> dataPoints) {
+    public void addDataForMetric(@Suspended
+    final AsyncResponse asyncResponse, @PathParam("tenantId") final String tenantId, @PathParam("id") String id,
+        @ApiParam(value = "List of datapoints containing timestamp and value", required = true) List<NumericDataPoint> dataPoints) {
 
         NumericMetric metric = new NumericMetric(tenantId, new MetricId(id));
         for (NumericDataPoint p : dataPoints) {
@@ -241,6 +277,9 @@ public class MetricHandler {
     @POST
     @Path("/{tenantId}/metrics/availability/{id}/data")
     @Consumes(APPLICATION_JSON)
+    @ApiOperation(value = "Add data for a single availability metric.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Adding data succeeded."),
+            @ApiResponse(code = 500, message = "Unexpected error happened while storing the data")})
     public void addAvailabilityForMetric(@Suspended final AsyncResponse asyncResponse,
         @PathParam("tenantId") final String tenantId, @PathParam("id") String id, List<AvailabilityDataPoint> data) {
         AvailabilityMetric metric = new AvailabilityMetric(tenantId, new MetricId(id));
@@ -255,6 +294,9 @@ public class MetricHandler {
 
     @POST
     @Path("/{tenantId}/metrics/numeric/data")
+    @ApiOperation(value = "Add metric data for multiple numeric metrics in a single call.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Adding data succeeded."),
+            @ApiResponse(code = 500, message = "Unexpected error happened while storing the data")})
     @Consumes(APPLICATION_JSON)
     public void addNumericData(@Suspended final AsyncResponse asyncResponse, @PathParam("tenantId") String tenantId,
         List<NumericDataParams> paramsList) {
@@ -278,6 +320,9 @@ public class MetricHandler {
 
     @POST
     @Path("/{tenantId}/metrics/availability/data")
+    @ApiOperation(value = "Add metric data for multiple availability metrics in a single call.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Adding data succeeded."),
+            @ApiResponse(code = 500, message = "Unexpected error happened while storing the data")})
     @Consumes(APPLICATION_JSON)
     public void addAvailabilityData(@Suspended final AsyncResponse asyncResponse,
         @PathParam("tenantId") String tenantId, List<AvailabilityDataParams> paramsList) {
@@ -300,9 +345,14 @@ public class MetricHandler {
     }
 
     @GET
+    @ApiOperation(value = "Find numeric metrics data by their tags.", response = MetricOut.class, responseContainer = "List")
+    // See HWKMETRICS-26 for details to improve error coding, there should be at least 400 here, and :value should be optional. E
+    @ApiResponses(value = { @ApiResponse(code = 200, message = ""),
+            @ApiResponse(code = 500, message = "Any error in the query.")})
     @Path("/{tenantId}/numeric")
     public void findNumericDataByTags(@Suspended final AsyncResponse asyncResponse,
-        @PathParam("tenantId") String tenantId, @QueryParam("tags") String encodedTags) {
+        @PathParam("tenantId") String tenantId,
+        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value") @QueryParam("tags") String encodedTags) {
         ListenableFuture<Map<MetricId, Set<NumericData>>> queryFuture = metricsService.findNumericDataByTags(
             tenantId, MetricUtils.decodeTags(encodedTags));
         Futures.addCallback(queryFuture, new FutureCallback<Map<MetricId, Set<NumericData>>>() {
@@ -333,9 +383,15 @@ public class MetricHandler {
     }
 
     @GET
+    @ApiOperation(value = "Find availabilities metrics data by their tags.", response = MetricOut.class, responseContainer = "List")
+    // See above method and HWKMETRICS-26 for fixes.
+    @ApiResponses(value = { @ApiResponse(code = 200, message = ""),
+            @ApiResponse(code = 204, message = "No matching availability metrics were found."),
+            @ApiResponse(code = 500, message = "Any error in the query.")})
     @Path("/{tenantId}/availability")
     public void findAvailabilityDataByTags(@Suspended final AsyncResponse asyncResponse,
-        @PathParam("tenantId") String tenantId, @QueryParam("tags") String encodedTags) {
+        @PathParam("tenantId") String tenantId,
+        @ApiParam(allowMultiple = true, required = true, value = "A list of tags in the format of name:value") @QueryParam("tags") String encodedTags) {
         ListenableFuture<Map<MetricId, Set<Availability>>> queryFuture = metricsService.findAvailabilityByTags(
             tenantId, MetricUtils.decodeTags(encodedTags));
         Futures.addCallback(queryFuture, new FutureCallback<Map<MetricId, Set<Availability>>>() {
@@ -371,14 +427,18 @@ public class MetricHandler {
     }
 
     @GET
+    @ApiOperation(value = "Retrieve numeric data.", response = MetricOut.class)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully fetched numeric data."),
+            @ApiResponse(code = 204, message = "No numeric data was found."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching numeric data.")})
     @Path("/{tenantId}/metrics/numeric/{id}/data")
     public void findNumericData(
         @Suspended final AsyncResponse response,
         @PathParam("tenantId") String tenantId,
         @PathParam("id") final String id,
-        @QueryParam("start") Long start,
-        @QueryParam("end") Long end,
-        @QueryParam("buckets") final int numberOfBuckets,
+        @ApiParam(value = "Defaults to now - 8 hours", required = false) @QueryParam("start") Long start,
+        @ApiParam(value = "Defaults to now", required = false) @QueryParam("end") Long end,
+        @ApiParam(value = "The number of buckets or intervals in which to divide the time range. A value of 60 for example will return 60 equally spaced buckets for the time period between start and end times, having max/min/avg calculated for each bucket.") @QueryParam("buckets") final int numberOfBuckets,
         @QueryParam("bucketWidthSeconds") final int bucketWidthSeconds,
         @QueryParam("skipEmpty") @DefaultValue("false") final boolean skipEmpty,
         @QueryParam("bucketCluster") @DefaultValue("true") final boolean bucketCluster) {
@@ -607,10 +667,15 @@ public class MetricHandler {
     }
 
     @GET
+    @ApiOperation(value = "Retrieve availability data.", response = MetricOut.class)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully fetched availability data."),
+            @ApiResponse(code = 204, message = "No availability data was found.")})
+//            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching availability data.")
     @Path("/{tenantId}/metrics/availability/{id}/data")
     public void findAvailabilityData(@Suspended final AsyncResponse asyncResponse,
-        @PathParam("tenantId") String tenantId, @PathParam("id") final String id, @QueryParam("start") Long start,
-        @QueryParam("end") Long end) {
+        @PathParam("tenantId") String tenantId, @PathParam("id") final String id,
+        @ApiParam(value = "Defaults to now - 8 hours", required = false) @QueryParam("start") Long start,
+        @ApiParam(value = "Defaults to now", required = false) @QueryParam("end") Long end) {
 
         long now = System.currentTimeMillis();
         if (start == null) {
@@ -649,6 +714,8 @@ public class MetricHandler {
     }
 
     @POST
+    @ApiOperation(value = "Add or update numeric metric's tags.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Tags were modified successfully.")})
     @Path("/{tenantId}/tags/numeric")
     public void tagNumericData(@Suspended final AsyncResponse asyncResponse, @PathParam("tenantId") String tenantId,
         TagParams params) {
@@ -675,6 +742,8 @@ public class MetricHandler {
     }
 
     @POST
+    @ApiOperation(value = "Add or update availability metric's tags.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Tags were modified successfully.")})
     @Path("/{tenantId}/tags/availability")
     public void tagAvailabilityData(@Suspended final AsyncResponse asyncResponse,
         @PathParam("tenantId") String tenantId, TagParams params) {
@@ -701,6 +770,9 @@ public class MetricHandler {
     }
 
     @GET
+    @ApiOperation(value = "Find numeric metric data with given tags.", response = MetricOut.class, responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Numeric values fetched successfully"),
+            @ApiResponse(code = 500, message = "Any error while fetching data.")})
     @Path("/{tenantId}/tags/numeric/{tag}")
     public void findTaggedNumericData(@Suspended final AsyncResponse asyncResponse,
         @PathParam("tenantId") String tenantId, @PathParam("tag") String encodedTag) {
@@ -745,6 +817,9 @@ public class MetricHandler {
     }
 
     @GET
+    @ApiOperation(value = "Find availability metric data with given tags.", response = MetricOut.class, responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Availability values fetched successfully"),
+            @ApiResponse(code = 500, message = "Any error while fetching data.")})
     @Path("/{tenantId}/tags/availability/{tag}")
     public void findTaggedAvailabilityData(@Suspended final AsyncResponse asyncResponse,
         @PathParam("tenantId") String tenantId, @PathParam("tag") String encodedTag) {
@@ -894,8 +969,13 @@ public class MetricHandler {
     @GET
     @Path("/{tenantId}/metrics")
     @Produces(APPLICATION_JSON)
+    @ApiOperation(value = "Find tenant's metric definitions.", notes = "Does not include any metric values. ", response = MetricOut.class, responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully retrieved at least one metric definition."),
+            @ApiResponse(code = 204, message = "No metrics found."),
+            @ApiResponse(code = 400, message = "Given type is not a valid type."),
+            @ApiResponse(code = 500, message = "Failed to retrieve metrics due to unexpected error.")})
     public void findMetrics(@Suspended final AsyncResponse response, @PathParam("tenantId") final String tenantId,
-        @QueryParam("type") String type) {
+        @ApiParam(value = "Queried metric type", required = true, allowableValues = "[num, avail, log]") @QueryParam("type") String type) {
         MetricType metricType = null;
         try {
             metricType = MetricType.fromTextCode(type);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricOut.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricOut.java
@@ -23,11 +23,13 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.wordnik.swagger.annotations.ApiModel;
 
 
 /**
  * @author John Sanda
  */
+@ApiModel
 public class MetricOut {
 
     private String tenantId;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricParams.java
@@ -34,25 +34,25 @@ public class MetricParams {
 
     private Integer dataRetention;
 
+    @ApiModelProperty(value = "Identifier of the metric.", required = true)
     public String getName() {
         return name;
     }
 
-    @ApiModelProperty(value = "Identifier of the metric, mandatory.")
     public void setName(String name) {
         this.name = name;
     }
 
+    @ApiModelProperty(value = "Arbitrary key/value definitions for this metric")
     public Map<String, String> getTags() {
         return tags;
     }
 
-    @ApiModelProperty(value = "Arbitary key/value definitions for this metric")
     public void setTags(Map<String, String> tags) {
         this.tags = tags;
     }
 
-    @ApiModelProperty(value = "Overrides the data retention setting at the tenant level")
+    @ApiModelProperty(value = "Overrides the data retention setting from the tenant level")
     public Integer getDataRetention() {
         return dataRetention;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricParams.java
@@ -19,9 +19,13 @@ package org.hawkular.metrics.api.jaxrs;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
 /**
  * @author John Sanda
  */
+@ApiModel(description = "Metric definition model")
 public class MetricParams {
 
     private String name;
@@ -34,6 +38,7 @@ public class MetricParams {
         return name;
     }
 
+    @ApiModelProperty(value = "Identifier of the metric, mandatory.")
     public void setName(String name) {
         this.name = name;
     }
@@ -42,10 +47,12 @@ public class MetricParams {
         return tags;
     }
 
+    @ApiModelProperty(value = "Arbitary key/value definitions for this metric")
     public void setTags(Map<String, String> tags) {
         this.tags = tags;
     }
 
+    @ApiModelProperty(value = "Overrides the data retention setting at the tenant level")
     public Integer getDataRetention() {
         return dataRetention;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/NumericDataParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/NumericDataParams.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.google.common.base.Objects;
 import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * @author John Sanda
@@ -37,6 +38,7 @@ public class NumericDataParams extends MetricDataParams {
     public NumericDataParams() {
     }
 
+    @ApiModelProperty(required = true, value = "Event timestamp in POSIX format")
     public Long getTimestamp() {
         return timestamp;
     }
@@ -45,6 +47,7 @@ public class NumericDataParams extends MetricDataParams {
         this.timestamp = timestamp;
     }
 
+    @ApiModelProperty(required = true, value = "Numeric value of the event")
     public Double getValue() {
         return value;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/NumericDataParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/NumericDataParams.java
@@ -20,10 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Objects;
+import com.wordnik.swagger.annotations.ApiModel;
 
 /**
  * @author John Sanda
  */
+@ApiModel
 public class NumericDataParams extends MetricDataParams {
 
     private Long timestamp;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/NumericDataPoint.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/NumericDataPoint.java
@@ -21,10 +21,12 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
+import com.wordnik.swagger.annotations.ApiModel;
 
 /**
  * @author John Sanda
  */
+@ApiModel
 public class NumericDataPoint {
 
     private long timestamp;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/NumericDataPoint.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/NumericDataPoint.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.google.common.base.Objects;
 import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * @author John Sanda
@@ -44,6 +45,7 @@ public class NumericDataPoint {
         this.value = value;
     }
 
+    @ApiModelProperty(required = true, value = "Event timestamp in POSIX format")
     public long getTimestamp() {
         return timestamp;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/PingHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/PingHandler.java
@@ -22,6 +22,7 @@ import static org.hawkular.metrics.api.jaxrs.CustomMediaTypes.APPLICATION_JAVASC
 import static org.hawkular.metrics.api.jaxrs.CustomMediaTypes.APPLICATION_VND_HAWKULAR_WRAPPED_JSON;
 
 import java.util.Date;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -49,7 +50,7 @@ public class PingHandler {
     @Consumes({ APPLICATION_JSON, APPLICATION_XML })
     @Produces({ APPLICATION_JSON, APPLICATION_XML, APPLICATION_VND_HAWKULAR_WRAPPED_JSON, APPLICATION_JAVASCRIPT })
     @ApiOperation(value = "Returns the current time and serves to check for the availability of the api.",
-            responseClass = "Map<String,String>")
+            response = String.class, responseContainer = "Map")
     public Response ping() {
         return Response.ok(new StringValue(new Date().toString())).build();
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/PingHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/PingHandler.java
@@ -22,7 +22,6 @@ import static org.hawkular.metrics.api.jaxrs.CustomMediaTypes.APPLICATION_JAVASC
 import static org.hawkular.metrics.api.jaxrs.CustomMediaTypes.APPLICATION_VND_HAWKULAR_WRAPPED_JSON;
 
 import java.util.Date;
-import java.util.Map;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/SimpleLink.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/SimpleLink.java
@@ -18,15 +18,15 @@ package org.hawkular.metrics.api.jaxrs;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.wordnik.swagger.annotations.ApiClass;
-import com.wordnik.swagger.annotations.ApiProperty;
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * Just a simple representation of a Link
  * @author Heiko W. Rupp
  */
 @SuppressWarnings("unused")
-@ApiClass("A simple representation of a link.")
+@ApiModel(value = "A simple representation of a link.")
 @XmlRootElement
 public class SimpleLink {
     private String rel;
@@ -42,17 +42,17 @@ public class SimpleLink {
         this.title = title;
     }
 
-    @ApiProperty("Name of the relation")
+    @ApiModelProperty(value = "Name of the relation")
     public String getRel() {
         return rel;
     }
 
-    @ApiProperty("Href to target entity")
+    @ApiModelProperty(value = "Href to target entity")
     public String getHref() {
         return href;
     }
 
-    @ApiProperty("Name of the target")
+    @ApiModelProperty(value = "Name of the target")
     public String getTitle() {
         return title;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StringValue.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StringValue.java
@@ -19,14 +19,14 @@ package org.hawkular.metrics.api.jaxrs;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.wordnik.swagger.annotations.ApiClass;
-import com.wordnik.swagger.annotations.ApiProperty;
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
 
 /**
  * Encapsulate a simple string value
  * @author Heiko W. Rupp
  */
-@ApiClass("Encapsulates a simple string value. In XML this is represented as <value value=\"...\"/>")
+@ApiModel(value = "Encapsulates a simple string value. In XML this is represented as <value value=\"...\"/>")
 @XmlRootElement(name =  "value")
 public class StringValue {
 
@@ -40,7 +40,7 @@ public class StringValue {
     }
 
     @XmlAttribute
-    @ApiProperty("The actual value")
+    @ApiModelProperty(value = "The actual value")
     public String getValue() {
         return value;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TagParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TagParams.java
@@ -20,10 +20,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.base.Objects;
+import com.wordnik.swagger.annotations.ApiModel;
 
 /**
  * @author John Sanda
  */
+@ApiModel
 public class TagParams {
 
     private String tenantId;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantParams.java
@@ -50,7 +50,8 @@ public class TenantParams {
         this.id = id;
     }
 
-    @ApiModelProperty(required = false, allowableValues = "[numeric, availability]", value = "Retention periods for different metric types.")
+    @ApiModelProperty(required = false, allowableValues = "[numeric, availability]", value = "Retention periods for "
+            + "different metric types.")
     public Map<String, Integer> getRetentions() {
         return retentions;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantParams.java
@@ -19,10 +19,14 @@ package org.hawkular.metrics.api.jaxrs;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
 /**
  * @author John Sanda
  */
 // TODO rename class to better reflect it is used for input and output
+@ApiModel
 public class TenantParams {
 
     private String id;
@@ -37,6 +41,7 @@ public class TenantParams {
         this.retentions = retentions;
     }
 
+    @ApiModelProperty(required = true, value = "Tenant's unique identifier.")
     public String getId() {
         return id;
     }
@@ -45,6 +50,7 @@ public class TenantParams {
         this.id = id;
     }
 
+    @ApiModelProperty(required = false, allowableValues = "[numeric, availability]", value = "Retention periods for different metric types.")
     public Map<String, Integer> getRetentions() {
         return retentions;
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantsHandler.java
@@ -40,6 +40,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 
 import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
@@ -49,6 +53,7 @@ import org.hawkular.metrics.core.api.TenantAlreadyExistsException;
 /**
  * @author Thomas Segismont
  */
+@Api(value = "/tenants", description = "Tenants related REST interface")
 @Path("/tenants")
 public class TenantsHandler {
 
@@ -56,6 +61,11 @@ public class TenantsHandler {
     private MetricsService metricsService;
 
     @POST
+    @ApiOperation(value = "Create a new tenant. ", notes = "Clients are not required to create explicitly create a tenant before starting to store metric data. It is recommended to do so however to ensure that there are no tenant id naming collisions and to provide default data retention settings. ")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Tenant has been succesfully created."),
+            @ApiResponse(code = 400, message = "Retention properties are invalid. "),
+            @ApiResponse(code = 409, message = "Given tenant id has already been created."),
+            @ApiResponse(code = 500, message = "An unexpected error occured while trying to create a tenant.")})
     @Consumes(APPLICATION_JSON)
     public void createTenant(@Suspended AsyncResponse asyncResponse, TenantParams params) {
         Tenant tenant = new Tenant().setId(params.getId());
@@ -98,6 +108,10 @@ public class TenantsHandler {
     }
 
     @GET
+    @ApiOperation(value = "Returns a list of tenants.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Returned a list of tenants successfully."),
+            @ApiResponse(code = 204, message = "No tenants were found."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching tenants.")})
     @Consumes(APPLICATION_JSON)
     public void findTenants(@Suspended AsyncResponse response) {
         ListenableFuture<List<Tenant>> tenantsFuture = metricsService.getTenants();

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantsHandler.java
@@ -42,6 +42,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
 
@@ -69,7 +70,7 @@ public class TenantsHandler {
             @ApiResponse(code = 409, message = "Given tenant id has already been created."),
             @ApiResponse(code = 500, message = "An unexpected error occured while trying to create a tenant.")})
     @Consumes(APPLICATION_JSON)
-    public void createTenant(@Suspended AsyncResponse asyncResponse, TenantParams params) {
+    public void createTenant(@Suspended AsyncResponse asyncResponse, @ApiParam(required = true) TenantParams params) {
         Tenant tenant = new Tenant().setId(params.getId());
         for (String type : params.getRetentions().keySet()) {
             if (type.equals(MetricType.NUMERIC.getText())) {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/TenantsHandler.java
@@ -61,7 +61,9 @@ public class TenantsHandler {
     private MetricsService metricsService;
 
     @POST
-    @ApiOperation(value = "Create a new tenant. ", notes = "Clients are not required to create explicitly create a tenant before starting to store metric data. It is recommended to do so however to ensure that there are no tenant id naming collisions and to provide default data retention settings. ")
+    @ApiOperation(value = "Create a new tenant. ", notes = "Clients are not required to create explicitly create a "
+            + "tenant before starting to store metric data. It is recommended to do so however to ensure that there "
+            + "are no tenant id naming collisions and to provide default data retention settings. ")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Tenant has been succesfully created."),
             @ApiResponse(code = 400, message = "Retention properties are invalid. "),
             @ApiResponse(code = 409, message = "Given tenant id has already been created."),

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/swagger/filter/JaxRsFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/swagger/filter/JaxRsFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.swagger.filter;
+
+import java.util.List;
+import java.util.Map;
+
+import com.wordnik.swagger.core.filter.SwaggerSpecFilter;
+import com.wordnik.swagger.model.ApiDescription;
+import com.wordnik.swagger.model.Operation;
+import com.wordnik.swagger.model.Parameter;
+
+/**
+ * Filter out AsyncResponse from swagger-json
+ *
+ * @author Michael Burman
+ */
+public class JaxRsFilter implements SwaggerSpecFilter {
+    @Override
+    public boolean isOperationAllowed(Operation operation, ApiDescription apiDescription, Map<String, List<String>>
+            map, Map<String, String> map1, Map<String, List<String>> map2) {
+        return true;
+    }
+
+    @Override
+    public boolean isParamAllowed(Parameter parameter, Operation operation, ApiDescription apiDescription,
+                                  Map<String, List<String>> map, Map<String, String> map1, Map<String, List<String>>
+            map2) {
+        if(parameter.dataType().equals("AsyncResponse")) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/resources/rest-doc/asciidoc.mustache
+++ b/api/metrics-api-jaxrs/src/main/resources/rest-doc/asciidoc.mustache
@@ -1,0 +1,66 @@
+== APIs
+{{#apiDocuments}}
+=== {{{description}}}
+
+{{#apis}}
+==== {{apiIndex}} `{{path}}`
+{{#operations}}
+
+{{summary}}
+
+{{{notes}}}
+
+----
+*{{httpMethod}}* `{{path}}`
+----
+
+{{#parameters}}
+===== {{paramType}} parameters
+
+[options="header"]
+|=======================
+|Parameter|Required|Description|Data Type
+{{#paras}}
+|{{name}}|{{required}}|{{description}}|{{type}}
+{{/paras}}
+|=======================
+{{/parameters}}
+
+{{#responseClass}}
+===== Response
+[{{className}}](#{{classLinkName}}){{^genericClasses}}{{/genericClasses}}{{#genericClasses}}< [{{className}}](#{{classLinkName}}) >{{/genericClasses}}
+{{/responseClass}}
+
+===== Status codes
+[options="header"]
+|=======================
+| Status Code | Reason      | Response Model
+{{#errorResponses}}
+| {{code}}    | {{message}} | {{#linkType}}[{{type}}](#{{linkType}}){{/linkType}}{{^linkType}}{{#type}}{{{type}}}{{/type}}{{^type}}-{{/type}}{{/linkType}}
+{{/errorResponses}}
+|=======================
+
+{{/operations}}
+{{/apis}}
+{{/apiDocuments}}
+
+== Data Types
+{{#dataTypes}}
+
+=== {{name}}
+[options="header"]
+|=======================
+| name | type | required | access | description | notes
+{{#items}}
+|{{name}}|{{#linkType}}{{linkType}}{{type}} {{/linkType}}{{^linkType}}{{type}}{{/linkType}}|{{#required}}required{{/required}}{{^required}}optional{{/required}}|{{#access}}{{{access}}}{{/access}}{{^access}}-{{/access}}|{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}{{#allowableValue}} Allowable values:{{.}}{{/allowableValue}}|{{#notes}}{{{notes}}}{{/notes}}{{^notes}}-{{/notes}}
+{{/items}}
+|=======================
+
+{{/dataTypes}}
+
+{{#enumTypes}}
+    ## {{name}}
+    {{#allowableValues}}
+        {{.}}
+    {{/allowableValues}}
+{{/enumTypes}}

--- a/api/metrics-api-jaxrs/src/main/resources/rest-doc/asciidoc.mustache
+++ b/api/metrics-api-jaxrs/src/main/resources/rest-doc/asciidoc.mustache
@@ -21,14 +21,14 @@
 |=======================
 |Parameter|Required|Description|Data Type
 {{#paras}}
-|{{name}}|{{required}}|{{description}}|{{type}}
+    |{{name}}|{{required}}|{{description}}|{{#linkType}}<<{{linkType}},{{type}}>>{{/linkType}}{{^linkType}}{{type}}{{/linkType}}
 {{/paras}}
 |=======================
 {{/parameters}}
 
 {{#responseClass}}
 ===== Response
-[{{className}}](#{{classLinkName}}){{^genericClasses}}{{/genericClasses}}{{#genericClasses}}< [{{className}}](#{{classLinkName}}) >{{/genericClasses}}
+[{{className}}](#{{classLinkName}}){{^genericClasses}}{{/genericClasses}}{{#genericClasses}}< [{{className}}](#<<{{classLinkName}}>>) >{{/genericClasses}}
 {{/responseClass}}
 
 ===== Status codes
@@ -36,7 +36,7 @@
 |=======================
 | Status Code | Reason      | Response Model
 {{#errorResponses}}
-| {{code}}    | {{message}} | {{#linkType}}[{{type}}](#{{linkType}}){{/linkType}}{{^linkType}}{{#type}}{{{type}}}{{/type}}{{^type}}-{{/type}}{{/linkType}}
+| {{code}}    | {{message}} | {{#linkType}}[{{type}}](#<<{{linkType}}>>){{/linkType}}{{^linkType}}{{#type}}{{{type}}}{{/type}}{{^type}}-{{/type}}{{/linkType}}
 {{/errorResponses}}
 |=======================
 
@@ -47,6 +47,7 @@
 == Data Types
 {{#dataTypes}}
 
+[[{{name}}]]
 === {{name}}
 [options="header"]
 |=======================


### PR DESCRIPTION
This patch attempts to add up-to-date documentation by using swagger-annotations in our REST handlers. All the documentation options target current implementation, not how they should look like (eg. HWKMETRICS-26 is not seen in here) and will require updating once people do changes to the REST-API.

Slightly unfinished, I'm waiting to hear comments on certain parts because they're sometimes guesses on how things are working / are attempting to work.

It's also possible that generating documentation using RHQ rest-doc-generator doesn't work anymore as the swagger annotations have changed.