### PR TITLE
[HWKMETRICS-20] [HWKMETRICS-171] Ability to fetch all the metric definitions, tags and type as filters

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -88,8 +88,8 @@ public class MetricHandler {
                       allowableValues = "[gauge, availability, counter]")
             @QueryParam("type") MetricType metricType,
             @ApiParam(value = "List of tags", required = false) @QueryParam ("tags") Tags tags) {
-        if(metricType != null && !MetricType.userTypes().stream().filter(t -> metricType == t)
-                .findAny().isPresent()) {
+
+        if(metricType != null && !MetricType.userTypes().contains(metricType)) {
             asyncResponse.resume(badRequest(new ApiError("Incorrect type param")));
             return;
         }

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricType.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricType.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.Arrays;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 
 /**
  * An enumeration of the supported metric types.
@@ -87,6 +88,10 @@ public enum MetricType {
             throw new IllegalArgumentException(textCode + " is not a recognized metric type");
         }
         return type;
+    }
+
+    public static List<MetricType> userTypes() {
+        return Arrays.asList(Arrays.copyOf(MetricType.values(), 3));
     }
 
 }

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricType.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricType.java
@@ -18,10 +18,9 @@ package org.hawkular.metrics.core.api;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Arrays;
-
 import com.google.common.collect.ImmutableMap;
-import java.util.List;
+import java.util.Arrays;
+import java.util.EnumSet;
 
 /**
  * An enumeration of the supported metric types.
@@ -36,6 +35,8 @@ public enum MetricType {
 
     private int code;
     private String text;
+
+    private static EnumSet<MetricType> userDefinableTypes = EnumSet.range(GAUGE, COUNTER);
 
     MetricType(int code, String text) {
         this.code = code;
@@ -90,8 +91,7 @@ public enum MetricType {
         return type;
     }
 
-    public static List<MetricType> userTypes() {
-        return Arrays.asList(Arrays.copyOf(MetricType.values(), 3));
+    public static EnumSet<MetricType> userTypes() {
+        return userDefinableTypes;
     }
-
 }

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -84,6 +84,15 @@ public interface MetricsService {
 
     Observable<Metric> findMetrics(String tenantId, MetricType type);
 
+    /**
+     *
+     * @param tenantId
+     * @param tags
+     * @param type Optional MetricType, if null is given all matching metrics are returned
+     * @return
+     */
+    Observable<Metric> findMetricsWithTags(String tenantId, Map<String, String> tags, MetricType type);
+
     Observable<Optional<Map<String, String>>> getMetricTags(String tenantId, MetricType type, MetricId id);
 
     Observable<Void> addTags(Metric metric, Map<String, String> tags);

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -82,12 +82,21 @@ public interface MetricsService {
 
     Observable<Metric> findMetric(String tenantId, MetricType type, MetricId id);
 
+    /**
+     * Returns tenant's metric definitions. The results can be filtered using a type.
+     *
+     * @param tenantId
+     * @param type If type is null, all user definable metric definitions are returned.
+     * @return
+     */
     Observable<Metric> findMetrics(String tenantId, MetricType type);
 
     /**
+     * Returns tenant's metric definitions. The results can be filtered using a type and tags. Use findMetrics
+     * if you don't intend to use tags for filtering.
      *
      * @param tenantId
-     * @param tags
+     * @param tags Tag names and values that are used to filter definitions
      * @param type Optional MetricType, if null is given all matching metrics are returned
      * @return
      */

--- a/core/metrics-core-api/src/test/java/org/hawkular/metrics/core/api/MetricTypeTest.java
+++ b/core/metrics-core-api/src/test/java/org/hawkular/metrics/core/api/MetricTypeTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * @author miburman
+ */
+public class MetricTypeTest {
+
+    @Test
+    public void testUserValues() {
+        MetricType.userTypes().stream().filter(metricType -> metricType == MetricType.COUNTER_RATE).forEach
+                (metricType -> fail("COUNTER_RATE is not user defined type"));
+        assertEquals(3, MetricType.userTypes().size());
+    }
+}

--- a/core/metrics-core-api/src/test/java/org/hawkular/metrics/core/api/MetricTypeTest.java
+++ b/core/metrics-core-api/src/test/java/org/hawkular/metrics/core/api/MetricTypeTest.java
@@ -17,7 +17,7 @@
 package org.hawkular.metrics.core.api;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 
@@ -28,8 +28,7 @@ public class MetricTypeTest {
 
     @Test
     public void testUserValues() {
-        MetricType.userTypes().stream().filter(metricType -> metricType == MetricType.COUNTER_RATE).forEach
-                (metricType -> fail("COUNTER_RATE is not user defined type"));
+        assertFalse("COUNTER_RATE is not user defined type", MetricType.userTypes().contains(MetricType.COUNTER_RATE));
         assertEquals(3, MetricType.userTypes().size());
     }
 }

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
@@ -116,4 +116,6 @@ public interface DataAccess {
     Observable<ResultSet> deleteFromMetricsTagsIndex(Metric metric, Map<String, String> tags);
 
     Observable<ResultSet> findMetricsByTag(String tenantId, String tag);
+
+    Observable<ResultSet> findMetricsFromTagsIndex(String tenantId, Map<String, String> tags);
 }

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
@@ -43,18 +43,6 @@ import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.ResultSetFuture;
-import com.datastax.driver.core.Session;
-import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import org.hawkular.metrics.core.api.AvailabilityBucketDataPoint;
 import org.hawkular.metrics.core.api.AvailabilityType;
 import org.hawkular.metrics.core.api.BucketedOutput;
@@ -80,9 +68,25 @@ import org.joda.time.Duration;
 import org.joda.time.Hours;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+
 import rx.Observable;
 import rx.functions.Func1;
 import rx.subjects.PublishSubject;
+
+//import org.hawkular.metrics.core.api.Metric;
 
 /**
  * @author John Sanda
@@ -472,7 +476,8 @@ public class MetricsServiceImpl implements MetricsService {
     public Observable<Metric> findMetricsWithTags(String tenantId, Map<String, String> tags, MetricType type) {
         return dataAccess.findMetricsFromTagsIndex(tenantId, tags)
                 .flatMap(Observable::from)
-                .filter(r -> (type == null || MetricType.fromCode(r.getInt(0)) == type))
+                .filter(r -> ((type == null && MetricType.userTypes().contains(MetricType.fromCode(r.getInt(0))))
+                        || MetricType.fromCode(r.getInt(0)) == type))
                 .distinct(r -> Integer.valueOf(r.getInt(0)).toString() + r.getString(1) + r.getString(2))
                 .flatMap(r -> findMetric(tenantId, MetricType.fromCode(r.getInt(0)), new MetricId(r.getString
                         (1), Interval.parse(r.getString(2)))));

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
@@ -240,4 +240,9 @@ public class DelegatingDataAccess implements DataAccess {
     public Observable<ResultSet> findMetricsByTag(String tenantId, String tag) {
         return delegate.findMetricsByTag(tenantId, tag);
     }
+
+    @Override
+    public Observable<ResultSet> findMetricsFromTagsIndex(String tenantId, Map<String, String> tags) {
+        return delegate.findMetricsFromTagsIndex(tenantId, tags);
+    }
 }

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsServiceITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsServiceITest.java
@@ -192,6 +192,10 @@ public class MetricsServiceITest extends MetricsITest {
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(metrics.size(), 3, "The returned size does not match expected");
 
+        metrics = metricsService.findMetricsWithTags("t1", tagMap, AVAILABILITY).toList().toBlocking()
+                .lastOrDefault(null);
+        assertEquals(metrics.size(), 1, "The returned size does not match expected, only m2 is expected");
+
         Metric actualAvail = metricsService.findMetric(m2.getTenantId(), m2.getType(), m2.getId()).toBlocking()
                 .last();
         assertEquals(actualAvail, m2, "The metric does not match the expected value");

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -355,19 +355,19 @@ class CassandraBackendITest extends RESTTest {
   void findMetricsShouldFailProperlyWhenTypeIsMissingOrInvalid() {
     def tenantId = nextTenantId()
 
-    badGet(path: "metrics",
-        headers: [(tenantHeaderName): tenantId]) { exception ->
-      // Missing type
-      assertEquals(400, exception.response.status)
-      assertEquals("Missing type param", exception.response.data["errorMsg"])
-    }
-
     def invalidType = MetricType.values().join('"')
     badGet(path: "metrics", query: [type: invalidType],
         headers: [(tenantHeaderName): tenantId]) { exception ->
       // Invalid type
       assertEquals(400, exception.response.status)
       assertEquals(invalidType + " is not a recognized metric type", exception.response.data["errorMsg"])
+    }
+
+    badGet(path: "metrics", query: [type: MetricType.COUNTER_RATE.toString()],
+            headers: [(tenantHeaderName): tenantId]) { exception ->
+      // Not user definable type
+      assertEquals(400, exception.response.status)
+      assertEquals("Incorrect type param", exception.response.data["errorMsg"])
     }
 
     def response = hawkularMetrics.get(path: "metrics", query: [type: MetricType.GAUGE.text],

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -18,6 +18,7 @@ package org.hawkular.metrics.rest
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
 
 import org.junit.Test
 
@@ -209,19 +210,19 @@ class TagsITest extends RESTTest {
             query: [tags: "a22:22,b22:22,a1:A,d1:B"],
             headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
-    assertEquals([
-            [
-                    tenantId     : tenantId,
-                    id           : 'A2',
-                    tags         : [a22: '22', b22: '22'],
-                    dataRetention: 48
-            ],
-            [
-                    tenantId: tenantId,
-                    id      : 'N1',
-                    tags    : ['a1': 'A', 'd1': 'B']
-            ]
-    ], response.data)
+    assertTrue(response.data instanceof List)
+    assertEquals(response.data.size(), 2)
+    assertTrue(response.data.contains([
+            tenantId: tenantId,
+            id      : 'N1',
+            tags    : ['a1': 'A', 'd1': 'B']
+    ]))
+    assertTrue(response.data.contains([
+            tenantId     : tenantId,
+            id           : 'A2',
+            tags         : [a22: '22', b22: '22'],
+            dataRetention: 48
+    ]))
 
     // Fetch with tags & type
     response = hawkularMetrics.get(path: "metrics",
@@ -230,8 +231,8 @@ class TagsITest extends RESTTest {
     assertEquals(200, response.status)
     assertEquals([[
                           tenantId: tenantId,
-                          id  : 'N1',
-                          tags: ['a1': 'A', 'd1': 'B']
+                          id      : 'N1',
+                          tags    : ['a1': 'A', 'd1': 'B']
                   ]], response.data)
   }
 }


### PR DESCRIPTION
[HWKMETRICS-20] [HWKMETRICS-171] Allow / to fetch all the metric definitions, use tags and type as filters. Create new methods for fetching with tags.

Changes signature of fetching metric definition, missing type is no longer considered an error (and no code 400 is returned), instead all the metric definitions are returned for the tenant.