### PR TITLE
Single definition fetching only works when tags are present

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -123,8 +123,10 @@ public class AvailabilityHandler {
             @HeaderParam("tenantId") String tenantId, @PathParam("id") String id) {
 
         metricsService.findMetric(tenantId, MetricType.AVAILABILITY, new MetricId(id))
+                .map(m -> Response.ok(m).build())
+                .defaultIfEmpty(Response.noContent().build())
                 .subscribe(
-                        optional -> asyncResponse.resume(ApiUtils.valueToResponse(optional)),
+                        v -> asyncResponse.resume(v),
                         t -> asyncResponse.resume(ApiUtils.serverError(t))
                 );
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -125,8 +125,10 @@ public class GaugeHandler {
     public void getGaugeMetric(@Suspended final AsyncResponse asyncResponse, @PathParam("id") String id) {
 
         metricsService.findMetric(tenantId, MetricType.GAUGE, new MetricId(id))
+                .map(m -> Response.ok(m).build())
+                .defaultIfEmpty(Response.noContent().build())
                 .subscribe(
-                        optional -> asyncResponse.resume(ApiUtils.valueToResponse(optional)),
+                        v -> asyncResponse.resume(v),
                         t -> asyncResponse.resume(ApiUtils.serverError(t))
                 );
     }

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -77,8 +77,8 @@ public interface MetricsService {
 
     Observable<Void> createMetric(Metric<?> metric);
 
-    Observable<Optional<? extends Metric<? extends MetricData>>> findMetric(String tenantId, MetricType type,
-            MetricId id);
+    Observable<? extends Metric<? extends MetricData>> findMetric(String tenantId, MetricType type,
+                                                                  MetricId id);
 
     Observable<Metric<?>> findMetrics(String tenantId, MetricType type);
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/cassandra/DataAccessImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/cassandra/DataAccessImpl.java
@@ -78,8 +78,6 @@ public class DataAccessImpl implements DataAccess {
 
     private PreparedStatement insertIntoMetricsIndex;
 
-    private PreparedStatement findMetric;
-
     private PreparedStatement getMetricTags;
 
     private PreparedStatement addMetricTagsToDataTable;
@@ -163,11 +161,6 @@ public class DataAccessImpl implements DataAccess {
         findAllTenantIds = session.prepare("SELECT DISTINCT id FROM tenants");
 
         findTenant = session.prepare("SELECT id, retentions, aggregation_templates FROM tenants WHERE id = ?");
-
-        findMetric = session.prepare(
-            "SELECT tenant_id, type, metric, interval, dpart, m_tags, data_retention " +
-            "FROM data " +
-            "WHERE tenant_id = ? AND type = ? AND metric = ? AND interval = ? AND dpart = ?");
 
         getMetricTags = session.prepare(
                 "SELECT m_tags " +

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/cassandra/DataAccessImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/cassandra/DataAccessImpl.java
@@ -132,6 +132,8 @@ public class DataAccessImpl implements DataAccess {
 
     private PreparedStatement deleteTagsFromMetricsIndex;
 
+    private PreparedStatement findMetricsIndex;
+
     private PreparedStatement readMetricsIndex;
 
     private PreparedStatement findAvailabilitiesWithWriteTime;
@@ -204,6 +206,11 @@ public class DataAccessImpl implements DataAccess {
             "UPDATE metrics_idx " +
             "SET tags = tags - ?" +
             "WHERE tenant_id = ? AND type = ? AND interval = ? AND metric = ?");
+
+        findMetricsIndex = session.prepare(
+                "SELECT metric, interval, tags, data_retention " +
+                        "FROM metrics_idx " +
+                        "WHERE tenant_id = ? AND type = ? AND interval = ? AND metric = ?");
 
         readMetricsIndex = session.prepare(
             "SELECT metric, interval, tags, data_retention " +
@@ -380,8 +387,8 @@ public class DataAccessImpl implements DataAccess {
 
     @Override
     public Observable<ResultSet> findMetric(String tenantId, MetricType type, MetricId id, long dpart) {
-        return rxSession.execute(findMetric.bind(tenantId, type.getCode(), id.getName(), id.getInterval().toString(),
-                dpart));
+        return rxSession.execute(findMetricsIndex.bind(tenantId, type.getCode(), id.getInterval().toString(),
+                                                       id.getName()));
     }
 
     @Override

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -517,4 +517,23 @@ class CassandraBackendITest extends RESTTest {
       assertGaugeDataPointEquals(expectedDataPoint, response.data.n4[i])
     }
   }
+
+  @Test
+  void createMetric() {
+    String tenantId = nextTenantId()
+
+    // Create a gauge metric
+    def response = hawkularMetrics.post(path: "gauges", body: [
+            id: 'Empty1'
+    ], headers: [(tenantHeaderName): tenantId])
+    assertEquals(201, response.status)
+
+    // Fetch the metric
+    response = hawkularMetrics.get(path: "gauges/N1", headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    assertEquals([
+            tenantId: tenantId,
+            id: 'Empty1'
+    ], response.data)
+  }
 }


### PR DESCRIPTION
### https://issues.jboss.org/browse/HWKMETRICS-110

Do not merge yet (tests are failing on my machine for all tests, so I can't verify this yet)

* Change findMetrics to return Observable<Metric instead of Optional (doesn't make much sense with RxJava to use Optional)
* Add some tests and try to fix the fetching single definition

Do not merge yet, @jsanda could you comment if the approach to reading from metrics_idx is the right way?