### PR TITLE
Fixing the travis after success section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,6 @@ after_success:
 - VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`
 - if [[ "$VERSION" =~ .*SNAPSHOT ]] && [[ "${TRAVIS_BRANCH}" = "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]];
   then
-    mvn -s .travis.maven.settings.xml deploy -DskipTests
+    mvn -s .travis.maven.settings.xml deploy -DskipTests ;
     ./.travis.swagger.sh
   fi


### PR DESCRIPTION
Currently it concatenates the commands on each like in the if-then statement so it fails with https://travis-ci.org/hawkular/hawkular-metrics/builds/61045031#L2066

Adding a semicolon (no need to use &&, because we want to deploy the docs even if the mvn deploy fails). And also mvn return codes are inherently broken, it returns 0 all the time ;)