### PR TITLE
Test code updates

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -105,11 +105,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -107,10 +107,12 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -102,6 +102,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/config/ConfigurableProducerTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/config/ConfigurableProducerTest.java
@@ -16,8 +16,7 @@
  */
 package org.hawkular.metrics.api.jaxrs.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -27,7 +26,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Properties;
-
 import javax.enterprise.inject.spi.Annotated;
 import javax.enterprise.inject.spi.InjectionPoint;
 
@@ -35,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -48,6 +47,8 @@ import com.google.common.io.Resources;
 @RunWith(MockitoJUnitRunner.class)
 public class ConfigurableProducerTest {
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -87,8 +88,7 @@ public class ConfigurableProducerTest {
         URL resource = Resources.getResource("META-INF/metrics.conf");
         properties.load(Resources.asByteSource(resource).openStream());
 
-        assertThat(value).isNotNull().isEqualTo(
-                properties.getProperty(ConfigurationKey.CASSANDRA_KEYSPACE.getExternalForm()));
+        assertEquals(properties.getProperty(ConfigurationKey.CASSANDRA_KEYSPACE.getExternalForm()), value);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class ConfigurableProducerTest {
         configurableProducer.init();
         String value = configurableProducer.getConfigurationPropertyAsString(injectionPoint);
 
-        assertThat(value).isNotNull().isEqualTo("marseille");
+        assertEquals("marseille", value);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class ConfigurableProducerTest {
         configurableProducer.init();
         String value = configurableProducer.getConfigurationPropertyAsString(injectionPoint);
 
-        assertThat(value).isNotNull().isEqualTo("mare nostrum");
+        assertEquals("mare nostrum", value);
     }
 
     @Test
@@ -129,13 +129,10 @@ public class ConfigurableProducerTest {
         InjectionPoint injectionPoint = mock(InjectionPoint.class);
         when(injectionPoint.getAnnotated()).thenReturn(annotated);
 
-        try {
-            configurableProducer.getConfigurationPropertyAsString(injectionPoint);
-            fail("Expected " + IllegalArgumentException.class.getSimpleName());
-        } catch (Exception e) {
-            String message = "Any field or parameter annotated with @Configurable "
-                + "must also be annotated with @ConfigurationProperty";
-            assertThat(e).isInstanceOf(IllegalArgumentException.class).hasMessage(message);
-        }
+        expectedException.expect(IllegalArgumentException.class);
+        String message = "Any field or parameter annotated with @Configurable "
+                         + "must also be annotated with @ConfigurationProperty";
+        expectedException.expectMessage(message);
+        configurableProducer.getConfigurationPropertyAsString(injectionPoint);
     }
 }

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/InfluxTimeUnitTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/InfluxTimeUnitTest.java
@@ -16,7 +16,7 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.TimeUnit;
 
@@ -29,11 +29,11 @@ public class InfluxTimeUnitTest {
 
     @Test
     public void testConvertTo() throws Exception {
-        assertThat(InfluxTimeUnit.WEEKS.convertTo(TimeUnit.HOURS, 5)).isEqualTo(5 * 7 * 24);
-        assertThat(InfluxTimeUnit.DAYS.convertTo(TimeUnit.HOURS, 2)).isEqualTo(48);
-        assertThat(InfluxTimeUnit.HOURS.convertTo(TimeUnit.SECONDS, 4)).isEqualTo(4 * 3600);
-        assertThat(InfluxTimeUnit.MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5)).isEqualTo(5);
-        assertThat(InfluxTimeUnit.SECONDS.convertTo(TimeUnit.HOURS, 3600 * 7)).isEqualTo(7);
-        assertThat(InfluxTimeUnit.MICROSECONDS.convertTo(TimeUnit.NANOSECONDS, 13)).isEqualTo(13 * 1000);
+        assertEquals(5, InfluxTimeUnit.MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5));
+        assertEquals(5, InfluxTimeUnit.MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5));
+        assertEquals(5, InfluxTimeUnit.MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5));
+        assertEquals(5, InfluxTimeUnit.MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5));
+        assertEquals(7, InfluxTimeUnit.SECONDS.convertTo(TimeUnit.HOURS, 3600 * 7));
+        assertEquals(13 * 1000, InfluxTimeUnit.MICROSECONDS.convertTo(TimeUnit.NANOSECONDS, 13));
     }
 }

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/translate/ToIntervalTranslatorTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/translate/ToIntervalTranslatorTest.java
@@ -16,8 +16,11 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.query.translate;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.AndBooleanExpression;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.DateOperand;
@@ -45,9 +48,7 @@ public class ToIntervalTranslatorTest {
 
         GtBooleanExpression gt = new GtBooleanExpression(new DateOperand(sylvesterNoon2008.toInstant()), timeOperand);
 
-        assertThat(translator.toInterval(gt))
-                .isNotNull()
-                .isEqualTo(new Interval(new Instant(0), sylvesterNoon2008.toInstant()));
+        assertEquals(new Interval(new Instant(0), sylvesterNoon2008.toInstant()), translator.toInterval(gt));
 
         LtBooleanExpression lt = new LtBooleanExpression(new DateOperand(mariaNoon2006.toInstant()), timeOperand);
 
@@ -55,21 +56,19 @@ public class ToIntervalTranslatorTest {
         Interval interval = translator.toInterval(lt);
         Instant nowAfter = Instant.now();
 
-        assertThat(interval).isNotNull();
-        assertThat(interval.getStart()).isEqualTo(mariaNoon2006);
-        assertThat(interval.contains(nowBefore)).isTrue();
-        assertThat(new Interval(mariaNoon2006, nowAfter).contains(interval)).isTrue();
+        assertNotNull(interval);
+        assertEquals(mariaNoon2006, interval.getStart());
+        assertTrue(interval.contains(nowBefore));
+        assertTrue(new Interval(mariaNoon2006, nowAfter).contains(interval));
 
         AndBooleanExpression and = new AndBooleanExpression(gt, lt);
 
-        assertThat(translator.toInterval(and))
-                .isNotNull()
-                .isEqualTo(new Interval(mariaNoon2006, sylvesterNoon2008));
+        assertEquals(new Interval(mariaNoon2006, sylvesterNoon2008), translator.toInterval(and));
 
         gt = new GtBooleanExpression(timeOperand, new DateOperand(sylvesterNoon2008.toInstant()));
         lt = new LtBooleanExpression(timeOperand, new DateOperand(mariaNoon2006.toInstant()));
         and = new AndBooleanExpression(gt, lt);
 
-        assertThat(translator.toInterval(and)).isNull();
+        assertNull(translator.toInterval(and));
     }
 }

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/validation/ValidationRulesProducerTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/validation/ValidationRulesProducerTest.java
@@ -16,7 +16,7 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.query.validation;
 
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.junit.Assert.fail;
 
 import java.util.List;
 
