### PR TITLE
The REST api of metrics has still base path '{host}/hawkular-metrics/…

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -217,7 +217,7 @@
                 <apiSource>
                   <locations>org.hawkular.metrics.api.jaxrs</locations>
                   <apiVersion>1.0</apiVersion>
-                  <basePath>http://localhost:8080/hawkular/metrics/</basePath>
+                  <basePath>http://localhost:8080/hawkular-metrics/</basePath>
                   <outputTemplate>${project.build.directory}/dependency/hawkular-documentation/asciidoc.mustache</outputTemplate>
                   <swaggerDirectory>${project.build.directory}/generated/swagger-ui</swaggerDirectory>
                   <swaggerInternalFilter>org.hawkular.metrics.api.jaxrs.swagger.filter.JaxRsFilter</swaggerInternalFilter>


### PR DESCRIPTION
…'. It'd be better to change that to align with other components where the convention is '{host}/hawkular/{componentName}/' However, for now I am changing the path for the generated docs to reflect the reality.