### PR TITLE
HWKMETRICS-85 Tags will return only tags and definition has its own method

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -132,7 +132,8 @@ public class AvailabilityHandler {
 
     @GET
     @Path("/{id}/tags")
-    @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Map.class)
+    @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = String.class,
+                  responseContainer = "Map")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Metric's tags were successfully retrieved."),
             @ApiResponse(code = 204, message = "Query was successful, but no metrics were found."),

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -58,7 +57,6 @@ import org.hawkular.metrics.core.api.AvailabilityBucketDataPoint;
 import org.hawkular.metrics.core.api.AvailabilityData;
 import org.hawkular.metrics.core.api.BucketedOutput;
 import org.hawkular.metrics.core.api.Buckets;
-import org.hawkular.metrics.core.api.Metric;
 import org.hawkular.metrics.core.api.MetricId;
 import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
@@ -124,9 +122,9 @@ public class AvailabilityHandler {
         executeAsync(
                 asyncResponse,
                 () -> {
-                    ListenableFuture<Optional<Metric<?>>> future = metricsService.findMetric(tenantId,
-                            MetricType.AVAILABILITY, new MetricId(id));
-                    return Futures.transform(future, ApiUtils.MAP_VALUE);
+                ListenableFuture<Map<String, String>> future = metricsService.getMetricTags(tenantId,
+                    MetricType.AVAILABILITY, new MetricId(id));
+                    return Futures.transform(future, ApiUtils.MAP_MAP);
                 });
     }
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -57,6 +58,7 @@ import org.hawkular.metrics.core.api.AvailabilityBucketDataPoint;
 import org.hawkular.metrics.core.api.AvailabilityData;
 import org.hawkular.metrics.core.api.BucketedOutput;
 import org.hawkular.metrics.core.api.Buckets;
+import org.hawkular.metrics.core.api.Metric;
 import org.hawkular.metrics.core.api.MetricId;
 import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
