### PR TITLE
Wildfly Maven Plugin: skip server start when tests are disabled

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -162,8 +162,11 @@
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-maven-plugin</artifactId>
         <configuration>
-          <jvmArgs>-Dhawkular-metrics.backend=em_cass -Xdebug
-            -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</jvmArgs>
+          <javaOpts>
+            <javaOpt>-Dhawkular-metrics.backend=em_cass</javaOpt>
+            <javaOpt>-Xdebug</javaOpt>
+            <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
+          </javaOpts>
         </configuration>
       </plugin>
     </plugins>

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -219,14 +219,21 @@
             </goals>
             <configuration>
               <serverConfig>standalone-test.xml</serverConfig>
-              <jvmArgs>
-                -Xms64m -Xmx512m -Xss256k -Djava.net.preferIPv4Stack=true
-                -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000
-                -Djboss.socket.binding.port-offset=${ptrans.wildfly.port.offset}
-                -Djboss.server.config.dir=${project.build.directory}/wildfly-configuration
-                -Dhawkular-metrics.backend=${hawkular-metrics.backend} -Dcassandra.keyspace=${cassandra.keyspace} -Dcassandra.resetdb=true
-                -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787
-              </jvmArgs>
+              <javaOpts>
+                <javaOpt>-Xms64m</javaOpt>
+                <javaOpt>-Xmx512m</javaOpt>
+                <javaOpt>-Xss256k</javaOpt>
+                <javaOpt>-Djava.net.preferIPv4Stack=true</javaOpt>
+                <javaOpt>-Dsun.rmi.dgc.client.gcInterval=3600000</javaOpt>
+                <javaOpt>-Dsun.rmi.dgc.server.gcInterval=3600000</javaOpt>
+                <javaOpt>-Djboss.socket.binding.port-offset=${ptrans.wildfly.port.offset}</javaOpt>
+                <javaOpt>-Djboss.server.config.dir=${project.build.directory}/wildfly-configuration</javaOpt>
+                <javaOpt>-Dhawkular-metrics.backend=${hawkular-metrics.backend}</javaOpt>
+                <javaOpt>-Dcassandra.keyspace=${cassandra.keyspace}</javaOpt>
+                <javaOpt>-Dcassandra.resetdb=true</javaOpt>
+                <javaOpt>-Xdebug</javaOpt>
+                <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
+              </javaOpts>
             </configuration>
           </execution>
           <execution>

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -207,6 +207,7 @@
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-maven-plugin</artifactId>
         <configuration>
+          <skip>${skipTests}</skip>
           <port>${ptrans.wildfly.management.port}</port>
         </configuration>
         <executions>
@@ -235,7 +236,6 @@
               <goal>deploy-artifact</goal>
             </goals>
             <configuration>
-              <skip>${skipTests}</skip>
               <groupId>${project.groupId}</groupId>
               <artifactId>hawkular-metrics-api-jaxrs</artifactId>
               <name>hawkular-metric-rest.war</name>

--- a/embedded-cassandra/embedded-cassandra-ear/pom.xml
+++ b/embedded-cassandra/embedded-cassandra-ear/pom.xml
@@ -83,12 +83,12 @@
       <plugin>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-maven-plugin</artifactId>
-        <version>1.0.2.Final</version>
         <configuration>
-          <version>${version.wildfly}</version>
-          <skip>false</skip>
-          <jvmArgs>-Dhawkular-metrics.backend=embedded_cass -Xdebug
-            -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</jvmArgs>
+          <javaOpts>
+            <javaOpt>-Dhawkular-metrics.backend=em_cass</javaOpt>
+            <javaOpt>-Xdebug</javaOpt>
+            <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
+          </javaOpts>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <plugin>
           <groupId>org.wildfly.plugins</groupId>
           <artifactId>wildfly-maven-plugin</artifactId>
-          <version>1.0.2.Final</version>
+          <version>1.1.0.Alpha1</version>
           <configuration>
             <version>${version.wildfly}</version>
           </configuration>

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -127,14 +127,21 @@
             </goals>
             <configuration>
               <serverConfig>standalone-test.xml</serverConfig>
-              <jvmArgs>
-                -Xms64m -Xmx512m -Xss256k -Djava.net.preferIPv4Stack=true
-                -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000
-                -Djboss.socket.binding.port-offset=${wildfly.port.offset}
-                -Djboss.server.config.dir=${project.build.directory}/wildfly-configuration
-                -Dhawkular-metrics.backend=${hawkular-metrics.backend} -Dcassandra.keyspace=${cassandra.keyspace} -Dcassandra.resetdb=true
-                -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787
-              </jvmArgs>
+              <javaOpts>
+                <javaOpt>-Xms64m</javaOpt>
+                <javaOpt>-Xmx512m</javaOpt>
+                <javaOpt>-Xss256k</javaOpt>
+                <javaOpt>-Djava.net.preferIPv4Stack=true</javaOpt>
+                <javaOpt>-Dsun.rmi.dgc.client.gcInterval=3600000</javaOpt>
+                <javaOpt>-Dsun.rmi.dgc.server.gcInterval=3600000</javaOpt>
+                <javaOpt>-Djboss.socket.binding.port-offset=${wildfly.port.offset}</javaOpt>
+                <javaOpt>-Djboss.server.config.dir=${project.build.directory}/wildfly-configuration</javaOpt>
+                <javaOpt>-Dhawkular-metrics.backend=${hawkular-metrics.backend}</javaOpt>
+                <javaOpt>-Dcassandra.keyspace=${cassandra.keyspace}</javaOpt>
+                <javaOpt>-Dcassandra.resetdb=true</javaOpt>
+                <javaOpt>-Xdebug</javaOpt>
+                <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
+              </javaOpts>
             </configuration>
           </execution>
           <execution>

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -115,6 +115,7 @@
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-maven-plugin</artifactId>
         <configuration>
+          <skip>${skipTests}</skip>
           <port>${wildfly.management.port}</port>
         </configuration>
         <executions>
@@ -143,7 +144,6 @@
               <goal>deploy-artifact</goal>
             </goals>
             <configuration>
-              <skip>${skipTests}</skip>
               <groupId>${project.groupId}</groupId>
               <artifactId>hawkular-metrics-api-jaxrs</artifactId>
               <name>hawkular-metric-rest.war</name>


### PR DESCRIPTION
Upgrade Wildfly Maven Plugin version -> now we can skip server start when tests are disabled