### PR TITLE
Use different ports for pTrans Wildfly integration tests server

### DIFF
--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -39,10 +39,10 @@
     <hawkular-metrics.backend>cass</hawkular-metrics.backend>
     <cassandra.keyspace>hawkular_metrics_ptrans_integration_tests</cassandra.keyspace>
     <!-- IMPORTANT: The port must be the port offset + 8080. -->
-    <base-uri>127.0.0.1:55977/hawkular-metrics</base-uri>
-    <wildfly.port.offset>47897</wildfly.port.offset>
+    <base-uri>127.0.0.1:55988/hawkular-metrics</base-uri>
+    <ptrans.wildfly.port.offset>47908</ptrans.wildfly.port.offset>
     <!-- IMPORTANT: The management port must be the port offset + 9990. -->
-    <wildfly.management.port>57887</wildfly.management.port>
+    <ptrans.wildfly.management.port>57898</ptrans.wildfly.management.port>
     <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
     <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
   </properties>
@@ -207,7 +207,7 @@
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-maven-plugin</artifactId>
         <configuration>
-          <port>${wildfly.management.port}</port>
+          <port>${ptrans.wildfly.management.port}</port>
         </configuration>
         <executions>
           <execution>
@@ -221,7 +221,7 @@
               <jvmArgs>
                 -Xms64m -Xmx512m -Xss256k -Djava.net.preferIPv4Stack=true
                 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000
-                -Djboss.socket.binding.port-offset=${wildfly.port.offset}
+                -Djboss.socket.binding.port-offset=${ptrans.wildfly.port.offset}
                 -Djboss.server.config.dir=${project.build.directory}/wildfly-configuration
                 -Dhawkular-metrics.backend=${hawkular-metrics.backend} -Dcassandra.keyspace=${cassandra.keyspace} -Dcassandra.resetdb=true
                 -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787


### PR DESCRIPTION
Sometimes the build fails weirdly and it seems to be because rest-tests and and ptrans use the same Wildfly ports (even though they are executed one after the other).