### PR TITLE
HWKMETRICS-122 Grafana can't display metrics list popup

### DIFF
--- a/api/metrics-api-jaxrs/src/main/antlr4/org/hawkular/metrics/api/jaxrs/influx/query/parse/InfluxQuery.g4
+++ b/api/metrics-api-jaxrs/src/main/antlr4/org/hawkular/metrics/api/jaxrs/influx/query/parse/InfluxQuery.g4
@@ -20,7 +20,7 @@ query: listSeries EOF
      | selectQuery EOF
      ;
 
-listSeries: LIST SERIES;
+listSeries: LIST SERIES REGEXP?;
 
 selectQuery: SELECT selectColumns fromClause (groupByClause? whereClause | whereClause? groupByClause)? limitClause?
            orderClause?
@@ -114,6 +114,8 @@ fragment SINGLE_QUOTED_STRING_ESC: '\\\'' | '\\\\';
 
 DOUBLE_QUOTED_STRING: '"' (DOUBLE_QUOTED_STRING_ESC|.)*? '"';
 fragment DOUBLE_QUOTED_STRING_ESC: '\\"' | '\\\\';
+
+REGEXP: '/' .+? '/' ('i'|'I')?;
 
 INT: DIGIT+;
 FLOAT: DIGIT+ '.' DIGIT*

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/ListSeriesDefinitionsParser.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/ListSeriesDefinitionsParser.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
+
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryBaseListener;
+import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser;
+
+/**
+ * @author Thomas Segismont
+ */
+public class ListSeriesDefinitionsParser extends InfluxQueryBaseListener {
+    private RegularExpression regularExpression;
+
+    @Override
+    public void exitListSeries(InfluxQueryParser.ListSeriesContext ctx) {
+        TerminalNode regexp = ctx.REGEXP();
+        if (regexp == null) {
+            return;
+        }
+        String text = regexp.getText();
+        boolean caseSensitive = text.charAt(text.length() - 1) == '/';
+        String expression = text.substring(1, text.length() - (caseSensitive ? 1 : 2));
+        regularExpression = new RegularExpression(expression, caseSensitive);
+    }
+
+    public RegularExpression getRegularExpression() {
+        return regularExpression;
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/RegularExpression.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/RegularExpression.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
+
+/**
+ * @author Thomas Segismont
+ */
+public class RegularExpression {
+    private final String expression;
+    private final boolean caseSensitive;
+
+    public RegularExpression(String expression, boolean caseSensitive) {
+        this.expression = expression;
+        this.caseSensitive = caseSensitive;
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+
+    public boolean isCaseSensitive() {
+        return caseSensitive;
+    }
+}

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/ListSeriesRegexpTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/ListSeriesRegexpTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser;
+import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParserFactory;
+import org.junit.Test;
+
+/**
+ * @author Thomas Segismont
+ */
+public class ListSeriesRegexpTest {
+    private static final String REGEXP = "^sqd lk .\\sqkl'' *$";
+
+    private final ListSeriesDefinitionsParser definitionsParser = new ListSeriesDefinitionsParser();
+    private final ParseTreeWalker parseTreeWalker = ParseTreeWalker.DEFAULT;
+    private final InfluxQueryParserFactory parserFactory = new InfluxQueryParserFactory();
+
+    @Test
+    public void shouldDetectQueryWithoutRegularExpression() {
+        InfluxQueryParser parser = parserFactory.newInstanceForQuery("list series");
+        parseTreeWalker.walk(definitionsParser, parser.listSeries());
+        RegularExpression regularExpression = definitionsParser.getRegularExpression();
+
+        assertNull(regularExpression);
+    }
+
+    @Test
+    public void shouldDetectQueryWithRegularExpression() {
+        InfluxQueryParser parser = parserFactory.newInstanceForQuery("list series /" + REGEXP + "/");
+        parseTreeWalker.walk(definitionsParser, parser.listSeries());
+        RegularExpression regularExpression = definitionsParser.getRegularExpression();
+
+        assertNotNull(regularExpression);
+        assertTrue(regularExpression.isCaseSensitive());
+        assertEquals(REGEXP, regularExpression.getExpression());
+    }
+
+    @Test
+    public void shouldDetectQueryWithCaseInsensitiveRegularExpression() {
+        InfluxQueryParser parser = parserFactory.newInstanceForQuery("list series /" + REGEXP + "/I");
+        parseTreeWalker.walk(definitionsParser, parser.listSeries());
+        RegularExpression regularExpression = definitionsParser.getRegularExpression();
+
+        assertNotNull(regularExpression);
+        assertFalse(regularExpression.isCaseSensitive());
+        assertEquals(REGEXP, regularExpression.getExpression());
+    }
+}

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/type/QueryTypeVisitorTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/type/QueryTypeVisitorTest.java
@@ -33,7 +33,7 @@ public class QueryTypeVisitorTest {
 
     @Test
     public void shouldDetectListSeriesQuery() {
-        ParseTree parseTree = parserFactory.newInstanceForQuery("list series").query();
+        ParseTree parseTree = parserFactory.newInstanceForQuery("list series /a.dsfqsd/I").query();
         QueryType queryType = queryTypeVisitor.visit(parseTree);
         assertEquals(LIST_SERIES, queryType);
     }

--- a/api/metrics-api-jaxrs/src/test/resources/influx/query/syntactically-correct-queries.iql
+++ b/api/metrics-api-jaxrs/src/test/resources/influx/query/syntactically-correct-queries.iql
@@ -20,6 +20,8 @@
 -- Empty lines and lines starting with double dash are ignored
 --
 lIst    seRIes
+lIst    seRIes /kjd sqkljdlkqs j_è_çè-- ^$§/
+lIst    seRIes /kjd sqkljdlkqs j_è_çè-- ^$§/I
 select * frOm _sqlkd_j0504
 select * frOm " dmqsqsj kà\"qsdqsdq"
 SeleCt a from "z"

--- a/api/metrics-api-jaxrs/src/test/resources/influx/query/syntactically-incorrect-queries.iql
+++ b/api/metrics-api-jaxrs/src/test/resources/influx/query/syntactically-incorrect-queries.iql
@@ -20,6 +20,10 @@
 -- Empty lines and lines starting with double dash are ignored
 --
 
+-- Invalid regexp flag 'a'
+lIst    seRIes /kjd sqkljdlkqs j_è_çè-- ^$§/a
+-- Invalid regexp (contains slash)
+lIst    seRIes /kjd sqkljdlkq/ j_è_çè-- ^$§/
 -- Missing from clause
 select 1
 -- Name staring with digit

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
@@ -53,6 +53,45 @@ class InfluxITest extends RESTTest {
   }
 
   @Test
+  void testListSeriesWithRegularExpression() {
+    def tenantId = nextTenantId()
+
+    postData(tenantId, "serie1", now())
+    postData(tenantId, "serie2", now())
+
+    def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: "list series /rIe\\d/i"])
+    assertEquals(200, response.status)
+
+    assertEquals(
+        [
+            [
+                name   : "list_series_result",
+                columns: ["time", "name"],
+                points : [
+                    [0, "serie1"],
+                    [0, "serie2"],
+                ]
+            ]
+        ],
+        response.data
+    )
+
+    response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: "list series /^rIe\\d/i"])
+    assertEquals(200, response.status)
+
+    assertEquals(
+        [
+            [
+                name   : "list_series_result",
+                columns: ["time", "name"],
+                points : []
+            ]
+        ],
+        response.data
+    )
+  }
+
+  @Test
   void testInfluxDataOrderedAsc() {
     def tenantId = nextTenantId()
     def timeseriesName = "influx.dataasc"


### PR DESCRIPTION
Influx Grammar did not support "list series" queries with regular expression arguments like:

```
list series /cpu\.user/I
```

Grafana executes such queries to build the list series popup based on what the user typed in the "serie name" field.