### PR TITLE
Using the dependencies/plugins version for gatling declared in the ha…

### DIFF
--- a/load-tests/pom.xml
+++ b/load-tests/pom.xml
@@ -32,15 +32,10 @@
 
   <name>Hawkular Metrics Load Tests</name>
 
-  <properties>
-    <version.io.gatling>2.1.6</version.io.gatling>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.gatling.highcharts</groupId>
       <artifactId>gatling-charts-highcharts</artifactId>
-      <version>${version.io.gatling}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -50,7 +45,6 @@
       <plugin>
         <groupId>io.gatling</groupId>
         <artifactId>gatling-maven-plugin</artifactId>
-        <version>${version.io.gatling}</version>
         <configuration>
           <simulationClass>org.hawkular.metrics.loadtest.MetricsSimulation</simulationClass>
           <propagateSystemProperties>true</propagateSystemProperties>


### PR DESCRIPTION
…wkular parent pom.

~~**Don't merge yet!**~~
ready to merge

~~This will fail the build, because the new parent pom hasn't been released yet, so this should be merged after the parent pom version bump (https://github.com/hawkular/hawkular-metrics/pull/288)~~