@@ -38,30 +38,20 @@ public class ValidationRulesProducerTest {
     @Test
     public void validationRulesShouldBeImmutable() throws Exception {
         List<SelectQueryValidationRule> rules = rulesProducer.selectQueryValidationRules();
+
+        failIfNoExceptionThrown(() -> rules.addAll(rules));
+        failIfNoExceptionThrown(() -> rules.remove(0));
+        failIfNoExceptionThrown(() -> rules.clear());
+        failIfNoExceptionThrown(() -> rules.listIterator().remove());
+        failIfNoExceptionThrown(() -> rules.set(0, FAKE_RULE));
+    }
+
+    private void failIfNoExceptionThrown(Runnable test) {
         try {
-            rules.addAll(rules);
-            failBecauseExceptionWasNotThrown(Exception.class);
+            test.run();
+            fail("Expected exception (immutable list modification)");
         } catch (Exception ignored) {
-        }
-        try {
-            rules.remove(0);
-            failBecauseExceptionWasNotThrown(Exception.class);
-        } catch (Exception ignored) {
-        }
-        try {
-            rules.clear();
-            failBecauseExceptionWasNotThrown(Exception.class);
-        } catch (Exception ignored) {
-        }
-        try {
-            rules.listIterator().remove();
-            failBecauseExceptionWasNotThrown(Exception.class);
-        } catch (Exception ignored) {
-        }
-        try {
-            rules.set(0, FAKE_RULE);
-            failBecauseExceptionWasNotThrown(Exception.class);
-        } catch (Exception ignored) {
+
         }
     }
 }

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/write/validation/InfluxObjectValidationRulesProducerTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/write/validation/InfluxObjectValidationRulesProducerTest.java
@@ -16,7 +16,7 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.write.validation;
 
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.junit.Assert.fail;
 
 import java.util.List;
 
