### PR TITLE
Remove default tenant id

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -19,7 +19,6 @@ package org.hawkular.metrics.api.jaxrs.handler;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import static org.hawkular.metrics.api.jaxrs.filter.TenantFilter.TENANT_HEADER_NAME;
-import static org.hawkular.metrics.core.api.MetricsService.DEFAULT_TENANT_ID;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -98,8 +97,7 @@ public class CounterHandler {
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("group") String group, @PathParam("counter") String counter
     ) {
-        ListenableFuture<Void> future = metricsService
-                .updateCounter(new Counter(DEFAULT_TENANT_ID, group, counter, 1L));
+        ListenableFuture<Void> future = metricsService.updateCounter(new Counter(tenantId, group, counter, 1L));
         Futures.addCallback(future, new NoDataCallback<>(asyncResponse));
     }
 
@@ -110,8 +108,7 @@ public class CounterHandler {
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("group") String group, @PathParam("counter") String counter, @PathParam("value") Long value
     ) {
-        ListenableFuture<Void> future = metricsService.updateCounter(new Counter(DEFAULT_TENANT_ID, group, counter,
-                value));
+        ListenableFuture<Void> future = metricsService.updateCounter(new Counter(tenantId, group, counter, value));
         Futures.addCallback(future, new NoDataCallback<>(asyncResponse));
     }
 

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -34,14 +34,9 @@ import rx.Observable;
  */
 public interface MetricsService {
 
-    public enum State {
+    enum State {
         STARTING, STARTED, STOPPING, STOPPED, FAILED
     }
-
-
-    // For now we will use a default or fake tenant id until we get APIs in place for
-    // creating tenants.
-    String DEFAULT_TENANT_ID = "test";
 
     /**
      * Startup with a given cassandra session


### PR DESCRIPTION
Remove default tenant id

It's no longer needed, we reject any request without tenant header (where applicable).