@@ -107,6 +109,25 @@ public class AvailabilityHandler {
         URI created = uriInfo.getBaseUriBuilder().path("/availability/{id}").build(metric.getId().getName());
         MetricCreatedCallback metricCreatedCallback = new MetricCreatedCallback(asyncResponse, created);
         Futures.addCallback(future, metricCreatedCallback);
+    }
+
+    @GET
+    @Path("/{id}")
+    @ApiOperation(value = "Retrieve single metric definition.", response = Metric.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Metric's definition was successfully retrieved."),
+            @ApiResponse(code = 204, message = "Query was successful, but no metrics definition is set."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric's definition.",
+                         response = ApiError.class) })
+    public void getAvailabilityMetric(@Suspended final AsyncResponse asyncResponse,
+                                         @HeaderParam("tenantId") String tenantId, @PathParam("id") String id) {
+        executeAsync(
+                asyncResponse,
+                () -> {
+                ListenableFuture<Optional<Metric<?>>> future = metricsService.findMetric(tenantId,
+                    MetricType.AVAILABILITY, new MetricId(id));
+                    return Futures.transform(future, ApiUtils.MAP_VALUE);
+                });
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -136,7 +136,8 @@ public class GaugeHandler {
 
     @GET
     @Path("/{id}/tags")
-    @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Metric.class)
+    @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = String.class,
+                  responseContainer = "Map")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Metric's tags were successfully retrieved."),
             @ApiResponse(code = 204, message = "Query was successful, but no metrics were found."),

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -112,6 +113,25 @@ public class GaugeHandler {
         URI created = uriInfo.getBaseUriBuilder().path("/gauges/{id}").build(metric.getId().getName());
         MetricCreatedCallback metricCreatedCallback = new MetricCreatedCallback(asyncResponse, created);
         Futures.addCallback(future, metricCreatedCallback);
+    }
+
+    @GET
+    @Path("/{id}")
+    @ApiOperation(value = "Retrieve single metric definition.", response = Metric.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Metric's definition was successfully retrieved."),
+            @ApiResponse(code = 204, message = "Query was successful, but no metrics definition is set."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric's definition.",
+                         response = ApiError.class) })
+    public void getGaugeMetric(@Suspended final AsyncResponse asyncResponse,
+                                   @HeaderParam("tenantId") String tenantId, @PathParam("id") String id) {
+        executeAsync(
+                asyncResponse,
+                () -> {
+                ListenableFuture<Optional<Metric<?>>> future = metricsService.findMetric(tenantId, MetricType.GAUGE,
+                    new MetricId(id));
+                 return Futures.transform(future, ApiUtils.MAP_VALUE);
+                });
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -128,9 +127,9 @@ public class GaugeHandler {
         executeAsync(
                 asyncResponse,
                 () -> {
-                    ListenableFuture<Optional<Metric<?>>> future = metricsService.findMetric(tenantId,
-                            MetricType.GAUGE, new MetricId(id));
-                    return Futures.transform(future, ApiUtils.MAP_VALUE);
+                ListenableFuture<Map<String, String>> future = metricsService.getMetricTags(tenantId, MetricType.GAUGE,
+                    new MetricId(id));
+                    return Futures.transform(future, ApiUtils.MAP_MAP);
                 });
     }
 

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -74,6 +74,8 @@ public interface MetricsService {
 
     ListenableFuture<List<Metric<?>>> findMetrics(String tenantId, MetricType type);
 
+    ListenableFuture<Map<String, String>> getMetricTags(String tenantId, MetricType type, MetricId id);
+
     ListenableFuture<Void> addTags(Metric metric, Map<String, String> tags);
 
     ListenableFuture<Void> deleteTags(Metric metric, Map<String, String> tags);

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/cassandra/DataAccess.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/cassandra/DataAccess.java
@@ -51,6 +51,8 @@ public interface DataAccess {
 
     ResultSetFuture addTagsAndDataRetention(Metric<?> metric);
 
+    ResultSetFuture getMetricTags(String tenantId, MetricType type, MetricId id, long dpart);
+
     ResultSetFuture addTags(Metric<?> metric, Map<String, String> tags);
 
     ResultSetFuture deleteTags(Metric<?> metric, Set<String> tags);

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/cassandra/DataAccessImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/cassandra/DataAccessImpl.java
@@ -73,6 +73,8 @@ public class DataAccessImpl implements DataAccess {
 
     private PreparedStatement findMetric;
 
+    private PreparedStatement getMetricTags;
+
     private PreparedStatement addMetricTagsToDataTable;
 
     private PreparedStatement addMetadataAndDataRetention;
@@ -156,6 +158,11 @@ public class DataAccessImpl implements DataAccess {
             "SELECT tenant_id, type, metric, interval, dpart, m_tags, data_retention " +
             "FROM data " +
             "WHERE tenant_id = ? AND type = ? AND metric = ? AND interval = ? AND dpart = ?");
+
+        getMetricTags = session.prepare(
+                "SELECT m_tags " +
+                "FROM data " +
+                "WHERE tenant_id = ? AND type = ? AND metric = ? AND interval = ? AND dpart = ?");
 
         addMetricTagsToDataTable = session.prepare(
             "UPDATE data " +
@@ -367,6 +374,12 @@ public class DataAccessImpl implements DataAccess {
     public ResultSetFuture findMetric(String tenantId, MetricType type, MetricId id, long dpart) {
         return session.executeAsync(findMetric.bind(tenantId, type.getCode(), id.getName(),
             id.getInterval().toString(), dpart));
+    }
+
+    @Override
+    public ResultSetFuture getMetricTags(String tenantId, MetricType type, MetricId id, long dpart) {
+        return session.executeAsync(getMetricTags.bind(tenantId, type.getCode(), id.getName(), id.getInterval()
+            .toString(), dpart));
     }
 
     // This method updates the metric tags and data retention in the data table. In the

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/cassandra/DelegatingDataAccess.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/cassandra/DelegatingDataAccess.java
@@ -72,6 +72,11 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
+    public ResultSetFuture getMetricTags(String tenantId, MetricType type, MetricId id, long dpart) {
+        return delegate.getMetricTags(tenantId, type, id, dpart);
+    }
+
+    @Override
     public ResultSetFuture addTagsAndDataRetention(Metric metric) {
         return delegate.addTagsAndDataRetention(metric);
     }

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -69,6 +69,9 @@ class TagsITest extends RESTTest {
 
     response = hawkularMetrics.get(path: "availability/missing/tags", headers: ["tenantId": tenantId])
     assertEquals("Expected a 204 response when the availability metric is not found", 204, response.status)
+
+    response = hawkularMetrics.get(path: "gauges/missing", headers: ["tenantId": tenantId])
+    assertEquals("Expected a 204 response when the gauge metric is not found", 204, response.status)
   }
 
   @Test
@@ -81,6 +84,15 @@ class TagsITest extends RESTTest {
         tags: ['  a  1   ': '   A', 'bsq   d1': 'B   ']
     ], headers: ["tenantId": tenantId])
     assertEquals(201, response.status)
+
+    // Fetch the metric
+    response = hawkularMetrics.get(path: "gauges/N1", headers: ["tenantId": tenantId])
+    assertEquals(200, response.status)
+    assertEquals([
+        tenantId: tenantId,
+        id  : 'N1',
+        tags: ['  a  1   ': '   A', 'bsq   d1': 'B   ']
+    ], response.data)
 
     // Make sure we do not allow duplicates
     badPost(path: "gauges", body: [id: 'N1'], headers: ["tenantId": tenantId]) { exception ->

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -16,6 +16,8 @@
  */
 package org.hawkular.metrics.rest
 
+import groovy.json.JsonOutput
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 
@@ -118,26 +120,11 @@ class TagsITest extends RESTTest {
     // Fetch gauge tags
     response = hawkularMetrics.get(path: "gauges/N1/tags", headers: ["tenantId": tenantId])
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            tenantId: tenantId,
-            id      : 'N1',
-            tags    : ['  a  1   ': '   A', 'bsq   d1': 'B   ']
-        ],
-        response.data
-    )
+    assertEquals('  a  1   ': '   A', 'bsq   d1': 'B   ', response.data)
 
     response = hawkularMetrics.get(path: "gauges/N2/tags", headers: ["tenantId": tenantId])
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            tenantId     : tenantId,
-            id           : 'N2',
-            tags         : [a2: '2', b2: 'B2'],
-            dataRetention: 96
-        ],
-        response.data
-    )
+    assertEquals([a2: '2', b2: 'B2'], response.data)
 
     // Verify the response for a non-existent metric
     response = hawkularMetrics.get(path: "gauges/N-doesNotExist/tags", headers: ["tenantId": tenantId])
@@ -146,26 +133,11 @@ class TagsITest extends RESTTest {
     // Fetch availability metric tags
     response = hawkularMetrics.get(path: "availability/A1/tags", headers: ["tenantId": tenantId])
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            tenantId: tenantId,
-            id      : 'A1',
-            tags    : [a2: '2', b2: '2']
-        ],
-        response.data
-    )
+    assertEquals([a2: '2', b2: '2'], response.data)
 
     response = hawkularMetrics.get(path: "availability/A2/tags", headers: ["tenantId": tenantId])
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            tenantId     : tenantId,
-            id           : 'A2',
-            tags         : [a22: '22', b22: '22'],
-            dataRetention: 48
-        ],
-        response.data
-    )
+    assertEquals([a22: '22', b22: '22'], response.data)
 
     // Verify the response for a non-existent metric
     response = hawkularMetrics.get(path: "gauges/A-doesNotExist/tags", headers: ["tenantId": tenantId])
