### PR TITLE
Add endpoint for retrieving rates

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -30,7 +30,8 @@ public enum ConfigurationKey {
     CASSANDRA_CQL_PORT("hawkular-metrics.cassandra-cql-port", "9042", "CASSANDRA_CQL_PORT", false),
     CASSANDRA_KEYSPACE("cassandra.keyspace", "hawkular_metrics", null, false),
     CASSANDRA_RESETDB("cassandra.resetdb", null, null, true),
-    WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true);
+    WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
+    TASK_SCHEDULER_TIME_UNITS("hawkular.scheduler.time-units", "minutes", "SCHEDULER_TIME_UNITS", false);
 
     private final String name;
     private final String env;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -206,7 +206,10 @@ public class CounterHandler {
 
     @GET
     @Path("/{id}/rate")
-    @ApiOperation(value = "Retrieve counter rate data points.", response = List.class)
+    @ApiOperation(
+            value = "Retrieve counter rate data points which are automatically generated on the server side.",
+            notes = "Rate data points are only generated for counters that are explicitly created.",
+            response = List.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched metric data."),
             @ApiResponse(code = 204, message = "No metric data was found."),

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -152,7 +152,7 @@ public interface MetricsService {
 
     /**
      * Fetches counter rate data points which are automatically generated for counter metrics. Note that rate data is
-     * generated if the metric has been explicitly created via the {@link #createMetric(Metric)} method.
+     * generated only if the metric has been explicitly created via the {@link #createMetric(Metric)} method.
      *
      * @param tenantId The teant to which the metric belongs
      * @param id This is the id of the counter metric

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccessImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccessImpl.java
@@ -480,7 +480,7 @@ public class DataAccessImpl implements DataAccess {
     @Override
     public Observable<ResultSet> findCounterData(String tenantId, MetricId id, long startTime, long endTime) {
         return rxSession.execute(findCounterDataExclusive.bind(tenantId, COUNTER.getCode(), id.getName(),
-                id.getInterval().toString(), DPART, UUIDs.startOf(startTime), UUIDs.endOf(endTime)));
+                id.getInterval().toString(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
     }
 
     @Override

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GenerateRate.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GenerateRate.java
@@ -46,9 +46,8 @@ public class GenerateRate implements Action1<Task> {
     public void call(Task task) {
         logger.info("Generating rate for {}", task);
         MetricId id = new MetricId(task.getSources().iterator().next());
-        long end = task.getTimeSlice().getMillis();
-        long start = task.getTimeSlice().minusSeconds(task.getWindow()).getMillis();
-        logger.debug("start = {}, end = {}", start, end);
+        long start = task.getTimeSlice().getMillis();
+        long end = task.getTimeSlice().plusSeconds(task.getWindow()).getMillis();
         metricsService.findCounterData(task.getTenantId(), id, start, end)
                 .take(1)
                 .map(dataPoint -> ((dataPoint.getValue().doubleValue() / (end - start) * 1000)))
@@ -58,7 +57,7 @@ public class GenerateRate implements Action1<Task> {
                 .subscribe(
                         aVoid -> {},
                         t -> logger.warn("Failed to persist rate data", t),
-                        () -> logger.debug("Successfully persisted rate data")
+                        () -> logger.debug("Successfully persisted rate data for {}", task)
                 );
     }
 }

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GenerateRate.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GenerateRate.java
@@ -18,12 +18,15 @@ package org.hawkular.metrics.core.impl;
 
 import static java.util.Collections.singletonList;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER_RATE;
+import static org.joda.time.Duration.standardMinutes;
+import static org.joda.time.Duration.standardSeconds;
 
 import org.hawkular.metrics.core.api.DataPoint;
 import org.hawkular.metrics.core.api.Metric;
 import org.hawkular.metrics.core.api.MetricId;
 import org.hawkular.metrics.core.api.MetricsService;
 import org.hawkular.metrics.tasks.api.Task;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -47,7 +50,7 @@ public class GenerateRate implements Action1<Task> {
         logger.info("Generating rate for {}", task);
         MetricId id = new MetricId(task.getSources().iterator().next());
         long start = task.getTimeSlice().getMillis();
-        long end = task.getTimeSlice().plusSeconds(task.getWindow()).getMillis();
+        long end = task.getTimeSlice().plus(getDuration(task.getWindow())).getMillis();
         metricsService.findCounterData(task.getTenantId(), id, start, end)
                 .take(1)
                 .map(dataPoint -> ((dataPoint.getValue().doubleValue() / (end - start) * 1000)))
@@ -55,9 +58,21 @@ public class GenerateRate implements Action1<Task> {
                         singletonList(new DataPoint<>(start, rate))))
                 .flatMap(metric -> metricsService.addGaugeData(Observable.just(metric)))
                 .subscribe(
-                        aVoid -> {},
+                        aVoid -> {
+                        },
                         t -> logger.warn("Failed to persist rate data", t),
                         () -> logger.debug("Successfully persisted rate data for {}", task)
                 );
+    }
+
+    private Duration getDuration(int duration) {
+        // This is somewhat of a temporary hack until HWKMETRICS-142 is done. The time units
+        // for tasks are currently scheduled globally with the TaskServiceBuilder class. The
+        // system property below is the only hook we have right now for specifying and
+        // checking the time units used.
+        if (System.getProperty("hawkular.scheduler.time-units", "minutes").equals("seconds")) {
+            return standardSeconds(duration);
+        }
+        return standardMinutes(duration);
     }
 }

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/FakeTaskService.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/FakeTaskService.java
@@ -23,6 +23,8 @@ import org.hawkular.metrics.tasks.api.TaskService;
 import org.hawkular.metrics.tasks.api.TaskType;
 import org.joda.time.DateTime;
 import rx.Observable;
+import rx.Subscription;
+import rx.functions.Action1;
 
 /**
  * @author jsanda
@@ -75,5 +77,10 @@ public class FakeTaskService implements TaskService {
                 return time;
             }
         });
+    }
+
+    @Override
+    public Subscription subscribe(TaskType taskType, Action1<? super Task> onNext) {
+        return null;
     }
 }

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsServiceITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsServiceITest.java
@@ -336,7 +336,6 @@ public class MetricsServiceITest extends MetricsITest {
                 start.getMillis(), end.getMillis());
         List<DataPoint<Long>> actual = toList(data);
         List<DataPoint<Long>> expected = asList(
-                new DataPoint<>(end.getMillis(), 45L),
                 new DataPoint<>(start.plusMinutes(4).getMillis(), 25L),
                 new DataPoint<>(start.plusMinutes(2).getMillis(), 15L),
                 new DataPoint<>(start.getMillis(), 10L)

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/RatesITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/RatesITest.java
@@ -66,7 +66,7 @@ public class RatesITest extends MetricsITest {
         metricsService = new MetricsServiceImpl();
         metricsService.setTaskService(taskService);
 
-        ((TaskServiceImpl) taskService).subscribe(TaskTypes.COMPUTE_RATE, new GenerateRate(metricsService));
+        taskService.subscribe(TaskTypes.COMPUTE_RATE, new GenerateRate(metricsService));
 
         String keyspace = "hawkulartest";
         System.setProperty("keyspace", keyspace);

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/RatesITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/RatesITest.java
@@ -54,6 +54,8 @@ public class RatesITest extends MetricsITest {
     public void initClass() {
         initSession();
 
+        System.setProperty("hawkular.scheduler.time-units", "seconds");
+
         dateTimeService = new DateTimeService();
 
         taskService = new TaskServiceBuilder()

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -33,6 +33,7 @@
 
   <properties>
     <cassandra.keyspace>hawkular_metrics_rest_tests</cassandra.keyspace>
+    <scheduler.units>seconds</scheduler.units>
   </properties>
 
   <dependencies>
@@ -232,6 +233,7 @@
                     <javaOpt>-Dcassandra.keyspace=${cassandra.keyspace}</javaOpt>
                     <javaOpt>-Dcassandra.resetdb</javaOpt>
                     <javaOpt>-Dhawkular.metrics.waitForService</javaOpt>
+                    <javaOpt>-Dhawkular.scheduler.time-units=${scheduler.units}</javaOpt>
                     <javaOpt>-Xdebug</javaOpt>
                     <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
                   </javaOpts>

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals
  */
 class CountersITest extends RESTTest {
 
-//  @Test
+  @Test
   void createSimpleCounter() {
     String tenantId = nextTenantId()
     String id = "C1"
@@ -46,7 +46,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
   }
 
-//  @Test
+  @Test
   void createCounterWithTagsAndDataRetention() {
     String tenantId = nextTenantId()
     String id = "C1"
@@ -74,7 +74,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
   }
 
-//  @Test
+  @Test
   void createAndFindCounters() {
     String tenantId = nextTenantId()
     String counter1 = "C1"
@@ -121,7 +121,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
   }
 
-//  @Test
+  @Test
   void addDataForMultipleCountersAndFindhWithDateRange() {
     String tenantId = nextTenantId()
     String counter1 = "C1"
@@ -160,7 +160,6 @@ class CountersITest extends RESTTest {
     assertEquals(200, response.status)
 
     def expectedData = [
-        [timestamp: start.plusMinutes(1).millis, value: 20],
         [timestamp: start.millis, value: 10]
     ]
     assertEquals(expectedData, response.data)
@@ -168,7 +167,7 @@ class CountersITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "counters/$counter2/data",
         headers: [(tenantHeaderName): tenantId],
-        query: [start: start.millis, end: start.plusMinutes(1).millis]
+        query: [start: start.millis, end: start.plusMinutes(2).millis]
     )
     assertEquals(200, response.status)
 
@@ -179,7 +178,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
   }
 
-//  @Test
+  @Test
   void addDataForSingleCounterAndFindWithDefaultDateRange() {
     String tenantId = nextTenantId()
     String counter = "C1"
@@ -210,7 +209,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
   }
 
-//  @Test
+  @Test
   void findWhenThereIsNoData() {
     String tenantId = nextTenantId()
     String counter1 = "C1"

--- a/task-queue/src/main/java/org/hawkular/metrics/tasks/api/TaskService.java
+++ b/task-queue/src/main/java/org/hawkular/metrics/tasks/api/TaskService.java
@@ -68,5 +68,13 @@ public interface TaskService {
      */
     Observable<Task> scheduleTask(DateTime time, Task task);
 
+    /**
+     * The scheduler does not execute tasks. Instead when a task is ready for execution the scheduler emits an event
+     * where the event is the task to be executed. The observer can then execute the task.
+     *
+     * @param taskType The type of task for which you want to observe tasks
+     * @param onNext The action that will be called when a a task is ready for execution
+     * @return The {@link Subscription Rx subscription}
+     */
     Subscription subscribe(TaskType taskType, Action1<? super Task> onNext);
 }

--- a/task-queue/src/main/java/org/hawkular/metrics/tasks/api/TaskService.java
+++ b/task-queue/src/main/java/org/hawkular/metrics/tasks/api/TaskService.java
@@ -18,6 +18,8 @@ package org.hawkular.metrics.tasks.api;
 
 import org.joda.time.DateTime;
 import rx.Observable;
+import rx.Subscription;
+import rx.functions.Action1;
 
 /**
  * The primary API for task scheduling and execution. See {@link TaskServiceBuilder} for details on creating and
@@ -65,4 +67,6 @@ public interface TaskService {
      * @return The task with its {@link Task#getTimeSlice() scheduled execution time} set
      */
     Observable<Task> scheduleTask(DateTime time, Task task);
+
+    Subscription subscribe(TaskType taskType, Action1<? super Task> onNext);
 }

--- a/task-queue/src/main/java/org/hawkular/metrics/tasks/impl/TaskServiceImpl.java
+++ b/task-queue/src/main/java/org/hawkular/metrics/tasks/impl/TaskServiceImpl.java
@@ -137,6 +137,7 @@ public class TaskServiceImpl implements TaskService {
      * </p>
      */
     public void setTimeUnit(TimeUnit timeUnit) {
+        logger.info("Using time unit of {}", timeUnit);
         switch (timeUnit) {
             case SECONDS:
                 this.timeUnit = TimeUnit.SECONDS;
@@ -190,6 +191,7 @@ public class TaskServiceImpl implements TaskService {
         return subject.subscribe(onNext, onError, onComplete);
     }
 
+    @Override
     public Subscription subscribe(TaskType taskType, Action1<? super Task> onNext) {
         PublishSubject<Task> subject = subjects.get(taskType);
         if (subject == null) {
@@ -316,6 +318,8 @@ public class TaskServiceImpl implements TaskService {
      * @param taskType
      */
     private void executeTasks(DateTime timeSlice, TaskType taskType) {
+        logger.info("Executing tasks for time slice {}", timeSlice);
+
         // I know, I know. We should not have to used CountDownLatch with RxJava. It is
         // left over from the original implementation and was/is used to ensure tasks of
         // one type finish executing before we start executing tasks of the next type.

--- a/task-queue/src/main/java/org/hawkular/metrics/tasks/impl/TaskServiceImpl.java
+++ b/task-queue/src/main/java/org/hawkular/metrics/tasks/impl/TaskServiceImpl.java
@@ -371,6 +371,7 @@ public class TaskServiceImpl implements TaskService {
         try {
             subject.onNext(task);
         } catch (Exception e) {
+            logger.warn("Execution of " + task + " failed", e);
             container.getFailedTimeSlices().add(task.getTimeSlice());
         }
         return container;


### PR DESCRIPTION
This PR also integrates the task scheduling service into the jaxrs WAR so that rates get calculated and updated for counter metrics. 