### PR TITLE
[HWKMETRICS-39]fix for JAX-RS warnings and send proper error message

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/BadRequestExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/BadRequestExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.exception.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.BadRequestException;
+
+/**
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Bad Request (400) is encountered.
+ * <p>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
+ * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
+ *
+ * @author Thomas Segismont
+ */
+@Provider
+public class BadRequestExceptionMapper implements ExceptionMapper<BadRequestException> {
+
+    @Override
+    public Response toResponse(BadRequestException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/ExceptionMapperUtils.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/ExceptionMapperUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.exception.mappers;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.hawkular.metrics.api.jaxrs.ApiError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
+
+/**
+ * @author Jeeva Kandasamy
+ */
+public class ExceptionMapperUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(ExceptionMapperUtils.class);
+    private ExceptionMapperUtils(){
+
+    }
+
+    public static Response buildResponse(Throwable exception, Status status){
+        LOG.trace("RestEasy exception,", exception);
+        return Response.status(status)
+                .entity(new ApiError(Throwables.getRootCause(exception).getMessage()))
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build();
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotAcceptableExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotAcceptableExceptionMapper.java
@@ -24,8 +24,8 @@ import javax.ws.rs.ext.Provider;
 /**
  * Exception mapper for any exception thrown by RESTEasy when HTTP Not Acceptable (406) is encountered.
  * <p>
- * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
- * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
+ * This mapper let us reply to the user with a pre-determined message format if, for example, receive a
+ * HTTP GET request with unsupported media type.
  *
  * @author Jeeva Kandasamy
  */

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotAcceptableExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotAcceptableExceptionMapper.java
@@ -14,31 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.api.jaxrs;
+package org.hawkular.metrics.api.jaxrs.exception.mappers;
 
+import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.jboss.resteasy.spi.BadRequestException;
-
-import com.google.common.base.Throwables;
-
 /**
- * Exception mapper for any exception thrown by RESTEasy when HTTP Bad Request (400) is encountered.
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Not Acceptable (406) is encountered.
  * <p>
  * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
  * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
  *
- * @author Thomas Segismont
+ * @author Jeeva Kandasamy
  */
 @Provider
-public class BadRequestExceptionMapper implements ExceptionMapper<BadRequestException> {
+public class NotAcceptableExceptionMapper implements ExceptionMapper<NotAcceptableException> {
 
     @Override
-    public Response toResponse(BadRequestException exception) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                       .entity(new ApiError(Throwables.getRootCause(exception).getMessage()))
-                       .build();
+    public Response toResponse(NotAcceptableException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.NOT_ACCEPTABLE);
     }
+
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotAllowedExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotAllowedExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.exception.mappers;
+
+import javax.ws.rs.NotAllowedException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Method Not Allowed (405) is encountered.
+ * <p>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
+ * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
+ *
+ * @author Jeeva Kandasamy
+ */
+@Provider
+public class NotAllowedExceptionMapper implements ExceptionMapper<NotAllowedException> {
+
+    @Override
+    public Response toResponse(NotAllowedException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.METHOD_NOT_ALLOWED);
+    }
+
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotAllowedExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotAllowedExceptionMapper.java
@@ -24,8 +24,8 @@ import javax.ws.rs.ext.Provider;
 /**
  * Exception mapper for any exception thrown by RESTEasy when HTTP Method Not Allowed (405) is encountered.
  * <p>
- * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
- * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
+ * This mapper let us reply to the user with a pre-determined message format if, for example, receive
+ * a HTTP POST request for a resource which does not support for HTTP POST method.
  *
  * @author Jeeva Kandasamy
  */

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotFoundExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotFoundExceptionMapper.java
@@ -21,10 +21,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import com.google.common.base.Predicates;
-import com.google.common.base.Throwables;
-import com.google.common.collect.FluentIterable;
-
 /**
  * Exception mapper for any exception thrown by RESTEasy when HTTP Not Found (404) is encountered.
  * Also checks the case chain, if NumberFormatException is present building response with HTTP Bad Request (400).
@@ -39,8 +35,7 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
 
     @Override
     public Response toResponse(NotFoundException exception) {
-        if (FluentIterable.from(Throwables.getCausalChain(exception))
-                .filter(Predicates.instanceOf(NumberFormatException.class)).first().isPresent()) {
+        if (exception.getCause() != null && exception.getCause() instanceof NumberFormatException) {
             return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
         } else {
             return ExceptionMapperUtils.buildResponse(exception, Response.Status.NOT_FOUND);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotFoundExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotFoundExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.exception.mappers;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Not Found (404) is encountered.
+ * <p>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
+ * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
+ *
+ * @author Jeeva Kandasamy
+ */
+@Provider
+public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
+
+    @Override
+    public Response toResponse(NotFoundException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
+    }
+
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotFoundExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotFoundExceptionMapper.java
@@ -35,7 +35,7 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
 
     @Override
     public Response toResponse(NotFoundException exception) {
-        if (exception.getCause() != null && exception.getCause() instanceof NumberFormatException) {
+        if (exception.getCause() instanceof NumberFormatException) {
             return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
         } else {
             return ExceptionMapperUtils.buildResponse(exception, Response.Status.NOT_FOUND);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotSupportedExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotSupportedExceptionMapper.java
@@ -14,33 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.api.jaxrs;
+package org.hawkular.metrics.api.jaxrs.exception.mappers;
 
-import javax.ws.rs.core.MediaType;
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.jboss.resteasy.spi.ReaderException;
-
-import com.google.common.base.Throwables;
-
 /**
- * Exception mapper for any exception thrown by a body reader chain.
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Unsupported Media Type (415) is encountered.
  * <p>
- * This mapper let us reply to the user with a pre-determined message format if, for example, a JSON entity cannot be
- * parsed.
+ * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
+ * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
  *
- * @author Thomas Segismont
+ * @author Jeeva Kandasamy
  */
 @Provider
-public class ReaderExceptionMapper implements ExceptionMapper<ReaderException> {
+public class NotSupportedExceptionMapper implements ExceptionMapper<NotSupportedException> {
 
     @Override
-    public Response toResponse(ReaderException exception) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                       .entity(new ApiError(Throwables.getRootCause(exception).getMessage()))
-                       .type(MediaType.APPLICATION_JSON)
-                       .build();
+    public Response toResponse(NotSupportedException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.UNSUPPORTED_MEDIA_TYPE);
     }
+
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotSupportedExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/NotSupportedExceptionMapper.java
@@ -24,8 +24,8 @@ import javax.ws.rs.ext.Provider;
 /**
  * Exception mapper for any exception thrown by RESTEasy when HTTP Unsupported Media Type (415) is encountered.
  * <p>
- * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
- * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
+ * This mapper let us reply to the user with a pre-determined message format if, for example, receive a
+ * HTTP POST request with unsupported media type.
  *
  * @author Jeeva Kandasamy
  */

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/ReaderExceptionMapper.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/exception/mappers/ReaderExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.exception.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ReaderException;
+
+/**
+ * Exception mapper for any exception thrown by a body reader chain.
+ * <p>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, a JSON entity cannot be
+ * parsed.
+ *
+ * @author Thomas Segismont
+ */
+@Provider
+public class ReaderExceptionMapper implements ExceptionMapper<ReaderException> {
+
+    @Override
+    public Response toResponse(ReaderException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
+    }
+}

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -243,16 +243,15 @@
       <version>1.5</version>
       <scope>test</scope>
     </dependency>
-    <!-- Wildfly provided -->
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -243,6 +243,17 @@
       <version>1.5</version>
       <scope>test</scope>
     </dependency>
+    <!-- Wildfly provided -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/ApiErrorJson.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/ApiErrorJson.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.test;
+
+public class ApiErrorJson {
+    private String errorMsg;
+
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+    public void setErrorMsg(String errorMsg) {
+        this.errorMsg = errorMsg;
+    }
+}

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/ErrorsITest.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/ErrorsITest.java
@@ -58,8 +58,8 @@ public class ErrorsITest extends RESTTest {
                 .get();
         Assert.assertEquals(404, response.getStatus());
         ApiErrorJson apiErrorJson = response.readEntity(ApiErrorJson.class);
-        Assert.assertEquals("Could not find resource for full path: http://127.0.0.1:55977"
-                + "/hawkular-metrics/test/metricsssss/numeric/test/data?buckets=999",
+        Assert.assertEquals("Could not find resource for full path: http://"+baseURI
+                + "/test/metricsssss/numeric/test/data?buckets=999",
                 apiErrorJson.getErrorMsg());
     }
 

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/ErrorsITest.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/ErrorsITest.java
@@ -40,7 +40,7 @@ public class ErrorsITest extends RESTTest {
     @Test
     public void testNotAllowedException() {
         response = target.clone()
-                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric/test/tags")
+                .path("/test/metrics/numeric/test/tags")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .post(null);
         Assert.assertEquals(405, response.getStatus());
@@ -52,21 +52,21 @@ public class ErrorsITest extends RESTTest {
     @Test
     public void testNotFoundException() {
         response = target.clone()
-                .path("/" + TENANT_PREFIX + "test" + "/metricsssss/numeric/test/data")
+                .path("/test/metricsssss/numeric/test/data")
                 .queryParam("buckets", "999")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get();
         Assert.assertEquals(404, response.getStatus());
         ApiErrorJson apiErrorJson = response.readEntity(ApiErrorJson.class);
         Assert.assertEquals("Could not find resource for full path: http://127.0.0.1:55977"
-                + "/hawkular-metrics/" + TENANT_PREFIX + "test" + "/metricsssss/numeric/test/data?buckets=999",
+                + "/hawkular-metrics/test/metricsssss/numeric/test/data?buckets=999",
                 apiErrorJson.getErrorMsg());
     }
 
     @Test
     public void testNumberFormatException() {
         response = target.clone()
-                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric/test/data")
+                .path("/test/metrics/numeric/test/data")
                 .queryParam("buckets", "999999999999999999999999")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get();
@@ -79,7 +79,7 @@ public class ErrorsITest extends RESTTest {
     @Test
     public void testNotAcceptableException() {
         response = target.clone()
-                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric/test/data")
+                .path("/test/metrics/numeric/test/data")
                 .request(MediaType.TEXT_PLAIN)
                 .get();
         Assert.assertEquals(406, response.getStatus());
@@ -91,7 +91,7 @@ public class ErrorsITest extends RESTTest {
     @Test
     public void testNotSupportedException() {
         response = target.clone()
-                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric/test/data")
+                .path("/test/metrics/numeric/test/data")
                 .request(MediaType.TEXT_PLAIN)
                 .post(null);
         Assert.assertEquals(415, response.getStatus());

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/ErrorsITest.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/ErrorsITest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.test;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jeeva Kandasamy
+ */
+public class ErrorsITest extends RESTTest {
+    Response response = null;
+
+    @After
+    public void closeResponse() {
+        if (response != null) {
+            response.close();
+            response = null;
+        }
+    }
+
+    @Test
+    public void testNotAllowedException() {
+        response = target.clone()
+                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric/test/tags")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(null);
+        Assert.assertEquals(405, response.getStatus());
+        ApiErrorJson apiErrorJson = response.readEntity(ApiErrorJson.class);
+        Assert.assertEquals("No resource method found for POST, return 405 with Allow header",
+                apiErrorJson.getErrorMsg());
+    }
+
+    @Test
+    public void testNotFoundException() {
+        response = target.clone()
+                .path("/" + TENANT_PREFIX + "test" + "/metricsssss/numeric/test/data")
+                .queryParam("buckets", "999")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+        Assert.assertEquals(404, response.getStatus());
+        ApiErrorJson apiErrorJson = response.readEntity(ApiErrorJson.class);
+        Assert.assertEquals("Could not find resource for full path: http://127.0.0.1:55977"
+                + "/hawkular-metrics/" + TENANT_PREFIX + "test" + "/metricsssss/numeric/test/data?buckets=999",
+                apiErrorJson.getErrorMsg());
+    }
+
+    @Test
+    public void testNumberFormatException() {
+        response = target.clone()
+                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric/test/data")
+                .queryParam("buckets", "999999999999999999999999")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+        Assert.assertEquals(400, response.getStatus());
+        ApiErrorJson apiErrorJson = response.readEntity(ApiErrorJson.class);
+        Assert.assertEquals("For input string: \"999999999999999999999999\"",
+                apiErrorJson.getErrorMsg());
+    }
+
+    @Test
+    public void testNotAcceptableException() {
+        response = target.clone()
+                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric/test/data")
+                .request(MediaType.TEXT_PLAIN)
+                .get();
+        Assert.assertEquals(406, response.getStatus());
+        ApiErrorJson apiErrorJson = response.readEntity(ApiErrorJson.class);
+        Assert.assertEquals("No match for accept header",
+                apiErrorJson.getErrorMsg());
+    }
+
+    @Test
+    public void testNotSupportedException() {
+        response = target.clone()
+                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric/test/data")
+                .request(MediaType.TEXT_PLAIN)
+                .post(null);
+        Assert.assertEquals(415, response.getStatus());
+        ApiErrorJson apiErrorJson = response.readEntity(ApiErrorJson.class);
+        Assert.assertEquals("Cannot consume content type",
+                apiErrorJson.getErrorMsg());
+    }
+}

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/RESTTest.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/RESTTest.java
@@ -16,19 +16,9 @@
  */
 package org.hawkular.metrics.test;
 
-import java.util.UUID;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
-import org.hawkular.metrics.core.api.MetricId;
-import org.hawkular.metrics.core.api.NumericMetric;
-import org.hawkular.metrics.core.api.Tenant;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 
 /**
@@ -36,7 +26,6 @@ import org.junit.BeforeClass;
  */
 public class RESTTest {
     static String baseURI = System.getProperty("hawkular-metrics.base-uri", "127.0.0.1:8080/hawkular-metrics");
-    static final String TENANT_PREFIX = UUID.randomUUID().toString();
     static ResteasyClient restClient = null;
     static ResteasyWebTarget target = null;
 
@@ -46,21 +35,5 @@ public class RESTTest {
             restClient = new ResteasyClientBuilder().build();
             target = restClient.target("http://" + baseURI);
         }
-        //Create Tenant
-        Tenant tenant = new Tenant();
-        tenant.setId(TENANT_PREFIX + "test");
-        Response response = target.clone()
-                .path("/tenants")
-                .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.entity(tenant, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus());
-        response.close();
-        //Create Numeric Metric
-        response = target.clone()
-                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric")
-                .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.entity(new NumericMetric(new MetricId("test")), MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus());
-        response.close();
     }
 }

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/RESTTest.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/RESTTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.test;
+
+import java.util.UUID;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.hawkular.metrics.core.api.MetricId;
+import org.hawkular.metrics.core.api.NumericMetric;
+import org.hawkular.metrics.core.api.Tenant;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+/**
+ * @author Jeeva Kandasamy
+ */
+public class RESTTest {
+    static String baseURI = System.getProperty("hawkular-metrics.base-uri", "127.0.0.1:8080/hawkular-metrics");
+    static final String TENANT_PREFIX = UUID.randomUUID().toString();
+    static ResteasyClient restClient = null;
+    static ResteasyWebTarget target = null;
+
+    @BeforeClass
+    public static void initClient() {
+        if (restClient == null) {
+            restClient = new ResteasyClientBuilder().build();
+            target = restClient.target("http://" + baseURI);
+        }
+        //Create Tenant
+        Tenant tenant = new Tenant();
+        tenant.setId(TENANT_PREFIX + "test");
+        Response response = target.clone()
+                .path("/tenants")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(tenant, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(201, response.getStatus());
+        response.close();
+        //Create Numeric Metric
+        response = target.clone()
+                .path("/" + TENANT_PREFIX + "test" + "/metrics/numeric")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(new NumericMetric(new MetricId("test")), MediaType.APPLICATION_JSON));
+        Assert.assertEquals(201, response.getStatus());
+        response.close();
+    }
+}


### PR DESCRIPTION
This fix handles NotAcceptable(406), NotAllowed(405), NotFound(404) and NotSupported(415) exceptions. Returns http response with error message and corresponding status code. For NotFound(404) exception only it returns status code as 400 (Bad request).