### PR TITLE
[HWKMETRICS-112] move classes up one level

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceProducer.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceProducer.java
@@ -33,8 +33,8 @@ import org.hawkular.metrics.api.jaxrs.config.Configurable;
 import org.hawkular.metrics.api.jaxrs.config.ConfigurationProperty;
 import org.hawkular.metrics.api.jaxrs.util.Eager;
 import org.hawkular.metrics.core.api.MetricsService;
-import org.hawkular.metrics.core.impl.cassandra.CassandraSession;
-import org.hawkular.metrics.core.impl.cassandra.MetricsServiceCassandra;
+import org.hawkular.metrics.core.impl.CassandraSession;
+import org.hawkular.metrics.core.impl.MetricsServiceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +69,7 @@ public class MetricsServiceProducer {
     @PostConstruct
     void init() {
         LOG.info("Initializing metrics service");
-        metricsService = new MetricsServiceCassandra();
+        metricsService = new MetricsServiceImpl();
         Map<String, String> options = new HashMap<>();
         options.put("cqlport", cqlPort);
         options.put("nodes", nodes);

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/AvailabilityBucketedOutputMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/AvailabilityBucketedOutputMapper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import static org.hawkular.metrics.core.api.AvailabilityType.DOWN;
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/BucketedOutputMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/BucketedOutputMapper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/CassandraSession.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/CassandraSession.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
@@ -44,7 +44,7 @@ import java.util.concurrent.Executors;
  */
 public class CassandraSession {
 
-    private static final Logger logger = LoggerFactory.getLogger(MetricsServiceCassandra.class);
+    private static final Logger logger = LoggerFactory.getLogger(MetricsServiceImpl.class);
 
     private static final String CASSANDRA_STORAGE_SERVICE = "org.apache.cassandra.db:type=StorageService";
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/CountersMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/CountersMapper.java
@@ -14,34 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
 import com.google.common.base.Function;
 
-import org.hawkular.metrics.core.api.MetricData;
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
+import org.hawkular.metrics.core.api.Counter;
 
 /**
  * @author John Sanda
  */
-public class ComputeTTL<T extends MetricData> implements Function<List<T>, List<T>> {
-
-    private int originalTTL;
-
-    public ComputeTTL(int originalTTL) {
-        this.originalTTL = originalTTL;
-    }
+public class CountersMapper implements Function<ResultSet, List<Counter>> {
 
     @Override
-    public List<T> apply(List<T> data) {
-        for (T d : data) {
-            Duration duration = new Duration(DateTime.now().minus(d.getWriteTime()).getMillis());
-            d.setTTL(originalTTL - duration.toStandardSeconds().getSeconds());
+    public List<Counter> apply(ResultSet resultSet) {
+        List<Counter> counters = new ArrayList<>();
+        for (Row row : resultSet) {
+            counters.add(new Counter(row.getString(0), row.getString(1), row.getString(2), row.getLong(3)));
         }
-        return data;
+        return counters;
     }
-
 }

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import java.util.Collection;
 import java.util.List;

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccessImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccessImpl.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import static java.util.stream.Collectors.toMap;
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataRetentionsMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataRetentionsMapper.java
@@ -14,28 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.google.common.base.Function;
 
-import org.hawkular.metrics.core.api.Counter;
+import org.hawkular.metrics.core.api.Interval;
+import org.hawkular.metrics.core.api.MetricId;
+import org.hawkular.metrics.core.api.Retention;
 
 /**
  * @author John Sanda
  */
-public class CountersMapper implements Function<ResultSet, List<Counter>> {
+public class DataRetentionsMapper implements Function<ResultSet, Set<Retention>> {
 
     @Override
-    public List<Counter> apply(ResultSet resultSet) {
-        List<Counter> counters = new ArrayList<>();
+    public Set<Retention> apply(ResultSet resultSet) {
+        Set<Retention> dataRetentions = new HashSet<>();
         for (Row row : resultSet) {
-            counters.add(new Counter(row.getString(0), row.getString(1), row.getString(2), row.getLong(3)));
+            dataRetentions.add(new Retention(new MetricId(row.getString(3), Interval.parse(row.getString(2))),
+                row.getInt(4)));
         }
-        return counters;
+        return dataRetentions;
     }
 }

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/Functions.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/Functions.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import static java.util.stream.Collectors.toList;
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GaugeAndTTL.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GaugeAndTTL.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import org.hawkular.metrics.core.api.Gauge;
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GaugeBucketedOutputMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GaugeBucketedOutputMapper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import java.util.List;
 import java.util.ListIterator;
@@ -29,7 +29,7 @@ import org.hawkular.metrics.core.api.GaugeBucketDataPoint;
 import org.hawkular.metrics.core.api.GaugeData;
 
 /**
- * A {@link org.hawkular.metrics.core.impl.cassandra.BucketedOutputMapper} for {@link org.hawkular.metrics.core.api
+ * A {@link BucketedOutputMapper} for {@link org.hawkular.metrics.core.api
  * .Gauge}.
  *
  * @author Thomas Segismont

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GaugeDataMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GaugeDataMapper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import static java.util.stream.Collectors.toList;
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsIndexMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsIndexMapper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import static org.joda.time.Hours.hours;
 
@@ -79,8 +79,8 @@ import rx.subjects.PublishSubject;
 /**
  * @author John Sanda
  */
-public class MetricsServiceCassandra implements MetricsService {
-    private static final Logger logger = LoggerFactory.getLogger(MetricsServiceCassandra.class);
+public class MetricsServiceImpl implements MetricsService {
+    private static final Logger logger = LoggerFactory.getLogger(MetricsServiceImpl.class);
 
     public static final String REQUEST_LIMIT = "hawkular.metrics.request.limit";
 
@@ -146,7 +146,7 @@ public class MetricsServiceCassandra implements MetricsService {
      */
     private final Map<DataRetentionKey, Integer> dataRetentions = new ConcurrentHashMap<>();
 
-    public MetricsServiceCassandra() {
+    public MetricsServiceImpl() {
         this.state = State.STARTING;
     }
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/Order.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/Order.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 /**
  * @author John Sanda

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/Table.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/Table.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 /**
  * @author John Sanda

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/TaggedAvailabilityMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/TaggedAvailabilityMapper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/TaggedGaugeDataMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/TaggedGaugeDataMapper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/VoidSubscriber.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/VoidSubscriber.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import rx.Subscriber;
 

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/AvailabilityBucketDataPointMatcher.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/AvailabilityBucketDataPointMatcher.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import org.hamcrest.Description;
 import org.hamcrest.Factory;

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/AvailabilityBucketedOutputMapperTest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/AvailabilityBucketedOutputMapperTest.java
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import static org.hawkular.metrics.core.api.AvailabilityType.DOWN;
 import static org.hawkular.metrics.core.api.AvailabilityType.UP;
-import static org.hawkular.metrics.core.impl.cassandra.AvailabilityBucketDataPointMatcher
+import static org.hawkular.metrics.core.impl.AvailabilityBucketDataPointMatcher
         .matchesAvailabilityBucketDataPoint;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DataAccessITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DataAccessITest.java
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import static java.util.Arrays.asList;
-import static org.hawkular.metrics.core.impl.cassandra.MetricsServiceCassandra.DEFAULT_TTL;
+import static org.hawkular.metrics.core.impl.MetricsServiceImpl.DEFAULT_TTL;
 import static org.joda.time.DateTime.now;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import java.util.Collection;
 import java.util.List;
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
-
 import org.hawkular.metrics.core.api.Availability;
 import org.hawkular.metrics.core.api.AvailabilityData;
 import org.hawkular.metrics.core.api.Counter;
@@ -36,7 +35,6 @@ import org.hawkular.metrics.core.api.MetricId;
 import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.Retention;
 import org.hawkular.metrics.core.api.Tenant;
-
 import rx.Observable;
 
 /**

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsITest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import static org.joda.time.DateTime.now;
 

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsServiceITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsServiceITest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.impl.cassandra;
+package org.hawkular.metrics.core.impl;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -25,7 +25,7 @@ import static org.hawkular.metrics.core.api.AvailabilityType.UP;
 import static org.hawkular.metrics.core.api.Metric.DPART;
 import static org.hawkular.metrics.core.api.MetricType.AVAILABILITY;
 import static org.hawkular.metrics.core.api.MetricType.GAUGE;
-import static org.hawkular.metrics.core.impl.cassandra.MetricsServiceCassandra.DEFAULT_TTL;
+import static org.hawkular.metrics.core.impl.MetricsServiceImpl.DEFAULT_TTL;
 import static org.joda.time.DateTime.now;
 import static org.joda.time.Days.days;
 import static org.joda.time.Hours.hours;
@@ -77,9 +77,9 @@ import rx.Observable;
 /**
  * @author John Sanda
  */
-public class MetricsServiceCassandraITest extends MetricsITest {
+public class MetricsServiceITest extends MetricsITest {
 
-    private MetricsServiceCassandra metricsService;
+    private MetricsServiceImpl metricsService;
 
     private DataAccess dataAccess;
 
@@ -90,7 +90,7 @@ public class MetricsServiceCassandraITest extends MetricsITest {
     @BeforeClass
     public void initClass() {
         initSession();
-        metricsService = new MetricsServiceCassandra();
+        metricsService = new MetricsServiceImpl();
         metricsService.startUp(session);
         dataAccess = metricsService.getDataAccess();
 


### PR DESCRIPTION
There is no need for a cassandra-specific package any more since we now only
support one backend.