@@ -38,30 +38,20 @@ public class InfluxObjectValidationRulesProducerTest {
     @Test
     public void validationRulesShouldBeImmutable() throws Exception {
         List<InfluxObjectValidationRule> rules = rulesProducer.influxObjectValidationRules();
+
+        failIfNoExceptionThrown(() -> rules.addAll(rules));
+        failIfNoExceptionThrown(() -> rules.remove(0));
+        failIfNoExceptionThrown(() -> rules.clear());
+        failIfNoExceptionThrown(() -> rules.listIterator().remove());
+        failIfNoExceptionThrown(() -> rules.set(0, FAKE_RULE));
+    }
+
+    private void failIfNoExceptionThrown(Runnable test) {
         try {
-            rules.addAll(rules);
-            failBecauseExceptionWasNotThrown(Exception.class);
+            test.run();
+            fail("Expected exception (immutable list modification)");
         } catch (Exception ignored) {
-        }
-        try {
-            rules.remove(0);
-            failBecauseExceptionWasNotThrown(Exception.class);
-        } catch (Exception ignored) {
-        }
-        try {
-            rules.clear();
-            failBecauseExceptionWasNotThrown(Exception.class);
-        } catch (Exception ignored) {
-        }
-        try {
-            rules.listIterator().remove();
-            failBecauseExceptionWasNotThrown(Exception.class);
-        } catch (Exception ignored) {
-        }
-        try {
-            rules.set(0, FAKE_RULE);
-            failBecauseExceptionWasNotThrown(Exception.class);
-        } catch (Exception ignored) {
+
         }
     }
 }

--- a/clients/common/pom.xml
+++ b/clients/common/pom.xml
@@ -33,6 +33,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -90,11 +90,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>test</scope>

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -87,6 +87,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -92,6 +92,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -101,6 +102,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/CanReadMatcher.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/CanReadMatcher.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.clients.ptrans;
+
+import java.io.File;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * @author Thomas Segismont
+ */
+public class CanReadMatcher extends TypeSafeMatcher<File> {
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("can read");
+    }
+
+    @Override
+    protected void describeMismatchSafely(File item, Description mismatchDescription) {
+        mismatchDescription.appendValue(item).appendText(" is not readable");
+    }
+
+    @Override
+    protected boolean matchesSafely(File item) {
+        return item.canRead();
+    }
+
+    @Factory
+    public static Matcher<File> canRead() {
+        return new CanReadMatcher();
+    }
+}

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/ConfigurationITest.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/ConfigurationITest.java
@@ -16,14 +16,20 @@
  */
 package org.hawkular.metrics.clients.ptrans;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static java.util.stream.Collectors.joining;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hawkular.metrics.clients.ptrans.CanReadMatcher.canRead;
 import static org.hawkular.metrics.clients.ptrans.ConfigurationKey.SERVICES;
+import static org.hawkular.metrics.clients.ptrans.IsFileMatcher.isFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Locale;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -50,10 +56,13 @@ public class ConfigurationITest extends ExecutableITestBase {
 
         ptransProcess = ptransProcessBuilder.start();
         int returnCode = ptransProcess.waitFor();
-        assertThat(returnCode).isNotEqualTo(0);
+        assertNotEquals(0, returnCode);
 
-        String expectedError = String.format(Locale.ROOT, "Invalid configuration:%nProperty services not found");
-        assertThat(ptransErr).isFile().canRead().hasContent(expectedError);
+        assertThat(ptransErr, allOf(isFile(), canRead()));
+
+        String expectedContent = String.format("Invalid configuration:%nProperty services not found");
+        String actualContent = Files.lines(ptransErr.toPath()).collect(joining(System.getProperty("line.separator")));
+        assertEquals(expectedContent, actualContent);
     }
 
     @Test
@@ -71,10 +80,13 @@ public class ConfigurationITest extends ExecutableITestBase {
 
         ptransProcess = ptransProcessBuilder.start();
         int returnCode = ptransProcess.waitFor();
-        assertThat(returnCode).isNotEqualTo(0);
+        assertNotEquals(0, returnCode);
 
-        String expectedError = String.format(Locale.ROOT, "Invalid configuration:%nEmpty services list");
-        assertThat(ptransErr).isFile().canRead().hasContent(expectedError);
+        assertThat(ptransErr, allOf(isFile(), canRead()));
+
+        String expectedContent = String.format("Invalid configuration:%nEmpty services list");
+        String actualContent = Files.lines(ptransErr.toPath()).collect(joining(System.getProperty("line.separator")));
+        assertEquals(expectedContent, actualContent);
     }
 
     @Test
