### PR TITLE
Updates after Grafana integration testing

### DIFF
--- a/api/metrics-api-jaxrs/src/main/antlr4/org/hawkular/metrics/api/jaxrs/influx/query/parse/InfluxQuery.g4
+++ b/api/metrics-api-jaxrs/src/main/antlr4/org/hawkular/metrics/api/jaxrs/influx/query/parse/InfluxQuery.g4
@@ -54,6 +54,7 @@ booleanExpression: operand '=' operand #eqExpression
                  ;
 
 operand: prefix? name #nameOperand
+       | TIMESPAN #absoluteMomentOperand
        | ID '(' ')' DASH TIMESPAN #pastMomentOperand
        | ID '(' ')' PLUS TIMESPAN #futureMomentOperand
        | ID '(' ')' #presentMomentOperand

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxObject.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxObject.java
@@ -17,14 +17,17 @@
 package org.hawkular.metrics.api.jaxrs.influx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Transfer object which is returned by Influx queries
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InfluxObject {
     private final String name;
     private final List<String> columns;
@@ -35,7 +38,7 @@ public class InfluxObject {
         @JsonProperty("points") List<List<?>> points) {
         this.name = name;
         this.columns = columns;
-        this.points = points;
+        this.points = points == null ? Collections.emptyList() : points;
     }
 
     public String getName() {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/prettyprint/PrettyFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/prettyprint/PrettyFilter.java
@@ -16,8 +16,6 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.prettyprint;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
-
 import java.io.IOException;
 
 import javax.ws.rs.container.ContainerRequestContext;
@@ -39,8 +37,7 @@ public class PrettyFilter implements ContainerRequestFilter {
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         UriInfo uriInfo = requestContext.getUriInfo();
-        if (!APPLICATION_JSON_TYPE.equals(requestContext.getMediaType())
-            || !uriInfo.getPath().startsWith("/db")) {
+        if (!uriInfo.getPath().startsWith("/db")) {
             return;
         }
         requestContext.setProperty(PRETTY_PRINT, Boolean.valueOf(uriInfo.getQueryParameters().getFirst("pretty")));

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/prettyprint/PrettyInterceptor.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/prettyprint/PrettyInterceptor.java
@@ -18,6 +18,8 @@ package org.hawkular.metrics.api.jaxrs.influx.prettyprint;
 
 import static java.lang.Boolean.TRUE;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
 import static org.hawkular.metrics.api.jaxrs.influx.prettyprint.PrettyFilter.PRETTY_PRINT;
 
 import java.io.ByteArrayOutputStream;
@@ -52,7 +54,7 @@ public class PrettyInterceptor implements WriterInterceptor {
 
     @Override
     public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
-        if (context.getProperty(PRETTY_PRINT) != TRUE) {
+        if (context.getProperty(PRETTY_PRINT) != TRUE || !APPLICATION_JSON_TYPE.equals(context.getMediaType())) {
             context.proceed();
             return;
         }

--- a/api/metrics-api-jaxrs/src/test/resources/influx/query/supported-select-queries.iql
+++ b/api/metrics-api-jaxrs/src/test/resources/influx/query/supported-select-queries.iql
@@ -29,3 +29,4 @@ select mean(a.value) from c as a where time < now() - 50w
 select a.value as b from c as a where time < '2011-07-28' and time > now() + 50w
 select a.value as b from c as a where '2011-07-28' < a.time and now() + 50w > a.time
 select a.value as b from c as a where '2011-07-28' > a.time and now() + 50w < a.time
+select * from test where time > 1501560s and time < 4560546h

--- a/api/metrics-api-jaxrs/src/test/resources/influx/query/syntactically-correct-queries.iql
+++ b/api/metrics-api-jaxrs/src/test/resources/influx/query/syntactically-correct-queries.iql
@@ -41,5 +41,6 @@ select percentile("d", .95) from a
 SeleCt dup.time as now, _agjsqdha(clui) as p from z as bi group by time(15s)
 SeleCt dup.time as now, _agjsqdha(clui) as p from z as bi group by time(15s) where time > now() -15s
 SeleCt dup.time as now, _agjsqdha(clui, -5, -33.1) as p from z as bi group by time(15s) where time > now() -15s and a=-.33
+select * from test where time > 1501560s and time < 4560546h
 SeleCt dup.a fROm "z" as bi order desc
 SeleCt dup.b fROm "z" as bi order asc

--- a/clients/ptranslator/log4j-dev.xml
+++ b/clients/ptranslator/log4j-dev.xml
@@ -38,7 +38,7 @@
   </appender>
 
   <root>
-    <level value="TRACE"/>
+    <level value="DEBUG"/>
     <appender-ref ref="CONSOLE"/>
     <appender-ref ref="FILE"/>
   </root>

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
@@ -16,24 +16,48 @@
  */
 package org.hawkular.metrics.rest
 
-import org.joda.time.DateTime
-import org.junit.Test
-
 import static org.joda.time.DateTime.now
 import static org.junit.Assert.assertEquals
+
+import org.joda.time.DateTime
+import org.junit.Test
 
 /**
  * @author Thomas Segismont
  */
 class InfluxITest extends RESTTest {
 
-  static def tenantId = "influxtest"
+  @Test
+  void testListSeries() {
+    def tenantId = nextTenantId()
+
+    postData(tenantId, "serie1", now())
+    postData(tenantId, "serie2", now())
+
+    def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: "list series"])
+    assertEquals(200, response.status)
+
+    assertEquals(
+        [
+            [
+                name   : "list_series_result",
+                columns: ["time", "name"],
+                points : [
+                    [0, "serie1"],
+                    [0, "serie2"],
+                ]
+            ]
+        ],
+        response.data
+    )
+  }
 
   @Test
   void testInfluxDataOrderedAsc() {
+    def tenantId = nextTenantId()
     def timeseriesName = "influx.dataasc"
     def start = now().minus(4000)
-    postData(timeseriesName, start)
+    postData(tenantId, timeseriesName, start)
 
     def influxQuery = 'select value from "' + timeseriesName + '" order asc'
 
@@ -60,9 +84,10 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxDataOrderedDescByDefault() {
+    def tenantId = nextTenantId()
     def timeseriesName = "influx.datadesc"
     def start = now().minus(4000)
-    postData(timeseriesName, start)
+    postData(tenantId, timeseriesName, start)
 
     def influxQuery = 'select value from "' + timeseriesName + '"'
 
@@ -89,9 +114,10 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxAddGetOneMetric() {
+    def tenantId = nextTenantId()
     def timeseriesName = "influx.foo"
     def start = now().minus(4000)
-    postData(timeseriesName, start)
+    postData(tenantId, timeseriesName, start)
 
     def influxQuery = 'select mean(value) from "' + timeseriesName + '" where time > now() - 30s group by time(30s) '
 
@@ -114,9 +140,10 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxLimitClause() {
+    def tenantId = nextTenantId()
     def timeseriesName = "influx.limitclause"
     def start = now().minus(4000)
-    postData(timeseriesName, start)
+    postData(tenantId, timeseriesName, start)
 
     def influxQuery = 'select value from "' + timeseriesName + '" limit 2 order asc '
 
@@ -140,9 +167,10 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxAddGetOneSillyMetric() {
+    def tenantId = nextTenantId()
     def timeseriesName = "influx.foo3"
     def start = now().minus(4000)
-    postData(timeseriesName, start)
+    postData(tenantId, timeseriesName, start)
 
     def influxQuery = 'select mean(value) from "' + timeseriesName + '''" where time > '2013-08-12 23:32:01.232'
                         and time < '2013-08-13' group by time(30s) '''
@@ -155,7 +183,8 @@ class InfluxITest extends RESTTest {
         [
             [
                 columns: ["time", "mean"],
-                name: timeseriesName
+                name: timeseriesName,
+                points: []
             ]
         ],
         response.data
@@ -164,9 +193,10 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxTop() {
+    def tenantId = nextTenantId()
     def timeseriesName = "influx.top"
     def start = now().minus(4000)
-    postData(timeseriesName, start)
+    postData(tenantId, timeseriesName, start)
 
     def influxQuery = 'select top(value, 3) from "' + timeseriesName + '" where time > now() - 30s group by time(30s)'
 
@@ -190,9 +220,10 @@ class InfluxITest extends RESTTest {
   }
  @Test
   void testInfluxBottom() {
+   def tenantId = nextTenantId()
     def timeseriesName = "influx.bottom"
     def start = now().minus(4000)
-    postData(timeseriesName, start)
+   postData(tenantId, timeseriesName, start)
 
     def influxQuery = 'select bottom(value, 3) from "' + timeseriesName + '" where time > now() - 30s group by time(30s)'
 
@@ -217,9 +248,10 @@ class InfluxITest extends RESTTest {
 
  @Test
   void testInfluxStddev() {
+   def tenantId = nextTenantId()
     def timeseriesName = "influx.stddev"
     def start = now().minus(4000)
-    postData(timeseriesName, start)
+   postData(tenantId, timeseriesName, start)
 
     def influxQuery = 'select stddev(value) from "' + timeseriesName + '" where time > now() - 30s group by time(30s)'
 
@@ -240,7 +272,7 @@ class InfluxITest extends RESTTest {
     )
   }
 
-  private static void postData(String timeseriesName, DateTime start) {
+  private static void postData(String tenantId, String timeseriesName, DateTime start) {
     def response = hawkularMetrics.post(path: "db/${tenantId}/series", body: [
         [
             name: timeseriesName,

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/InfluxDBTest.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/InfluxDBTest.java
@@ -17,6 +17,7 @@
 package org.hawkular.metrics.test;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
@@ -25,14 +26,18 @@ import org.junit.BeforeClass;
  * @author Jeeva Kandasamy
  */
 public class InfluxDBTest {
+    private static final String TENANT_PREFIX = UUID.randomUUID().toString();
+    private static final AtomicInteger TENANT_ID_COUNTER = new AtomicInteger(0);
+
     static String baseURI = System.getProperty("hawkular-metrics.base-uri", "127.0.0.1:8080/hawkular/metrics");
-    static final String DB_PREFIX = UUID.randomUUID().toString();
-    static InfluxDB influxDB = null;
+    static InfluxDB influxDB;
 
     @BeforeClass
     public static void initClient() {
-        if(influxDB == null){
             influxDB = InfluxDBFactory.connect("http://"+baseURI+"/", "hawkular", "hawkular");
-        }
+    }
+
+    static String nextTenantId() {
+        return "T" + TENANT_PREFIX + TENANT_ID_COUNTER.incrementAndGet();
     }
 }

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/InfluxDatabaseITest.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/InfluxDatabaseITest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
  * @author Jeeva Kandasamy
  */
 public class InfluxDatabaseITest extends InfluxDBTest {
-    private static String dbName = DB_PREFIX + "influxdbjavaclienttest";
+    private String dbName = nextTenantId();
 
     /**
      * Test that writing of a simple Serie works.
@@ -48,7 +48,6 @@ public class InfluxDatabaseITest extends InfluxDBTest {
         long startTime = System.currentTimeMillis();
         Serie generatedSerie = getSerie(timeSeries, startTime);
         influxDB.write(dbName, TimeUnit.MILLISECONDS, generatedSerie);
-        startTime = startTime - 9000L;
         List<Serie> series = influxDB.query(dbName,
                 "select value from " + timeSeries + " order asc",
                 TimeUnit.MILLISECONDS);
@@ -224,7 +223,7 @@ public class InfluxDatabaseITest extends InfluxDBTest {
 
     private static Serie getSerie(String timeSeries, long startTime) {
         startTime = startTime - 9000L;//Minus N milliseconds from 'start time' based on number of rows going to write.
-        Serie serie = new Serie.Builder(timeSeries)
+        return new Serie.Builder(timeSeries)
                 .columns("time", "value")
                 .values(startTime, 10.9)
                 .values(startTime + 1000L, 11.9)
@@ -236,6 +235,5 @@ public class InfluxDatabaseITest extends InfluxDBTest {
                 .values(startTime + 7000L, 17.9)
                 .values(startTime + 8000L, 18.9)
                 .build();
-        return serie;
     }
 }


### PR DESCRIPTION
- Catch query parse exception so that a proper response can be built
- Use plain text error messages as Influx does
- Fixed list series output bug
- Fix pretty interceptor/filter: InfluxHandler may change the media type (for errors)
- Support absolute moment operands in queries (select * from test where time > 1501560s and time < 4560546h)
- Configure InfluxObject explicitly to include empty points collection in JSON output

Also:
- make sure Influx tests never fail because of data conflict (user distinct tenantId/dbName)
- change ptrans log level in development config file