### PR TITLE
HAWKULAR-134 - Moving the asciidoc.mustache to hawkular-build-tools

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -174,6 +174,30 @@
         <!-- Document generation from the Swagger annotations on the REST-API. -->
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.hawkular</groupId>
+                      <artifactId>hawkular-build-tools</artifactId>
+                      <version>${version.org.hawkular.hawkular-build-tools}</version>
+                      <type>jar</type>
+                      <includes>**/*.mustache</includes>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>com.github.kongchen</groupId>
             <artifactId>swagger-maven-plugin</artifactId>
             <configuration>
@@ -182,7 +206,7 @@
                   <locations>org.hawkular.metrics.api.jaxrs</locations>
                   <apiVersion>1.0</apiVersion>
                   <basePath>http://localhost:8080/hawkular-metrics/</basePath>
-                  <outputTemplate>https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/asciidoc.mustache</outputTemplate>
+                  <outputTemplate>${project.build.directory}/dependency/hawkular-documentation/asciidoc.mustache</outputTemplate>
                   <swaggerDirectory>${project.build.directory}/generated/swagger-ui</swaggerDirectory>
                   <swaggerInternalFilter>org.hawkular.metrics.api.jaxrs.swagger.filter.JaxRsFilter</swaggerInternalFilter>
                   <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>


### PR DESCRIPTION
**don't merge yet**

This can be merged once hawkular/hawkular-build-tools/pull/15 is merged and hawkular-parent version is updated. Also, I guess, the version of build-tools should be bumped.