### PR TITLE
HWKMETRICS-175 Put integration tests in profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 install:
 - mvn -version -B
 script:
-- mvn verify -Dwildfly.logging.console.level=DEBUG -B
+- mvn verify -Dintegration-tests -Dwildfly.logging.console.level=DEBUG -B
 after_failure: bash .travis.diagnose.sh
 after_success:
 - PROJECT_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 install:
 - mvn -version -B
 script:
-- mvn verify -Dintegration-tests -Dwildfly.logging.console.level=DEBUG -B
+- mvn verify -Dwildfly.logging.console.level=DEBUG -B
 after_failure: bash .travis.diagnose.sh
 after_success:
 - PROJECT_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -37,13 +37,7 @@
 
   <properties>
     <cassandra.keyspace>hawkular_metrics_ptrans_integration_tests</cassandra.keyspace>
-    <!-- IMPORTANT: The port must be the port offset + 8080. -->
-    <base-uri>127.0.0.1:55988/hawkular/metrics</base-uri>
-    <ptrans.wildfly.port.offset>47908</ptrans.wildfly.port.offset>
-    <!-- IMPORTANT: The management port must be the port offset + 9990. -->
-    <ptrans.wildfly.management.port>57898</ptrans.wildfly.management.port>
-    <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
-    <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
+    <scheduler.units>seconds</scheduler.units>
     <!-- Configuration files used when starting a development ptrans instance with mvn exec:java -->
     <dev.log4j.configuration>${project.basedir}/log4j-dev.xml</dev.log4j.configuration>
     <dev.ptrans.conf>${project.basedir}/ptrans.conf</dev.ptrans.conf>
