### PR TITLE
HWKMETRICS-184 && HWKMETRICS-183

### DIFF
--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -36,6 +36,7 @@
   <description>A protocol translator that can receive data from various system and feed it to the Hawkular Metrics REST api.</description>
 
   <properties>
+    <wildfly-maven-plugin.skip>true</wildfly-maven-plugin.skip>
     <cassandra.keyspace>hawkular_metrics_ptrans_integration_tests</cassandra.keyspace>
     <scheduler.units>seconds</scheduler.units>
     <!-- Configuration files used when starting a development ptrans instance with mvn exec:java -->
@@ -192,45 +193,12 @@
     <profile>
       <id>ptrans-integration-tests</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!skipTests</name>
+        </property>
       </activation>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-standalone-test</id>
-                <phase>process-test-resources</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <!--
-                    We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
-                    configuration files and override the default configuration directory. See
-                    https://issues.jboss.org/browse/JBASMP-75 for details.
-                  -->
-                  <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
-                  <overwrite>true</overwrite>
-                  <useDefaultDelimiters>false</useDefaultDelimiters>
-                  <delimiters>
-                    <delimiter>@@@</delimiter>
-                  </delimiters>
-                  <resources>
-                    <resource>
-                      <directory>${project.basedir}/src/test/wildfly-configuration</directory>
-                      <includes>
-                        <include>*</include>
-                      </includes>
-                      <filtering>true</filtering>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
@@ -256,7 +224,7 @@
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-maven-plugin</artifactId>
             <configuration>
-              <skip>${running.service}</skip>
+              <skip>${wildfly-maven-plugin.skip}</skip>
               <port>${ptrans.wildfly.management.port}</port>
             </configuration>
             <executions>
@@ -319,6 +287,7 @@
         </property>
       </activation>
       <properties>
+        <wildfly-maven-plugin.skip>false</wildfly-maven-plugin.skip>
         <!-- IMPORTANT: The port must be the port offset + 8080. -->
         <base-uri>127.0.0.1:55988/hawkular/metrics</base-uri>
         <ptrans.wildfly.port.offset>47908</ptrans.wildfly.port.offset>
@@ -327,6 +296,45 @@
         <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
         <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-standalone-test</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <!--
+                    We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
+                    configuration files and override the default configuration directory. See
+                    https://issues.jboss.org/browse/JBASMP-75 for details.
+                  -->
+                  <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
+                  <overwrite>true</overwrite>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
+                  <delimiters>
+                    <delimiter>@@@</delimiter>
+                  </delimiters>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src/test/wildfly-configuration</directory>
+                      <includes>
+                        <include>*</include>
+                      </includes>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
   </profiles>

--- a/core/metrics-core-impl/pom.xml
+++ b/core/metrics-core-impl/pom.xml
@@ -139,7 +139,9 @@
     <profile>
       <id>core-impl-integration-tests</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!skipTests</name>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -32,6 +32,7 @@
   <name>Hawkular Metrics Rest Tests</name>
 
   <properties>
+    <wildfly-maven-plugin.skip>true</wildfly-maven-plugin.skip>
     <cassandra.keyspace>hawkular_metrics_rest_tests</cassandra.keyspace>
     <scheduler.units>seconds</scheduler.units>
   </properties>
@@ -129,42 +130,31 @@
     <profile>
       <id>rest-tests-integration-tests</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!skipTests</name>
+        </property>
       </activation>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*ITest*</include>
+              </includes>
+              <systemPropertyVariables>
+                <keyspace>${cassandra.keyspace}</keyspace>
+                <hawkular-metrics.base-uri>${base-uri}</hawkular-metrics.base-uri>
+                <project.version>${project.version}</project.version>
+              </systemPropertyVariables>
+            </configuration>
             <executions>
               <execution>
-                <id>copy-standalone-test</id>
-                <phase>process-test-resources</phase>
                 <goals>
-                  <goal>copy-resources</goal>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
                 </goals>
-                <configuration>
-                  <!--
-                    We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
-                    configuration files and override the default configuration directory. See
-                    https://issues.jboss.org/browse/JBASMP-75 for details.
-                  -->
-                  <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
-                  <overwrite>true</overwrite>
-                  <useDefaultDelimiters>false</useDefaultDelimiters>
-                  <delimiters>
-                    <delimiter>@@@</delimiter>
-                  </delimiters>
-                  <resources>
-                    <resource>
-                      <directory>${project.basedir}/src/test/wildfly-configuration</directory>
-                      <includes>
-                        <include>*</include>
-                      </includes>
-                      <filtering>true</filtering>
-                    </resource>
-                  </resources>
-                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -172,7 +162,7 @@
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-maven-plugin</artifactId>
             <configuration>
-              <skip>${running.service}</skip>
+              <skip>${wildfly-maven-plugin.skip}</skip>
               <port>${wildfly.management.port}</port>
             </configuration>
             <executions>
@@ -223,28 +213,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <configuration>
-              <includes>
-                <include>**/*ITest*</include>
-              </includes>
-              <systemPropertyVariables>
-                <keyspace>${cassandra.keyspace}</keyspace>
-                <hawkular-metrics.base-uri>${base-uri}</hawkular-metrics.base-uri>
-                <project.version>${project.version}</project.version>
-              </systemPropertyVariables>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>integration-test</goal>
-                  <goal>verify</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -257,6 +225,7 @@
         </property>
       </activation>
       <properties>
+        <wildfly-maven-plugin.skip>false</wildfly-maven-plugin.skip>
         <!-- IMPORTANT: The port must be the port offset + 8080. -->
         <base-uri>127.0.0.1:55977/hawkular/metrics</base-uri>
         <wildfly.port.offset>47897</wildfly.port.offset>
@@ -265,6 +234,45 @@
         <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
         <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-standalone-test</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <!--
+                    We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
+                    configuration files and override the default configuration directory. See
+                    https://issues.jboss.org/browse/JBASMP-75 for details.
+                  -->
+                  <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
+                  <overwrite>true</overwrite>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
+                  <delimiters>
+                    <delimiter>@@@</delimiter>
+                  </delimiters>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src/test/wildfly-configuration</directory>
+                      <includes>
+                        <include>*</include>
+                      </includes>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
   </profiles>

--- a/task-queue/pom.xml
+++ b/task-queue/pom.xml
@@ -99,7 +99,9 @@
     <profile>
       <id>task-queue-integration-tests</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!skipTests</name>
+        </property>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
Active by default no longer used to activate itests profiles. Instead, they're active if 'skipTests' property is absent.
This fixed the other issue at the same time: we shouldn't require a running Cassandra to build Hawkular Metrics when tests are skipped.

Side work: moved wildfly config setup to 'wildfly.deployment' profile to avoid execution when it's not needed