@@ -92,9 +104,12 @@ public class ConfigurationITest extends ExecutableITestBase {
 
         ptransProcess = ptransProcessBuilder.start();
         int returnCode = ptransProcess.waitFor();
-        assertThat(returnCode).isNotEqualTo(0);
+        assertNotEquals(0, returnCode);
 
-        String expectedError = String.format(Locale.ROOT, "Invalid configuration:%nUnknown service marseille");
-        assertThat(ptransErr).isFile().canRead().hasContent(expectedError);
+        assertThat(ptransErr, allOf(isFile(), canRead()));
+
+        String expectedContent = String.format("Invalid configuration:%nUnknown service marseille");
+        String actualContent = Files.lines(ptransErr.toPath()).collect(joining(System.getProperty("line.separator")));
+        assertEquals(expectedContent, actualContent);
     }
 }

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/ContainsMatcher.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/ContainsMatcher.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.clients.ptrans;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Objects;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * @author Thomas Segismont
+ */
+public class ContainsMatcher extends TypeSafeMatcher<File> {
+    private final String content;
+
+    public ContainsMatcher(String content) {
+        Objects.requireNonNull(content);
+        this.content = content;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("contains");
+    }
+
+    @Override
+    protected void describeMismatchSafely(File item, Description mismatchDescription) {
+        mismatchDescription.appendValue(item).appendText(" has no line with content: ").appendText(content);
+    }
+
+    @Override
+    protected boolean matchesSafely(File item) {
+        try {
+            return Files.lines(item.toPath()).anyMatch(line -> line.contains(content));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Factory
+    public static Matcher<File> contains(String content) {
+        return new ContainsMatcher(content);
+    }
+}

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/HasSizeMatcher.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/HasSizeMatcher.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.clients.ptrans;
+
+import java.io.File;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * @author Thomas Segismont
+ */
+public class HasSizeMatcher extends TypeSafeMatcher<File> {
+    private final long size;
+
+    public HasSizeMatcher(long size) {
+        this.size = size;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("has size");
+    }
+
+    @Override
+    protected void describeMismatchSafely(File item, Description mismatchDescription) {
+        mismatchDescription.appendValue(item).appendText(" has size: ").appendText(String.valueOf(size));
+    }
+
+    @Override
+    protected boolean matchesSafely(File item) {
+        return item.length() == size;
+    }
+
+    @Factory
+    public static Matcher<File> hasSize(long size) {
+        return new HasSizeMatcher(size);
+    }
+}

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/IsFileMatcher.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/IsFileMatcher.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.clients.ptrans;
+
+import java.io.File;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * @author Thomas Segismont
+ */
+public class IsFileMatcher extends TypeSafeMatcher<File> {
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("is file");
+    }
+
+    @Override
+    protected void describeMismatchSafely(File item, Description mismatchDescription) {
+        mismatchDescription.appendValue(item).appendText(" is not a file");
+    }
+
+    @Override
+    protected boolean matchesSafely(File item) {
+        return item.isFile();
+    }
+
+    @Factory
+    public static Matcher<File> isFile() {
+        return new IsFileMatcher();
+    }
+}

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/MetricBatcherTest.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/MetricBatcherTest.java
@@ -17,10 +17,11 @@
 package org.hawkular.metrics.clients.ptrans;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 import java.util.List;
 
@@ -90,11 +91,11 @@ public class MetricBatcherTest {
     private void checkBatchOutput(EmbeddedChannel embeddedChannel, int batchSize) {
         Object object = embeddedChannel.readInbound();
         assertNotNull("Expected a forwarded batch", object);
-        assertThat(object).isInstanceOf(List.class);
+        assertThat(object, instanceOf(List.class));
         List<?> list = (List<?>) object;
         assertEquals("Unexpected batch size", batchSize, list.size());
         for (Object item : list) {
-            assertThat(item).isInstanceOf(SingleMetric.class);
+            assertThat(item, instanceOf(SingleMetric.class));
         }
     }
 

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/OpenedPortsITest.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/OpenedPortsITest.java
@@ -16,13 +16,10 @@
  */
 package org.hawkular.metrics.clients.ptrans;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 import static org.hawkular.metrics.clients.ptrans.ConfigurationKey.SERVICES;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ConnectException;
@@ -31,7 +28,9 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.Properties;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.google.common.collect.Lists;
 
@@ -39,6 +38,9 @@ import com.google.common.collect.Lists;
  * @author Thomas Segismont
  */
 public class OpenedPortsITest extends ExecutableITestBase {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void shouldBindPortsForEnabledServicesOnly() throws Exception {
@@ -57,12 +59,9 @@ public class OpenedPortsITest extends ExecutableITestBase {
         assertPtransHasStarted(ptransProcess, ptransOut);
 
         Configuration configuration = Configuration.from(properties);
+        expectedException.expect(ConnectException.class);
         try (Socket socket = new Socket()) {
             socket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), configuration.getTcpPort()));
-            fail("ptrans shouldn't be listening on the TCP port");
-        } catch (IOException e) {
-            assertThat(e).isExactlyInstanceOf(ConnectException.class);
         }
     }
-
 }

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/OptionsITest.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/OptionsITest.java
@@ -16,7 +16,14 @@
  */
 package org.hawkular.metrics.clients.ptrans;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hawkular.metrics.clients.ptrans.CanReadMatcher.canRead;
