### PR TITLE
HWKMETRICS-67 Influx endpoint: support pretty print query parameter

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/prettyprint/PrettyFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/prettyprint/PrettyFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.influx.prettyprint;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Check if the request targets the Influx endpoint and the <em>pretty</em> query parameter is set to true. In this
+ * case, the {@link #PRETTY_PRINT} context property is set to {@link Boolean#TRUE}.
+ *
+ * @author Thomas Segismont
+ * @see PrettyInterceptor
+ */
+@Provider
+public class PrettyFilter implements ContainerRequestFilter {
+    static final String PRETTY_PRINT = PrettyFilter.class.getName();
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        UriInfo uriInfo = requestContext.getUriInfo();
+        if (!APPLICATION_JSON_TYPE.equals(requestContext.getMediaType())
+            || !uriInfo.getPath().startsWith("/db")) {
+            return;
+        }
+        requestContext.setProperty(PRETTY_PRINT, Boolean.valueOf(uriInfo.getQueryParameters().getFirst("pretty")));
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/prettyprint/PrettyInterceptor.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/prettyprint/PrettyInterceptor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.influx.prettyprint;
+
+import static java.lang.Boolean.TRUE;
+
+import static org.hawkular.metrics.api.jaxrs.influx.prettyprint.PrettyFilter.PRETTY_PRINT;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Check if {@link PrettyFilter#PRETTY_PRINT} context property is set. In this case, the JSON output is intercepted and
+ * formatted.
+ *
+ * @author Thomas Segismont
+ * @see PrettyFilter
+ */
+@Provider
+public class PrettyInterceptor implements WriterInterceptor {
+    private final ObjectMapper mapper;
+
+    public PrettyInterceptor() {
+        mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    }
+
+    @Override
+    public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
+        if (context.getProperty(PRETTY_PRINT) != TRUE) {
+            context.proceed();
+            return;
+        }
+
+        // Any content length set will be obsolete
+        context.getHeaders().remove(HttpHeaders.CONTENT_LENGTH);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputStream old = context.getOutputStream();
+        try {
+
+            context.setOutputStream(baos);
+            context.proceed();
+
+            JsonNode jsonNode = mapper.readValue(baos.toByteArray(), JsonNode.class);
+            mapper.writeValue(old, jsonNode);
+
+        } finally {
+            context.setOutputStream(old);
+        }
+    }
+}


### PR DESCRIPTION
PrettyFilter checks if the output should be formatted and PrettyInterceptor intercepts JSON response to format it.

I've tried to find how to interact with the RestEasy Jackson mappers directly but the solution would have been hard to maintain.

Here there's a little overhead due to parsing of the entity stream. But this will only be used by humans for a fraction of requests.