### PR TITLE
Upgrade to parent POM v9

### DIFF
--- a/api/metrics-api-jaxrs/src/main/resources/rest-doc/asciidoc.mustache
+++ b/api/metrics-api-jaxrs/src/main/resources/rest-doc/asciidoc.mustache
@@ -1,3 +1,20 @@
+{{!
+    Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+
 == APIs
 {{#apiDocuments}}
 === {{{description}}}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>6</version>
+    <version>9</version>
   </parent>
 
   <groupId>org.hawkular.metrics</groupId>


### PR DESCRIPTION
This allows to delay checkstyle execution to the verify phase (instead of compile) 