### PR TITLE
findMetrics did not follow consistent gauges naming

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -87,7 +87,8 @@ public class MetricHandler {
                         metricType = MetricType.fromTextCode(type);
                     } catch (IllegalArgumentException e) {
                         return badRequest(
-                                new ApiError("[" + type + "] is not a valid type. Accepted values are gauge|avail|log")
+                                new ApiError("[" + type + "] is not a valid type. Accepted values are " +
+                                                     "gauge|gauges|availability")
                         );
                     }
                     ListenableFuture<List<Metric<?>>> future = metricsService.findMetrics(tenantId, metricType);

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricType.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricType.java
@@ -66,6 +66,7 @@ public enum MetricType {
     public static MetricType fromTextCode(String textCode) {
         switch (textCode) {
         case "gauge": return GAUGE;
+        case "gauges": return GAUGE;
         case "availability": return AVAILABILITY;
         default: throw new IllegalArgumentException(textCode + " is not a recognized metric type code");
         }


### PR DESCRIPTION
type should follow the same naming convention than rest of the REST-API (even if plural doesn't sound right). I still would prefer moving this to PathParam ..