### PR TITLE
Always install latest C* 2.1.x

### DIFF
--- a/.travis.install.cassandra.sh
+++ b/.travis.install.cassandra.sh
@@ -18,23 +18,23 @@
 
 
 set -xe
-cVersion="2.1.1"
 
 cd "${HOME}"
 
-wget http://downloads.datastax.com/community/dsc-cassandra-${cVersion}-bin.tar.gz
-tar -xzf dsc-cassandra-${cVersion}-bin.tar.gz
-cHome="${HOME}/dsc-cassandra-${cVersion}"
+wget -O datastax-releases "http://downloads.datastax.com/community/?C=M;O=D"
+LATEST_MICRO=`cat datastax-releases | grep -m 1 -o -E "dsc-cassandra-2\.1\.[0-9]+-bin\.tar.gz" | head -1 | cut -d '.' -f3 | cut -d '-' -f1`
 
-mkdir "${cHome}/logs"
+CASSANDRA_VERSION="2.1.${LATEST_MICRO}"
+CASSANDRA_BINARY="dsc-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
 
-cat /proc/sys/kernel/core_pattern
+wget http://downloads.datastax.com/community/${CASSANDRA_BINARY}
+tar -xzf ${CASSANDRA_BINARY}
 
-ulimit -c unlimited -S
-ulimit -c
+CASSANDRA_HOME="${HOME}/dsc-cassandra-${CASSANDRA_VERSION}"
+
+mkdir "${CASSANDRA_HOME}/logs"
 
 export HEAP_NEWSIZE="100M"
 export MAX_HEAP_SIZE="1G"
 
-nohup sh ${cHome}/bin/cassandra -f -p ${HOME}/cassandra.pid > ${cHome}/logs/stdout.log 2>&1 &
-
+nohup sh ${CASSANDRA_HOME}/bin/cassandra -f -p ${HOME}/cassandra.pid > ${CASSANDRA_HOME}/logs/stdout.log 2>&1 &


### PR DESCRIPTION
The installer script now determines what is the latest released version of C*. Seems to work:
https://travis-ci.org/hawkular/hawkular-metrics/builds/70040930#L210-L251

```
+wget -O datastax-releases 'http://downloads.datastax.com/community/?C=M;O=D'
--2015-07-08 10:35:23--  http://downloads.datastax.com/community/?C=M;O=D
Resolving downloads.datastax.com (downloads.datastax.com)... 54.200.218.191, 52.24.161.158, 54.186.128.156, ...
Connecting to downloads.datastax.com (downloads.datastax.com)|54.200.218.191|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/html]
Saving to: `datastax-releases'
    [  <=>                                  ] 123,198      548K/s   in 0.2s    
2015-07-08 10:35:24 (548 KB/s) - `datastax-releases' saved [123198]
++cat datastax-releases
++grep -m 1 -o -E 'dsc-cassandra-2\.1\.[0-9]+-bin\.tar.gz'
++head -1
++cut -d . -f3
++cut -d - -f1
+LATEST_MICRO=7
```