@@ -178,27 +150,13 @@ class TagsITest extends RESTTest {
     // Fetch the updated tags
     response = hawkularMetrics.get(path: "gauges/N1/tags", headers: ["tenantId": tenantId])
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            tenantId: tenantId,
-            id      : 'N1',
-            tags    : ['  a  1   ': '   A', a1: 'one', a2: '2', b1: 'B', 'bsq   d1': 'B   ']
-        ],
-        response.data
-    )
+    assertEquals(['  a  1   ': '   A', a1: 'one', a2: '2', b1: 'B', 'bsq   d1': 'B   '], response.data)
 
     // Delete a gauge metric tag
     response = hawkularMetrics.delete(path: "gauges/N1/tags/a2:2,b1:B", headers: ["tenantId": tenantId])
     assertEquals(200, response.status)
     response = hawkularMetrics.get(path: "gauges/N1/tags", headers: ["tenantId": tenantId])
-    assertEquals(
-        [
-            tenantId: tenantId,
-            id      : 'N1',
-            tags    : ['  a  1   ': '   A', a1: 'one', 'bsq   d1': 'B   ']
-        ],
-        response.data
-    )
+    assertEquals(['  a  1   ': '   A', a1: 'one', 'bsq   d1': 'B   '], response.data)
 
     // Update the availability metric data
     response = hawkularMetrics.put(path: "availability/A1/tags", body: [a2: 'two', a3: 'THREE'], headers: ["tenantId": tenantId])
@@ -207,27 +165,13 @@ class TagsITest extends RESTTest {
     // Fetch the updated tags
     response = hawkularMetrics.get(path: "availability/A1/tags", headers: ["tenantId": tenantId])
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            tenantId: tenantId,
-            id      : 'A1',
-            tags    : [a2: 'two', a3: 'THREE', b2: '2']
-        ],
-        response.data
-    )
+    assertEquals([a2: 'two', a3: 'THREE', b2: '2'], response.data)
 
     // delete an availability metric tag
     response = hawkularMetrics.delete(path: "availability/A1/tags/a2:two,b2:2", headers: ["tenantId": tenantId])
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(path: "availability/A1/tags", headers: ["tenantId": tenantId])
-    assertEquals(
-        [
-            tenantId: tenantId,
-            id      : 'A1',
-            tags    : [a3: 'THREE']
-        ],
-        response.data
-    )
+    assertEquals([a3: 'THREE'], response.data)
   }
 }


### PR DESCRIPTION
This will change the REST-interface to be more consistent:

GET /{id}/tags will return the tags only, instead of metric definition
GET /{id} will return the metric definition