@@ -121,41 +115,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-standalone-test</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <!--
-                We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
-                configuration files and override the default configuration directory. See
-                https://issues.jboss.org/browse/JBASMP-75 for details.
-              -->
-              <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
-              <overwrite>true</overwrite>
-              <useDefaultDelimiters>false</useDefaultDelimiters>
-              <delimiters>
-                <delimiter>@@@</delimiter>
-              </delimiters>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/src/test/wildfly-configuration</directory>
-                  <includes>
-                    <include>*</include>
-                  </includes>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludes>
@@ -185,81 +144,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <includes>
-            <include>**/*ITest*</include>
-          </includes>
-          <systemPropertyVariables>
-            <keyspace>${cassandra.keyspace}</keyspace>
-            <hawkular-metrics.base-uri>${base-uri}</hawkular-metrics.base-uri>
-          </systemPropertyVariables>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.wildfly.plugins</groupId>
-        <artifactId>wildfly-maven-plugin</artifactId>
-        <configuration>
-          <skip>${skipTests}</skip>
-          <port>${ptrans.wildfly.management.port}</port>
-        </configuration>
-        <executions>
-          <execution>
-            <id>start-wildfly</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>start</goal>
-            </goals>
-            <configuration>
-              <serverConfig>standalone-test.xml</serverConfig>
-              <javaOpts>
-                <javaOpt>-Xms64m</javaOpt>
-                <javaOpt>-Xmx512m</javaOpt>
-                <javaOpt>-Xss256k</javaOpt>
-                <javaOpt>-Djava.net.preferIPv4Stack=true</javaOpt>
-                <javaOpt>-Dsun.rmi.dgc.client.gcInterval=3600000</javaOpt>
-                <javaOpt>-Dsun.rmi.dgc.server.gcInterval=3600000</javaOpt>
-                <javaOpt>-Djboss.socket.binding.port-offset=${ptrans.wildfly.port.offset}</javaOpt>
-                <javaOpt>-Djboss.server.config.dir=${project.build.directory}/wildfly-configuration</javaOpt>
-                <javaOpt>-Dcassandra.keyspace=${cassandra.keyspace}</javaOpt>
-                <javaOpt>-Dcassandra.resetdb</javaOpt>
-                <javaOpt>-Dhawkular.metrics.waitForService</javaOpt>
-                <javaOpt>-Xdebug</javaOpt>
-                <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
-              </javaOpts>
-            </configuration>
-          </execution>
-          <execution>
-            <id>deploy-webapp</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>deploy-artifact</goal>
-            </goals>
-            <configuration>
-              <groupId>${project.groupId}</groupId>
-              <artifactId>hawkular-metrics-api-jaxrs</artifactId>
-              <name>hawkular-metric-rest.war</name>
-            </configuration>
-          </execution>
-          <execution>
-            <id>stop-wildfly</id>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>shutdown</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <configuration>
@@ -280,6 +164,7 @@
   </build>
 
   <profiles>
+
     <profile>
       <id>publish</id>
       <build>
@@ -303,5 +188,148 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>ptrans-integration-tests</id>
+      <activation>
+        <property>
+          <name>integration-tests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-standalone-test</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <!--
+                    We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
+                    configuration files and override the default configuration directory. See
+                    https://issues.jboss.org/browse/JBASMP-75 for details.
+                  -->
+                  <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
+                  <overwrite>true</overwrite>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
+                  <delimiters>
+                    <delimiter>@@@</delimiter>
+                  </delimiters>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src/test/wildfly-configuration</directory>
+                      <includes>
+                        <include>*</include>
+                      </includes>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*ITest*</include>
+              </includes>
+              <systemPropertyVariables>
+                <keyspace>${cassandra.keyspace}</keyspace>
+                <hawkular-metrics.base-uri>${base-uri}</hawkular-metrics.base-uri>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <configuration>
+              <skip>${running.service}</skip>
+              <port>${ptrans.wildfly.management.port}</port>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start-wildfly</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+                <configuration>
+                  <serverConfig>standalone-test.xml</serverConfig>
+                  <javaOpts>
+                    <javaOpt>-Xms64m</javaOpt>
+                    <javaOpt>-Xmx512m</javaOpt>
+                    <javaOpt>-Xss256k</javaOpt>
+                    <javaOpt>-Djava.net.preferIPv4Stack=true</javaOpt>
+                    <javaOpt>-Dsun.rmi.dgc.client.gcInterval=3600000</javaOpt>
+                    <javaOpt>-Dsun.rmi.dgc.server.gcInterval=3600000</javaOpt>
+                    <javaOpt>-Djboss.socket.binding.port-offset=${ptrans.wildfly.port.offset}</javaOpt>
+                    <javaOpt>-Djboss.server.config.dir=${project.build.directory}/wildfly-configuration</javaOpt>
+                    <javaOpt>-Dcassandra.keyspace=${cassandra.keyspace}</javaOpt>
+                    <javaOpt>-Dcassandra.resetdb</javaOpt>
+                    <javaOpt>-Dhawkular.metrics.waitForService</javaOpt>
+                    <javaOpt>-Dhawkular.scheduler.time-units=${scheduler.units}</javaOpt>
+                    <javaOpt>-Xdebug</javaOpt>
+                    <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
+                  </javaOpts>
+                </configuration>
+              </execution>
+              <execution>
+                <id>deploy-webapp</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>deploy-artifact</goal>
+                </goals>
+                <configuration>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>hawkular-metrics-api-jaxrs</artifactId>
+                  <name>hawkular-metric-rest.war</name>
+                </configuration>
+              </execution>
+              <execution>
+                <id>stop-wildfly</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>shutdown</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>wildfly.deployment</id>
+      <activation>
+        <property>
+          <name>!running.service</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- IMPORTANT: The port must be the port offset + 8080. -->
+        <base-uri>127.0.0.1:55988/hawkular/metrics</base-uri>
+        <ptrans.wildfly.port.offset>47908</ptrans.wildfly.port.offset>
+        <!-- IMPORTANT: The management port must be the port offset + 9990. -->
+        <ptrans.wildfly.management.port>57898</ptrans.wildfly.management.port>
+        <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
+        <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
+      </properties>
+    </profile>
+
   </profiles>
 </project>

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -192,9 +192,7 @@
     <profile>
       <id>ptrans-integration-tests</id>
       <activation>
-        <property>
-          <name>integration-tests</name>
-        </property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/backend/MetricsSenderITest.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/backend/MetricsSenderITest.java
@@ -19,6 +19,7 @@ package org.hawkular.metrics.clients.ptrans.backend;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 import static org.hawkular.metrics.clients.ptrans.backend.Constants.METRIC_ADDRESS;
+import static org.hawkular.metrics.clients.ptrans.data.ServerDataHelper.BASE_URI;
 import static org.hawkular.metrics.clients.ptrans.util.TenantUtil.getRandomTenantId;
 import static org.junit.Assert.assertEquals;
 
@@ -47,11 +48,6 @@ import io.vertx.core.Vertx;
  * @author Thomas Segismont
  */
 public class MetricsSenderITest {
-    private static final String BASE_URI;
-
-    static {
-        BASE_URI = System.getProperty("hawkular-metrics.base-uri", "127.0.0.1:8080/hawkular/metrics");
-    }
 
     @Rule
     public final Timeout timeout = new Timeout(1, MINUTES);

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/data/ServerDataHelper.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/data/ServerDataHelper.java
@@ -38,10 +38,15 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  * @author Thomas Segismont
  */
 public class ServerDataHelper {
-    public static final String BASE_URI = System.getProperty(
-            "hawkular-metrics.base-uri",
-            "127.0.0.1:8080/hawkular/metrics"
-    );
+    public static final String BASE_URI;
+
+    static {
+        String baseUri = System.getProperty("hawkular-metrics.base-uri");
+        if (baseUri == null || baseUri.trim().isEmpty()) {
+            baseUri = "127.0.0.1:8080/hawkular/metrics";
+        }
+        BASE_URI = baseUri;
+    }
 
     private final String tenant;
     private final String findGaugeMetricsUrl;

--- a/core/metrics-core-impl/pom.xml
+++ b/core/metrics-core-impl/pom.xml
@@ -139,9 +139,7 @@
     <profile>
       <id>core-impl-integration-tests</id>
       <activation>
-        <property>
-          <name>integration-tests</name>
-        </property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>

--- a/core/metrics-core-impl/pom.xml
+++ b/core/metrics-core-impl/pom.xml
@@ -131,39 +131,16 @@
           </excludes>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <includes>
-            <include>**/*ITest*</include>
-          </includes>
-          <systemPropertyVariables>
-            <keyspace>${test.keyspace}</keyspace>
-            <nodes>${nodes}</nodes>
-          </systemPropertyVariables>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 
   <profiles>
+
     <profile>
-      <id>testOnly</id>
+      <id>core-impl-integration-tests</id>
       <activation>
         <property>
-          <name>skipTests</name>
-          <value>!true</value>
+          <name>integration-tests</name>
         </property>
       </activation>
       <build>
@@ -206,8 +183,30 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*ITest*</include>
+              </includes>
+              <systemPropertyVariables>
+                <keyspace>${test.keyspace}</keyspace>
+                <nodes>${nodes}</nodes>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>
+
   </profiles>
 </project>

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -129,9 +129,7 @@
     <profile>
       <id>rest-tests-integration-tests</id>
       <activation>
-        <property>
-          <name>integration-tests</name>
-        </property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -102,75 +102,16 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-standalone-test</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <!--
-                We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
-                configuration files and override the default configuration directory. See
-                https://issues.jboss.org/browse/JBASMP-75 for details.
-              -->
-              <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
-              <overwrite>true</overwrite>
-              <useDefaultDelimiters>false</useDefaultDelimiters>
-              <delimiters>
-                <delimiter>@@@</delimiter>
-              </delimiters>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/src/test/wildfly-configuration</directory>
-                  <includes>
-                    <include>*</include>
-                  </includes>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skipTests>true</skipTests>
-          <excludes>
-            <exclude>**/*ITest*</exclude>
-          </excludes>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <includes>
-            <include>**/*ITest*</include>
-          </includes>
-          <systemPropertyVariables>
-            <keyspace>${cassandra.keyspace}</keyspace>
-            <hawkular-metrics.base-uri>${base-uri}</hawkular-metrics.base-uri>
-            <project.version>${project.version}</project.version>
-          </systemPropertyVariables>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
 
   <profiles>
+
     <profile>
       <id>test.debug</id>
       <activation>
@@ -186,30 +127,54 @@
     </profile>
 
     <profile>
-      <id>wildfly.deployment</id>
+      <id>rest-tests-integration-tests</id>
       <activation>
         <property>
-          <name>!running.service</name>
+          <name>integration-tests</name>
         </property>
       </activation>
-
-      <properties>
-        <!-- IMPORTANT: The port must be the port offset + 8080. -->
-        <base-uri>127.0.0.1:55977/hawkular/metrics</base-uri>
-        <wildfly.port.offset>47897</wildfly.port.offset>
-        <!-- IMPORTANT: The management port must be the port offset + 9990. -->
-        <wildfly.management.port>57887</wildfly.management.port>
-        <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
-        <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
-      </properties>
-
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-standalone-test</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <!--
+                    We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
+                    configuration files and override the default configuration directory. See
+                    https://issues.jboss.org/browse/JBASMP-75 for details.
+                  -->
+                  <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
+                  <overwrite>true</overwrite>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
+                  <delimiters>
+                    <delimiter>@@@</delimiter>
+                  </delimiters>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src/test/wildfly-configuration</directory>
+                      <includes>
+                        <include>*</include>
+                      </includes>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-maven-plugin</artifactId>
             <configuration>
-              <skip>${skipTests}</skip>
+              <skip>${running.service}</skip>
               <port>${wildfly.management.port}</port>
             </configuration>
             <executions>
@@ -260,8 +225,49 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*ITest*</include>
+              </includes>
+              <systemPropertyVariables>
+                <keyspace>${cassandra.keyspace}</keyspace>
+                <hawkular-metrics.base-uri>${base-uri}</hawkular-metrics.base-uri>
+                <project.version>${project.version}</project.version>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>wildfly.deployment</id>
+      <activation>
+        <property>
+          <name>!running.service</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- IMPORTANT: The port must be the port offset + 8080. -->
+        <base-uri>127.0.0.1:55977/hawkular/metrics</base-uri>
+        <wildfly.port.offset>47897</wildfly.port.offset>
+        <!-- IMPORTANT: The management port must be the port offset + 9990. -->
+        <wildfly.management.port>57887</wildfly.management.port>
+        <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
+        <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
+      </properties>
+    </profile>
+
   </profiles>
 </project>

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/InfluxDBTest.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/InfluxDBTest.java
@@ -29,8 +29,15 @@ public class InfluxDBTest {
     private static final String TENANT_PREFIX = UUID.randomUUID().toString();
     private static final AtomicInteger TENANT_ID_COUNTER = new AtomicInteger(0);
 
-    static String baseURI = System.getProperty("hawkular-metrics.base-uri", "127.0.0.1:8080/hawkular/metrics");
+    static String baseURI = System.getProperty("hawkular-metrics.base-uri");
     static InfluxDB influxDB;
+
+    static {
+        baseURI = System.getProperty("hawkular-metrics.base-uri");
+        if (baseURI == null || baseURI.trim().isEmpty()) {
+            baseURI = "127.0.0.1:8080/hawkular/metrics";
+        }
+    }
 
     @BeforeClass
     public static void initClient() {

--- a/rest-tests/src/test/java/org/hawkular/metrics/test/RESTTest.java
+++ b/rest-tests/src/test/java/org/hawkular/metrics/test/RESTTest.java
@@ -26,10 +26,16 @@ import org.junit.BeforeClass;
  */
 public class RESTTest {
     static final String TENANT_HEADER_NAME = "Hawkular-Tenant";
-
-    static String baseURI = System.getProperty("hawkular-metrics.base-uri", "127.0.0.1:8080/hawkular/metrics");
+    static String baseURI;
     static ResteasyClient restClient = null;
     static ResteasyWebTarget target = null;
+
+    static {
+        baseURI = System.getProperty("hawkular-metrics.base-uri");
+        if (baseURI == null || baseURI.trim().isEmpty()) {
+            baseURI = "127.0.0.1:8080/hawkular/metrics";
+        }
+    }
 
     @BeforeClass
     public static void initClient() {

--- a/task-queue/pom.xml
+++ b/task-queue/pom.xml
@@ -85,11 +85,49 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
-            <keyspace>${test.keyspace}</keyspace>
-          </systemPropertyVariables>
+          <excludes>
+            <exclude>**/*ITest*</exclude>
+          </excludes>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
+
+  <profiles>
+
+    <profile>
+      <id>task-queue-integration-tests</id>
+      <activation>
+        <property>
+          <name>integration-tests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*ITest*</include>
+              </includes>
+              <systemPropertyVariables>
+                <keyspace>${test.keyspace}</keyspace>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
 </project>

--- a/task-queue/pom.xml
+++ b/task-queue/pom.xml
@@ -99,9 +99,7 @@
     <profile>
       <id>task-queue-integration-tests</id>
       <activation>
-        <property>
-          <name>integration-tests</name>
-        </property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>

--- a/task-queue/src/test/java/org/hawkular/metrics/tasks/BaseITest.java
+++ b/task-queue/src/test/java/org/hawkular/metrics/tasks/BaseITest.java
@@ -20,10 +20,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Session;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.Uninterruptibles;
 import org.hawkular.metrics.schema.SchemaManager;
 import org.hawkular.metrics.tasks.impl.Queries;
 import org.hawkular.rx.cassandra.driver.RxSession;
@@ -31,10 +27,15 @@ import org.hawkular.rx.cassandra.driver.RxSessionImpl;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.Uninterruptibles;
+
 /**
  * @author jsanda
  */
-public class BaseTest {
+public abstract class BaseITest {
 
     private static final long FUTURE_TIMEOUT = 3;
 

--- a/task-queue/src/test/java/org/hawkular/metrics/tasks/impl/LeaseServiceITest.java
+++ b/task-queue/src/test/java/org/hawkular/metrics/tasks/impl/LeaseServiceITest.java
@@ -17,6 +17,7 @@
 package org.hawkular.metrics.tasks.impl;
 
 import static java.util.Collections.singletonList;
+
 import static org.joda.time.DateTime.now;
 import static org.joda.time.Duration.standardMinutes;
 import static org.testng.Assert.assertEquals;
@@ -29,10 +30,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.datastax.driver.core.PreparedStatement;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import org.hawkular.metrics.tasks.BaseTest;
+import org.hawkular.metrics.tasks.BaseITest;
 import org.hawkular.rx.cassandra.driver.RxSessionImpl;
 import org.joda.time.DateTime;
 import org.joda.time.Minutes;
@@ -42,12 +40,16 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.datastax.driver.core.PreparedStatement;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
 /**
  * @author jsanda
  */
-public class LeaseServiceTest extends BaseTest {
+public class LeaseServiceITest extends BaseITest {
 
-    private static Logger logger = LoggerFactory.getLogger(LeaseServiceTest.class);
+    private static Logger logger = LoggerFactory.getLogger(LeaseServiceITest.class);
 
     private LeaseService leaseService;
 

--- a/task-queue/src/test/java/org/hawkular/metrics/tasks/impl/TaskSchedulerITest.java
+++ b/task-queue/src/test/java/org/hawkular/metrics/tasks/impl/TaskSchedulerITest.java
@@ -18,6 +18,7 @@ package org.hawkular.metrics.tasks.impl;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+
 import static org.joda.time.DateTime.now;
 import static org.joda.time.Duration.standardSeconds;
 import static org.testng.Assert.assertTrue;
@@ -26,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.hawkular.metrics.tasks.BaseTest;
+import org.hawkular.metrics.tasks.BaseITest;
 import org.hawkular.metrics.tasks.api.TaskType;
 import org.hawkular.rx.cassandra.driver.RxSessionImpl;
 import org.joda.time.DateTime;
@@ -36,7 +37,7 @@ import org.testng.annotations.Test;
 /**
  * @author jsanda
  */
-public class TaskSchedulerTest extends BaseTest {
+public class TaskSchedulerITest extends BaseITest {
 
     private LeaseService leaseService;
 

--- a/task-queue/src/test/java/org/hawkular/metrics/tasks/impl/TaskServiceITest.java
+++ b/task-queue/src/test/java/org/hawkular/metrics/tasks/impl/TaskServiceITest.java
@@ -20,6 +20,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+
 import static org.joda.time.DateTime.now;
 import static org.joda.time.Duration.standardMinutes;
 import static org.joda.time.Duration.standardSeconds;
@@ -39,9 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
-import com.datastax.driver.core.ResultSet;
-import com.google.common.collect.ImmutableSet;
-import org.hawkular.metrics.tasks.BaseTest;
+import org.hawkular.metrics.tasks.BaseITest;
 import org.hawkular.metrics.tasks.api.Task;
 import org.hawkular.metrics.tasks.api.TaskType;
 import org.joda.time.DateTime;
@@ -49,14 +48,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.datastax.driver.core.ResultSet;
+import com.google.common.collect.ImmutableSet;
+
 import rx.functions.Action1;
 
 /**
  * @author jsanda
  */
-public class TaskServiceTest extends BaseTest {
+public class TaskServiceITest extends BaseITest {
 
-    private static final Logger logger = LoggerFactory.getLogger(TaskServiceTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(TaskServiceITest.class);
 
     protected LeaseService leaseService;
 


### PR DESCRIPTION
Don't run integration tests by default.

Of course they will still have to run on Travis.

Each project with integration tests has its own profile, so that one can build the sources and run selected integration tests:
- "rests-tests-integration-tests"
- "ptrans-integration-tests"
- "core-impl-tests-integration-tests"
- "task-queue-integration-tests"

All these profile are activated if "-Dintegration-tests" is added to the build command.

In rests-tests and ptrans modules, developers can still use the "-Drunning.service" flag to skip Wildfly start/deploy/stop cycle.