### PR TITLE
HWKMETRICS-40

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -185,7 +185,7 @@
                   <apiVersion>1.0</apiVersion>
                   <basePath>http://localhost:8080/hawkular-metrics/</basePath>
                   <outputTemplate>${basedir}/src/main/resources/rest-doc/asciidoc.mustache</outputTemplate>
-                  <swaggerDirectory>generated/swagger-ui</swaggerDirectory>
+                  <swaggerDirectory>${build.directory}/generated/swagger-ui</swaggerDirectory>
                   <swaggerInternalFilter>org.hawkular.metrics.api.jaxrs.swagger.filter.JaxRsFilter</swaggerInternalFilter>
                   <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
                   <outputPath>${build.directory}/generated/rest-metrics.adoc</outputPath>


### PR DESCRIPTION
Don't create the generated/swagger-ui directory in the project root when building with docgen profile