### PR TITLE
Swagger documentation will be pushed to website repo after each successfull build

### DIFF
--- a/.travis.swagger.sh
+++ b/.travis.swagger.sh
@@ -20,7 +20,7 @@
 mvn clean compile -Pdocgen -DskipTests -Dcheckstyle.skip
 
 FILE_NAME="rest-metrics.adoc"
-FILE_PATH="api/metrics-api-jaxrs/generated/$FILE_NAME"
+FILE_PATH="api/metrics-api-jaxrs/target/generated/$FILE_NAME"
 REPO="hawkular/hawkular.github.io"
 BRANCH="swagger"
 SHA=`curl -Ls https://api.github.com/repos/$REPO/contents/$FILE_NAME?ref=$BRANCH | grep '"sha"' | cut -d '"' -f4`

--- a/.travis.swagger.sh
+++ b/.travis.swagger.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# generate the docs
+mvn clean compile -Pdocgen -DskipTests -Dcheckstyle.skip
+
+FILE_NAME="rest-metrics.adoc"
+FILE_PATH="api/metrics-api-jaxrs/generated/$FILE_NAME"
+REPO="hawkular/hawkular.github.io"
+BRANCH="swagger"
+SHA=`curl -Ls https://api.github.com/repos/$REPO/contents/$FILE_NAME?ref=$BRANCH | grep '"sha"' | cut -d '"' -f4`
+CONTENT=`openssl enc -base64 -in $FILE_PATH | sed ':a;N;$!ba;s/\n//g'`
+
+# update the adoc file using GitHub api
+curl -Lis -X PUT -H "Authorization: token $DEPLOY_TOKEN" -d "{\"path\": \"$FILE_NAME\", \"message\": \"Travis CI (metrics): updating swagger documentation\", \"commiter\": {\"name\": \"Travis CI\", \"email\": \"foo@bar.com\"}, \"sha\": \"$SHA\", \"content\": \"$CONTENT\", \"branch\": \"$BRANCH\"}" https://api.github.com/repos/$REPO/contents/$FILE_NAME
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
   - secure: mDUhAf474mlads7ZEAf2mWecQxZWgdfcjiBn6+yif0hJoWKQs38HU+jm4EE8UMgGvdn7avIYvdrxKJ9MnjWpncaXJ0366ZYbxP+7pybMk/SA80yr3dCg5gSHosJ9UqMvGga1bzgDeqF9UppKt0kqxgSLLwKAFoY+x70Pp0rIwQg=
   - secure: Xl2RWUee61vD7Ka/L9M4c9q03w0pn0H5LECsEH6FOTNwLZZdWnHepvF0n8O4YQiG7RdvnK3UHCOGh7G4J5t4XDOwt45IJ3QtjB7FtVdOhMreXHwbMmE0xn2nGGUmhBuYUNN3oIaVzQxWuozcC3g8gQXln4iJVv/f9ecg5R3eRHI=
   - secure: VIYnvHLr/H+2UpeHPe0UKoTK+l+pv6RcKV9tXfLpGEan6th/nmWjo9jR4ZtQNa90FcjOYexRPSLdaU4/SBlpVUHoR59koQQFfdsK+u8hVGpulOpBR6IUDYNQEris93g9NLJA+5PajhGxGnlUqJRP8QAE3RnGK+rq6nGVmlQd4S4=
+  # for pushing the swagger adoc documentation to the website repository
+  - secure: 6JUY0hUjTXaRcVHFqt1q06enCXdqZ9qYkgLA/uUoKq4tYBVDaaqF4yB88CRzr3rXpytz2aywH2dR1idZH4zoWzv1jQ/tCiYE7GjLRO2qn9wgCMzBRq8G7Ov5iFnsT+aBsf6Syx2rNXwH206cHXP4JY/CRs0ez9tcO4LlYls7XN8=
 addons:
   coverity_scan:
     project:
@@ -30,4 +32,4 @@ script:
   -eq 0
 after_failure: bash .travis.diagnose.sh
 after_success:
-- test "${TRAVIS_BRANCH}" = "master" && test "${TRAVIS_PULL_REQUEST}" = "false" && mvn  -s .travis.maven.settings.xml deploy -DskipTests
+- test "${TRAVIS_BRANCH}" = "master" && test "${TRAVIS_PULL_REQUEST}" = "false" && mvn -s .travis.maven.settings.xml deploy -DskipTests && ./.travis.swagger.shs

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ script:
   -eq 0
 after_failure: bash .travis.diagnose.sh
 after_success:
-- test "${TRAVIS_BRANCH}" = "master" && test "${TRAVIS_PULL_REQUEST}" = "false" && mvn -s .travis.maven.settings.xml deploy -DskipTests && ./.travis.swagger.shs
+- test "${TRAVIS_BRANCH}" = "master" && test "${TRAVIS_PULL_REQUEST}" = "false" && mvn -s .travis.maven.settings.xml deploy -DskipTests && ./.travis.swagger.sh

--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -193,7 +193,7 @@
                   <swaggerDirectory>generated/swagger-ui</swaggerDirectory>
                   <swaggerInternalFilter>org.hawkular.metrics.api.jaxrs.swagger.filter.JaxRsFilter</swaggerInternalFilter>
                   <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
-                  <outputPath>${basedir}/generated/rest-metrics.adoc</outputPath>
+                  <outputPath>${build.directory}/generated/rest-metrics.adoc</outputPath>
                 </apiSource>
               </apiSources>
             </configuration>

--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -189,11 +189,11 @@
                   <locations>org.hawkular.metrics.api.jaxrs</locations>
                   <apiVersion>1.0</apiVersion>
                   <basePath>http://localhost:8080/rhq-metrics/</basePath>
-                  <outputTemplate>src/main/resources/rest-doc/asciidoc.mustache</outputTemplate>
+                  <outputTemplate>${basedir}/src/main/resources/rest-doc/asciidoc.mustache</outputTemplate>
                   <swaggerDirectory>generated/swagger-ui</swaggerDirectory>
                   <swaggerInternalFilter>org.hawkular.metrics.api.jaxrs.swagger.filter.JaxRsFilter</swaggerInternalFilter>
                   <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
-                  <outputPath>${basedir}/generated/rest-api-doc.adoc</outputPath>
+                  <outputPath>${basedir}/generated/rest-metrics.adoc</outputPath>
                 </apiSource>
               </apiSources>
             </configuration>


### PR DESCRIPTION
This won't invoke the build of the website immediately (=> tons of builds), but once the website is built it takes this up-to-date adoc file by this script (and adds a jBake header) 

https://github.com/hawkular/hawkular.github.io/blob/pages/.travis.swagger.sh