### PR TITLE
Allow running rest-test multiple times without emptying the datastore in...

### DIFF
--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue
 class CassandraBackendITest extends RESTTest {
 
 //  static final double DELTA = 0.001
-
+  static final String TENANT_PREFIX = UUID.randomUUID().toString()
   static final AtomicInteger TENANT_ID_COUNTER = new AtomicInteger(0)
 
   def assertNumericDataPointEquals = { expected, actual ->
@@ -621,7 +621,7 @@ class CassandraBackendITest extends RESTTest {
   }
 
   static String nextTenantId() {
-    return "T${TENANT_ID_COUNTER.incrementAndGet()}"
+    return "T${TENANT_PREFIX}${TENANT_ID_COUNTER.incrementAndGet()}"
   }
 
 }


### PR DESCRIPTION
... between. Adds random UUID infront of the tenant_id. This makes the test work when running tests against running Hawkular-metrics instance from the IDE for example. Helps when improving the tests.