### PR TITLE
HWKMETRICS-117

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -147,6 +147,18 @@
             <resource>
               <filtering>false</filtering>
               <directory>${basedir}/src/main/webapp</directory>
+              <excludes>
+                <exclude>WEB-INF/web.xml</exclude>
+                <exclude>static/index.html</exclude>
+              </excludes>
+            </resource>
+            <resource>
+              <filtering>true</filtering>
+              <directory>${basedir}/src/main/webapp</directory>
+              <includes>
+                <include>WEB-INF/web.xml</include>
+                <include>static/index.html</include>
+              </includes>
             </resource>
           </webResources>
         </configuration>

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/TenantFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/TenantFilter.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Provider;
 
 import org.hawkular.metrics.api.jaxrs.ApiError;
+import org.hawkular.metrics.api.jaxrs.handler.BaseHandler;
 import org.hawkular.metrics.api.jaxrs.handler.StatusHandler;
 
 /**
@@ -50,7 +51,8 @@ public class TenantFilter implements ContainerRequestFilter {
         UriInfo uriInfo = requestContext.getUriInfo();
         String path = uriInfo.getPath();
 
-        if (path.startsWith("/tenants") || path.startsWith("/db") || path.startsWith(StatusHandler.PATH)) {
+        if (path.startsWith("/tenants") || path.startsWith("/db") || path.startsWith(StatusHandler.PATH)
+            || path.equals(BaseHandler.PATH)) {
             // Tenants, Influx and status handlers do not check the tenant header
             return;
         }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/BaseHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/BaseHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.handler;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import com.wordnik.swagger.annotations.ApiOperation;
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author mwringe
+ */
+@Path("/")
+public class BaseHandler {
+
+    public static final String PATH = "/";
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = "Returns some basic information about the Hawkular Metrics service.",
+                  response = String.class, responseContainer = "Map")
+    public Response baseJSON(@Context ServletContext context) {
+
+        String version = context.getInitParameter("hawkular.metrics.version");
+        if (version == null) {
+            version = "undefined";
+        }
+
+        HawkularMetricsBase hawkularMetrics = new HawkularMetricsBase();
+        hawkularMetrics.version = version;
+
+        return Response.ok(hawkularMetrics).build();
+    }
+
+    private class HawkularMetricsBase {
+
+        String name = "Hawkular-Metrics";
+        String version;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/webapp/WEB-INF/web.xml
+++ b/api/metrics-api-jaxrs/src/main/webapp/WEB-INF/web.xml
@@ -25,6 +25,11 @@
   <display-name>Hawkular Metrics Rest interface</display-name>
 
   <context-param>
+    <param-name>hawkular.metrics.version</param-name>
+    <param-value>${project.version}</param-value>
+  </context-param>
+
+  <context-param>
     <param-name>resteasy.media.type.mappings</param-name>
     <param-value>html : text/html, json : application/json, xml : application/xml, csv : text/csv, txt: text/plain,
       yaml: application/yaml, jsonw: application/vnd.hawkular.wrapped+json

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -92,6 +92,7 @@
           <systemPropertyVariables>
             <keyspace>${cassandra.keyspace}</keyspace>
             <hawkular-metrics.base-uri>${base-uri}</hawkular-metrics.base-uri>
+            <project.version>${project.version}</project.version>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -27,6 +27,8 @@ import com.google.common.base.Charsets
 import groovyx.net.http.ContentType
 import groovyx.net.http.RESTClient
 
+import static org.junit.Assert.fail
+
 class RESTTest {
 
   static baseURI = System.getProperty('hawkular-metrics.base-uri') ?: '127.0.0.1:8080/hawkular/metrics'
@@ -49,6 +51,24 @@ class RESTTest {
         println new String(baos.toByteArray(), Charsets.UTF_8)
       }
       defaultFailureHandler(resp)
+    }
+      waitAvailable();
+  }
+
+  static void waitAvailable() {
+    def available = false;
+    def startTime = System.currentTimeMillis();
+    while (available != true || (System.currentTimeMillis() - startTime) > 5000) {
+      def response = hawkularMetrics.get(path: "")
+      if (response.status != 200) {
+        wait(500);
+      } else {
+        available = true;
+      }
+    }
+
+    if (available == false) {
+      fail("Could not connect to the server");
     }
   }
 

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/RootITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/RootITest.groovy
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.rest
+
+import org.junit.Test
+import static org.junit.Assert.assertEquals
+
+/**
+ * @author mwringe
+ */
+class RootITest extends RESTTest {
+    @Test
+    void getStatusTest() {
+        def response = hawkularMetrics.get(path: "");
+
+        def version = System.properties.getProperty("project.version");
+
+        assertEquals(200, response.status);
+
+        def expectedData = ["name" : "Hawkular-Metrics", "version": version];
+
+        assertEquals(expectedData, response.data);
+    }
+}


### PR DESCRIPTION
Add some simple data to the base endpoint instead of throwing an error.
Fix an issue where the REST tests could fail based on a race condition.