+import static org.hawkular.metrics.clients.ptrans.ContainsMatcher.contains;
+import static org.hawkular.metrics.clients.ptrans.HasSizeMatcher.hasSize;
+import static org.hawkular.metrics.clients.ptrans.IsFileMatcher.isFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
@@ -29,9 +36,8 @@ public class OptionsITest extends ExecutableITestBase {
     public void shouldExitWithErrorIfConfigPathIsMissing() throws Exception {
         ptransProcess = ptransProcessBuilder.start();
         int returnCode = ptransProcess.waitFor();
-        assertThat(returnCode).isNotEqualTo(0);
-
-        assertThat(ptransErr).isFile().canRead().hasContent("Missing required option: c");
+        assertNotEquals(0, returnCode);
+        assertThat(ptransErr, allOf(isFile(), canRead(), contains("Missing required option: c")));
     }
 
     @Test
@@ -40,8 +46,7 @@ public class OptionsITest extends ExecutableITestBase {
 
         ptransProcess = ptransProcessBuilder.start();
         int returnCode = ptransProcess.waitFor();
-        assertThat(returnCode).isEqualTo(0);
-
-        assertThat(ptransErr).isFile().canRead().hasContent("");
+        assertEquals(0, returnCode);
+        assertThat(ptransErr, allOf(isFile(), canRead(), hasSize(0)));
     }
 }

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/WriteLockedMatcher.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/WriteLockedMatcher.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.clients.ptrans;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * @author Thomas Segismont
+ */
+public class WriteLockedMatcher extends TypeSafeMatcher<File> {
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("write locked");
+    }
+
+    @Override
+    protected void describeMismatchSafely(File item, Description mismatchDescription) {
+        mismatchDescription.appendValue(item).appendText(" is not write locked");
+    }
+
+    @Override
+    protected boolean matchesSafely(File item) {
+        try (
+                RandomAccessFile randomAccessFile = new RandomAccessFile(item, "rw");
+                FileChannel channel = randomAccessFile.getChannel();
+                FileLock fileLock = channel.tryLock()
+        ) {
+            return fileLock == null;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Factory
+    public static Matcher<File> writeLocked() {
+        return new WriteLockedMatcher();
+    }
+}

--- a/core/metrics-core-api/pom.xml
+++ b/core/metrics-core-api/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>${testng.version}</version>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/core/metrics-core-impl/pom.xml
+++ b/core/metrics-core-impl/pom.xml
@@ -51,6 +51,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -142,11 +142,6 @@
       </dependency>
       <!-- Tests dependencies -->
       <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>1.7.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>1.10.19</version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,8 @@
         <artifactId>mockito-core</artifactId>
         <version>1.10.19</version>
       </dependency>
-      <!-- TestNG is not RHQ-Metrics main testing framework -->
-      <!-- While still needed to run legacy tests, new tests should be based upon jUnit -->
+      <!-- TestNG is not Hawkular default testing tool -->
+      <!-- While needed to run legacy tests, new tests should be based upon jUnit -->
       <!-- It can still be used when there's a good reason (compatibility with a testing framework for example) -->
       <dependency>
         <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -145,13 +145,11 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>1.7.0</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>1.10.19</version>
-        <scope>test</scope>
       </dependency>
       <!-- TestNG is not RHQ-Metrics main testing framework -->
       <!-- While still needed to run legacy tests, new tests should be based upon jUnit -->
@@ -160,7 +158,6 @@
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
         <version>${testng.version}</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -206,6 +206,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy.modules.http-builder</groupId>


### PR DESCRIPTION
This all started when I realized REST WAR had junit and hamcrest in WEB-INF/lib

junit has no default scope in H* parent
So now we follow H* Parent way of defining test dependencies (no default scope)

Also, removed assertj dependency (nobody's been using it other than me, I'll only miss a few features)
