### PR TITLE
[HWKMETRICS-40] Fix target directory for the swagger json

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -185,10 +185,10 @@
                   <apiVersion>1.0</apiVersion>
                   <basePath>http://localhost:8080/hawkular-metrics/</basePath>
                   <outputTemplate>${basedir}/src/main/resources/rest-doc/asciidoc.mustache</outputTemplate>
-                  <swaggerDirectory>generated/swagger-ui</swaggerDirectory>
+                  <swaggerDirectory>${project.build.directory}/generated/swagger-ui</swaggerDirectory>
                   <swaggerInternalFilter>org.hawkular.metrics.api.jaxrs.swagger.filter.JaxRsFilter</swaggerInternalFilter>
                   <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
-                  <outputPath>${build.directory}/generated/rest-metrics.adoc</outputPath>
+                  <outputPath>${project.build.directory}/generated/rest-metrics.adoc</outputPath>
                 </apiSource>
               </apiSources>
             </configuration>


### PR DESCRIPTION
Use project.build.directory (build.directory notation is deprecated) for the generated stuff