### PR TITLE
[HWKMETRICS-114] Refactor MetricId to include tenantId and MetricType

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -115,7 +115,7 @@ public class AvailabilityHandler {
             @Context UriInfo uriInfo
     ) {
         URI location = uriInfo.getBaseUriBuilder().path("/availability/{id}").build(metricDefinition.getId());
-        Metric metric = new Metric(tenantId, AVAILABILITY, new MetricId(metricDefinition.getId()),
+        Metric metric = new Metric(new MetricId(tenantId, AVAILABILITY, metricDefinition.getId()),
                 metricDefinition.getTags(), metricDefinition.getDataRetention());
         metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
     }
@@ -131,7 +131,7 @@ public class AvailabilityHandler {
     public void getAvailabilityMetric(@Suspended final AsyncResponse asyncResponse,
             @HeaderParam("tenantId") String tenantId, @PathParam("id") String id) {
 
-        metricsService.findMetric(tenantId, AVAILABILITY, new MetricId(id))
+        metricsService.findMetric(new MetricId(tenantId, AVAILABILITY, id))
                 .map(MetricDefinition::new)
                 .map(metricDef -> Response.ok(metricDef).build())
                 .switchIfEmpty(Observable.just(noContent()))
@@ -151,7 +151,7 @@ public class AvailabilityHandler {
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id
     ) {
-        metricsService.getMetricTags(tenantId, AVAILABILITY, new MetricId(id)).subscribe(
+        metricsService.getMetricTags(new MetricId(tenantId, AVAILABILITY, id)).subscribe(
                 optional -> asyncResponse.resume(valueToResponse(optional)),
                 t -> asyncResponse.resume(serverError(t)));
     }
@@ -168,7 +168,7 @@ public class AvailabilityHandler {
             @PathParam("id") String id,
             @ApiParam(required = true) Map<String, String> tags
     ) {
-        Metric<AvailabilityType> metric = new Metric<>(tenantId, AVAILABILITY, new MetricId(id));
+        Metric<AvailabilityType> metric = new Metric<>(new MetricId(tenantId, AVAILABILITY, id));
         metricsService.addTags(metric, tags).subscribe(new ResultSetObserver(asyncResponse));
     }
 
@@ -185,7 +185,7 @@ public class AvailabilityHandler {
             @PathParam("id") String id,
             @ApiParam("Tag list") @PathParam("tags") Tags tags
     ) {
-        Metric<AvailabilityType> metric = new Metric<>(tenantId, AVAILABILITY, new MetricId(id));
+        Metric<AvailabilityType> metric = new Metric<>(new MetricId(tenantId, AVAILABILITY, id));
         metricsService.deleteTags(metric, tags.getTags()).subscribe(new ResultSetObserver(asyncResponse));
     }
 
@@ -202,7 +202,7 @@ public class AvailabilityHandler {
             @Suspended final AsyncResponse asyncResponse, @PathParam("id") String id,
             @ApiParam(value = "List of availability datapoints", required = true) List<AvailabilityDataPoint> data
     ) {
-        Metric<AvailabilityType> metric = new Metric<>(tenantId, AVAILABILITY, new MetricId(id),
+        Metric<AvailabilityType> metric = new Metric<>(new MetricId(tenantId, AVAILABILITY, id),
                 requestToAvailabilityDataPoints(data));
         metricsService.addAvailabilityData(Observable.just(metric)).subscribe(new ResultSetObserver(asyncResponse));
     }
@@ -278,9 +278,9 @@ public class AvailabilityHandler {
         Long startTime = start == null ? now - EIGHT_HOURS : start;
         Long endTime = end == null ? now : end;
 
-        Metric<AvailabilityType> metric = new Metric<>(tenantId, AVAILABILITY, new MetricId(id));
+        Metric<AvailabilityType> metric = new Metric<>(new MetricId(tenantId, AVAILABILITY, id));
         if (bucketsCount == null && bucketDuration == null) {
-            metricsService.findAvailabilityData(tenantId, metric.getId(), startTime, endTime, distinct)
+            metricsService.findAvailabilityData(metric.getId(), startTime, endTime, distinct)
                     .map(AvailabilityDataPoint::new)
                     .toList()
                     .map(ApiUtils::collectionToResponse)
@@ -325,7 +325,7 @@ public class AvailabilityHandler {
             @ApiParam(required = true) TagRequest params
     ) {
         Observable<Void> resultSetObservable;
-        Metric<AvailabilityType> metric = new Metric<>(tenantId, AVAILABILITY, new MetricId(id));
+        Metric<AvailabilityType> metric = new Metric<>(new MetricId(tenantId, AVAILABILITY, id));
         if (params.getTimestamp() != null) {
             resultSetObservable = metricsService.tagAvailabilityData(metric, params.getTags(), params.getTimestamp());
         } else {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -108,7 +108,7 @@ public class GaugeHandler {
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
-        Metric<Double> metric = new Metric<>(tenantId, GAUGE, new MetricId(metricDefinition.getId()),
+        Metric<Double> metric = new Metric<>(new MetricId(tenantId, GAUGE, metricDefinition.getId()),
                 metricDefinition.getTags(), metricDefinition.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/gauges/{id}").build(metric.getId().getName());
         metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
@@ -124,7 +124,7 @@ public class GaugeHandler {
                          response = ApiError.class) })
     public void getGaugeMetric(@Suspended final AsyncResponse asyncResponse, @PathParam("id") String id) {
 
-        metricsService.findMetric(tenantId, GAUGE, new MetricId(id))
+        metricsService.findMetric(new MetricId(tenantId, GAUGE, id))
                 .map(MetricDefinition::new)
                 .map(metricDef -> Response.ok(metricDef).build())
                 .switchIfEmpty(Observable.just(ApiUtils.noContent()))
@@ -144,7 +144,7 @@ public class GaugeHandler {
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id
     ) {
-        metricsService.getMetricTags(tenantId, GAUGE, new MetricId(id))
+        metricsService.getMetricTags(new MetricId(tenantId, GAUGE, id))
                 .subscribe(
                         optional -> asyncResponse.resume(ApiUtils.valueToResponse(optional)),
                         t ->asyncResponse.resume(ApiUtils.serverError(t))
@@ -163,7 +163,7 @@ public class GaugeHandler {
             @PathParam("id") String id,
             @ApiParam(required = true) Map<String, String> tags
     ) {
-        Metric<Double> metric = new Metric<>(tenantId, GAUGE, new MetricId(id));
+        Metric<Double> metric = new Metric<>(new MetricId(tenantId, GAUGE, id));
         metricsService.addTags(metric, tags).subscribe(new ResultSetObserver(asyncResponse));
     }
 
@@ -180,7 +180,7 @@ public class GaugeHandler {
             @PathParam("id") String id,
             @ApiParam("Tag list") @PathParam("tags") Tags tags
     ) {
-        Metric<Double> metric = new Metric<>(tenantId, GAUGE, new MetricId(id));
+        Metric<Double> metric = new Metric<>(new MetricId(tenantId, GAUGE, id));
         metricsService.deleteTags(metric, tags.getTags()).subscribe(new ResultSetObserver(asyncResponse));
     }
 
@@ -199,7 +199,7 @@ public class GaugeHandler {
             @ApiParam(value = "List of datapoints containing timestamp and value", required = true)
             List<GaugeDataPoint> data
     ) {
-        Metric<Double> metric = new Metric<>(tenantId, GAUGE, new MetricId(id), requestToGaugeDataPoints(data));
+        Metric<Double> metric = new Metric<>(new MetricId(tenantId, GAUGE, id), requestToGaugeDataPoints(data));
         Observable<Void> observable = metricsService.addGaugeData(Observable.just(metric));
         observable.subscribe(new ResultSetObserver(asyncResponse));
     }
@@ -270,7 +270,7 @@ public class GaugeHandler {
             long startTime = start == null ? now - EIGHT_HOURS : start;
             long endTime = end == null ? now : end;
 
-            metricsService.findGaugeData(tenantId, new MetricId(id), startTime, endTime)
+            metricsService.findGaugeData(new MetricId(tenantId, GAUGE, id), startTime, endTime)
                     .toList()
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
@@ -287,7 +287,7 @@ public class GaugeHandler {
             long startTime = start == null ? now - EIGHT_HOURS : start;
             long endTime = end == null ? now : end;
 
-            Metric<Double> metric = new Metric<>(tenantId, GAUGE, new MetricId(id));
+            Metric<Double> metric = new Metric<>(new MetricId(tenantId, GAUGE, id));
 
             Buckets buckets;
             try {
@@ -369,7 +369,7 @@ public class GaugeHandler {
                     )
             ));
         } else {
-            metricsService.getPeriods(tenantId, new MetricId(id), predicate, startTime, endTime)
+            metricsService.getPeriods(new MetricId(tenantId, GAUGE, id), predicate, startTime, endTime)
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
         }
@@ -410,7 +410,7 @@ public class GaugeHandler {
             @PathParam("id") final String id, @ApiParam(required = true) TagRequest params
     ) {
         Observable<Void> resultSetObservable;
-        Metric<Double> metric = new Metric<>(tenantId, GAUGE, new MetricId(id));
+        Metric<Double> metric = new Metric<>(new MetricId(tenantId, GAUGE, id));
         if (params.getTimestamp() != null) {
             resultSetObservable = metricsService.tagGaugeData(metric, params.getTags(), params.getTimestamp());
         } else {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxSeriesHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxSeriesHandler.java
@@ -157,7 +157,7 @@ public class InfluxSeriesHandler {
             }
             dataPoints.add(new DataPoint<>(timestamp, value));
         }
-        return new Metric<>(tenantId, GAUGE, new MetricId(influxObject.getName()), dataPoints);
+        return new Metric<>(new MetricId(tenantId, GAUGE, influxObject.getName()), dataPoints);
     }
 
     @GET
@@ -266,7 +266,7 @@ public class InfluxSeriesHandler {
                                   return Observable.just(null);
                               }
                               return metricsService.findGaugeData(
-                                      tenantId, new MetricId(metric),
+                                      new MetricId(tenantId, GAUGE, metric),
                                       timeInterval.getStartMillis(), timeInterval.getEndMillis()
                               ).toList();
                           }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/ApiUtils.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/ApiUtils.java
@@ -75,17 +75,17 @@ public class ApiUtils {
 
     public static Observable<Metric<Double>> requestToGauges(String tenantId, List<Gauge> gauges) {
         return Observable.from(gauges).map(g ->
-                new Metric<>(tenantId, GAUGE, new MetricId(g.getId()), requestToGaugeDataPoints(g.getData())));
+                new Metric<>(new MetricId(tenantId, GAUGE, g.getId()), requestToGaugeDataPoints(g.getData())));
     }
 
     public static Observable<Metric<Long>> requestToCounters(String tenantId, List<Counter> counters) {
         return Observable.from(counters).map(c ->
-                new Metric<>(tenantId, COUNTER, new MetricId(c.getId()), requestToCounterDataPoints(c.getData())));
+                new Metric<>(new MetricId(tenantId, COUNTER, c.getId()), requestToCounterDataPoints(c.getData())));
     }
 
     public static Observable<Metric<AvailabilityType>> requestToAvailabilities(String tenantId,
             List<Availability> avails) {
-        return Observable.from(avails).map(a -> new Metric<>(tenantId, AVAILABILITY, new MetricId(a.getId()),
+        return Observable.from(avails).map(a -> new Metric<>(new MetricId(tenantId, AVAILABILITY, a.getId()),
                 requestToAvailabilityDataPoints(a.getData())));
     }
 

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/Aggregate.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/Aggregate.java
@@ -22,7 +22,7 @@ import rx.observables.MathObservable;
 
 /**
  * Predefined aggregate functions usable with
- * {@link MetricsService#findGaugeData(String, MetricId, Long, Long, Func1...)}.
+ * {@link MetricsService#findGaugeData(MetricId, Long, Long, Func1[])}.
  *
  * @author john sanda
  * @author jay shaughnessy

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/Metric.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/Metric.java
@@ -30,22 +30,16 @@ import java.util.Objects;
  */
 public class Metric<T> {
 
-    private String tenantId;
-    private MetricType type;
     private MetricId id;
     private Map<String, String> tags = Collections.emptyMap();
     private Integer dataRetention;
     private List<DataPoint<T>> dataPoints = new ArrayList<>();
 
-    public Metric(String tenantId, MetricType type, MetricId id) {
-        this.tenantId = tenantId;
-        this.type = type;
+    public Metric(MetricId id) {
         this.id = id;
     }
 
-    public Metric(String tenantId, MetricType type, MetricId id, Map<String, String> tags, Integer dataRetention) {
-        this.tenantId = tenantId;
-        this.type = type;
+    public Metric(MetricId id, Map<String, String> tags, Integer dataRetention) {
         this.id = id;
         this.tags = unmodifiableMap(tags);
         // If the data_retention column is not set, the driver returns zero instead of null.
@@ -58,17 +52,13 @@ public class Metric<T> {
         }
     }
 
-    public Metric(String tenantId, MetricType type, MetricId id, List<DataPoint<T>> dataPoints) {
-        this.tenantId = tenantId;
-        this.type = type;
+    public Metric(MetricId id, List<DataPoint<T>> dataPoints) {
         this.id = id;
         this.dataPoints = unmodifiableList(dataPoints);
     }
 
-    public Metric(String tenantId, MetricType type, MetricId id, Map<String, String> tags, Integer dataRetention,
+    public Metric(MetricId id, Map<String, String> tags, Integer dataRetention,
             List<DataPoint<T>> dataPoints) {
-        this.tenantId = tenantId;
-        this.type = type;
         this.id = id;
         this.tags = unmodifiableMap(tags);
         // If the data_retention column is not set, the driver returns zero instead of null.
@@ -82,12 +72,14 @@ public class Metric<T> {
         this.dataPoints = unmodifiableList(dataPoints);
     }
 
-    public MetricType getType() {
-        return type;
+    @Deprecated
+    public String getTenantId() {
+        return getId().getTenantId();
     }
 
-    public String getTenantId() {
-        return tenantId;
+    @Deprecated
+    public MetricType getType() {
+        return getId().getType();
     }
 
     public MetricId getId() {
@@ -111,22 +103,19 @@ public class Metric<T> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Metric<?> metric = (Metric<?>) o;
-        return Objects.equals(tenantId, metric.tenantId) &&
-                Objects.equals(type, metric.type) &&
-                Objects.equals(id, metric.id) &&
+        return Objects.equals(id, metric.id) &&
                 Objects.equals(tags, metric.tags) &&
                 Objects.equals(dataRetention, metric.dataRetention);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tenantId, type, id, tags, dataRetention);
+        return Objects.hash(id, tags, dataRetention);
     }
 
     @Override
     public String toString() {
         return com.google.common.base.Objects.toStringHelper(this)
-                .add("tenantId", tenantId)
                 .add("id", id)
                 .add("tags", tags)
                 .add("dataRetention", dataRetention)

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricId.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricId.java
@@ -23,15 +23,21 @@ import com.google.common.base.Objects;
  */
 public class MetricId {
 
+    private String tenantId;
+
+    private MetricType type;
+
     private String name;
 
     private Interval interval;
 
-    public MetricId(String name) {
-        this(name, Interval.NONE);
+    public MetricId(String tenantId, MetricType type, String name) {
+        this(tenantId, type, name, Interval.NONE);
     }
 
-    public MetricId(String name, Interval interval) {
+    public MetricId(String tenantId, MetricType type, String name, Interval interval) {
+        this.tenantId = tenantId;
+        this.type = type;
         this.name = name;
         this.interval = interval;
     }
@@ -50,17 +56,29 @@ public class MetricId {
         if (o == null || getClass() != o.getClass()) return false;
         MetricId metricId = (MetricId) o;
         return java.util.Objects.equals(name, metricId.name) &&
-                java.util.Objects.equals(interval, metricId.interval);
+                java.util.Objects.equals(interval, metricId.interval) &&
+                java.util.Objects.equals(tenantId, metricId.tenantId) &&
+                java.util.Objects.equals(type, metricId.type);
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public MetricType getType() {
+        return type;
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(name, interval);
+        return java.util.Objects.hash(name, interval, tenantId, type);
     }
 
     @Override
     public String toString() {
         return Objects.toStringHelper(this)
+                .add("tenantId", tenantId)
+                .add("type", type.toString())
                 .add("name", name)
                 .add("interval", interval)
                 .omitNullValues()

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -80,7 +80,7 @@ public interface MetricsService {
      */
     Observable<Void> createMetric(Metric<?> metric);
 
-    Observable<Metric> findMetric(String tenantId, MetricType type, MetricId id);
+    Observable<Metric> findMetric(MetricId id);
 
     /**
      * Returns tenant's metric definitions. The results can be filtered using a type.
@@ -98,7 +98,7 @@ public interface MetricsService {
      */
     Observable<Metric> findMetricsWithTags(String tenantId, Map<String, String> tags, MetricType type);
 
-    Observable<Optional<Map<String, String>>> getMetricTags(String tenantId, MetricType type, MetricId id);
+    Observable<Optional<Map<String, String>>> getMetricTags(MetricId id);
 
     Observable<Void> addTags(Metric metric, Map<String, String> tags);
 
@@ -109,19 +109,17 @@ public interface MetricsService {
     /**
      * Fetches data points for a gauge metric.
      *
-     * @param tenantId The tenant to which the metric belongs
      * @param id The metric name
      * @param start The start time inclusive as  aUnix timestamp in milliseconds
      * @param end The end time exclusive as a Unix timestamp in milliseconds
      * @return an {@link Observable} that emits {@link DataPoint data points}
      */
-    Observable<DataPoint<Double>> findGaugeData(String tenantId, MetricId id, Long start, Long end);
+    Observable<DataPoint<Double>> findGaugeData(MetricId id, Long start, Long end);
 
     /**
      * This method applies one or more functions to an Observable that emits data points of a gauge metric. The data
      * points Observable is asynchronous. The functions however, are applied serially in the order specified.
      *
-     * @param tenantId The tenant to which the metric belongs
      * @param id The metric name
      * @param start The start time inclusive as a Unix timestamp in milliseconds
      * @param end The end time exclusive as a Unix timestamp in milliseconds
@@ -129,18 +127,18 @@ public interface MetricsService {
      * @return An {@link Observable} that emits the results with the same ordering as funcs
      * @see Aggregate
      */
-    <T> Observable<T> findGaugeData(String tenantId, MetricId id, Long start, Long end,
-            Func1<Observable<DataPoint<Double>>, Observable<T>>... funcs);
+    <T> Observable<T> findGaugeData(MetricId id, Long start, Long end,
+                                    Func1<Observable<DataPoint<Double>>, Observable<T>>... funcs);
 
     Observable<BucketedOutput<GaugeBucketDataPoint>> findGaugeStats(Metric<Double> metric, long start, long end,
             Buckets buckets);
 
     Observable<Void> addAvailabilityData(Observable<Metric<AvailabilityType>> availabilities);
 
-    Observable<DataPoint<AvailabilityType>> findAvailabilityData(String tenantId, MetricId id, long start, long end);
+    Observable<DataPoint<AvailabilityType>> findAvailabilityData(MetricId id, long start, long end);
 
-    Observable<DataPoint<AvailabilityType>> findAvailabilityData(String tenantId, MetricId id, long start, long end,
-            boolean distinct);
+    Observable<DataPoint<AvailabilityType>> findAvailabilityData(MetricId id, long start, long end,
+                                                                 boolean distinct);
 
     Observable<BucketedOutput<AvailabilityBucketDataPoint>> findAvailabilityStats(Metric<AvailabilityType> metric,
             long start, long end, Buckets buckets);
@@ -164,13 +162,12 @@ public interface MetricsService {
 
     Observable<Void> addCounterData(Observable<Metric<Long>> counters);
 
-    Observable<DataPoint<Long>> findCounterData(String tenantId, MetricId id, long start, long end);
+    Observable<DataPoint<Long>> findCounterData(MetricId id, long start, long end);
 
     /**
      * Fetches counter rate data points which are automatically generated for counter metrics. Note that rate data is
      * generated only if the metric has been explicitly created via the {@link #createMetric(Metric)} method.
      *
-     * @param tenantId The teant to which the metric belongs
      * @param id This is the id of the counter metric
      * @param start The start time which is inclusive
      * @param end The end time which is exclusive
@@ -178,7 +175,7 @@ public interface MetricsService {
      * @return An Observable of {@link DataPoint data points} which are emitted in descending order. In other words,
      * the most recent data is emitted first.
      */
-    Observable<DataPoint<Double>> findRateData(String tenantId, MetricId id, long start, long end);
+    Observable<DataPoint<Double>> findRateData(MetricId id, long start, long end);
 
     /**
      * <p>
@@ -196,7 +193,6 @@ public interface MetricsService {
      * {start: 2, end: 3}, {start: 5, end: 5}, {start: 7, end: 7}
      * </p>
      *
-     * @param tenantId
      * @param id
      * @param predicate A function applied to the value of each data point
      * @param start The start time inclusive
@@ -204,6 +200,6 @@ public interface MetricsService {
      * @return Each element in the list is a two element array. The first element is the start time inclusive for which
      * the predicate matches, and the second element is the end time inclusive for which the predicate matches.
      */
-    Observable<List<long[]>> getPeriods(String tenantId, MetricId id, Predicate<Double> predicate, long start,
-            long end);
+    Observable<List<long[]>> getPeriods(MetricId id, Predicate<Double> predicate, long start,
+                                        long end);
 }

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
@@ -46,11 +46,11 @@ public interface DataAccess {
 
     ResultSetFuture insertMetricInMetricsIndex(Metric metric);
 
-    Observable<ResultSet> findMetric(String tenantId, MetricType type, MetricId id);
+    Observable<ResultSet> findMetric(MetricId id);
 
     Observable<ResultSet> addTagsAndDataRetention(Metric metric);
 
-    Observable<ResultSet> getMetricTags(String tenantId, MetricType type, MetricId id, long dpart);
+    Observable<ResultSet> getMetricTags(MetricId id, long dpart);
 
     Observable<ResultSet> addTags(Metric metric, Map<String, String> tags);
 
@@ -69,13 +69,13 @@ public interface DataAccess {
 
     Observable<Integer> insertCounterData(Metric<Long> counter, int ttl);
 
-    Observable<ResultSet> findCounterData(String tenantId, MetricId id, long startTime, long endTime);
+    Observable<ResultSet> findCounterData(MetricId id, long startTime, long endTime);
 
-    Observable<ResultSet> findData(String tenantId, MetricId id, MetricType type, long startTime, long endTime);
+    Observable<ResultSet> findData(MetricId id, long startTime, long endTime);
 
     Observable<ResultSet> findData(Metric<Double> metric, long startTime, long endTime, Order order);
 
-    Observable<ResultSet> findData(String tenantId, MetricId id, MetricType type, long startTime, long endTime,
+    Observable<ResultSet> findData(MetricId id, long startTime, long endTime,
             boolean includeWriteTime);
 
     Observable<ResultSet> findData(Metric<Double> metric, long timestamp, boolean includeWriteTime);
@@ -105,7 +105,7 @@ public interface DataAccess {
 
     Observable<Integer> insertAvailabilityData(Metric<AvailabilityType> metric, int ttl);
 
-    Observable<ResultSet> findAvailabilityData(String tenantId, MetricId id, long startTime, long endTime);
+    Observable<ResultSet> findAvailabilityData(MetricId id, long startTime, long endTime);
 
     ResultSetFuture findDataRetentions(String tenantId, MetricType type);
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccessImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccessImpl.java
@@ -382,14 +382,15 @@ public class DataAccessImpl implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> findMetric(String tenantId, MetricType type, MetricId id) {
-        return rxSession.execute(findMetric.bind(tenantId, type.getCode(), id.getName(), id.getInterval().toString()));
+    public Observable<ResultSet> findMetric(MetricId id) {
+        return rxSession.execute(findMetric.bind(id.getTenantId(), id.getType().getCode(), id.getName(),
+                                                 id.getInterval().toString()));
     }
 
     @Override
-    public Observable<ResultSet> getMetricTags(String tenantId, MetricType type, MetricId id, long dpart) {
-        return rxSession.execute(getMetricTags.bind(tenantId, type.getCode(), id.getName(), id.getInterval()
-                .toString(), dpart));
+    public Observable<ResultSet> getMetricTags(MetricId id, long dpart) {
+        return rxSession.execute(getMetricTags.bind(id.getTenantId(), id.getType().getCode(), id.getName(),
+                                                    id.getInterval().toString(), dpart));
     }
 
     // This method updates the metric tags and data retention in the data table. In the
@@ -483,13 +484,13 @@ public class DataAccessImpl implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> findData(String tenantId, MetricId id, MetricType type, long startTime, long endTime) {
-        return findData(tenantId, id, type, startTime, endTime, false);
+    public Observable<ResultSet> findData(MetricId id, long startTime, long endTime) {
+        return findData(id, startTime, endTime, false);
     }
 
     @Override
-    public Observable<ResultSet> findCounterData(String tenantId, MetricId id, long startTime, long endTime) {
-        return rxSession.execute(findCounterDataExclusive.bind(tenantId, COUNTER.getCode(), id.getName(),
+    public Observable<ResultSet> findCounterData(MetricId id, long startTime, long endTime) {
+        return rxSession.execute(findCounterDataExclusive.bind(id.getTenantId(), COUNTER.getCode(), id.getName(),
                 id.getInterval().toString(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
     }
 
@@ -508,15 +509,16 @@ public class DataAccessImpl implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> findData(String tenantId, MetricId id, MetricType type, long startTime, long endTime,
+    public Observable<ResultSet> findData(MetricId id, long startTime, long endTime,
             boolean includeWriteTime) {
         if (includeWriteTime) {
-            return rxSession.execute(findGaugeDataWithWriteTimeByDateRangeExclusive.bind(tenantId, type.getCode(),
-                    id.getName(),
+            return rxSession.execute(findGaugeDataWithWriteTimeByDateRangeExclusive.bind(id.getTenantId(),
+                    id.getType().getCode(), id.getName(),
                     id.getInterval().toString(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
         } else {
-            return rxSession.execute(findGaugeDataByDateRangeExclusive.bind(tenantId, type.getCode(), id.getName(),
-                    id.getInterval().toString(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+            return rxSession.execute(findGaugeDataByDateRangeExclusive.bind(id.getTenantId(),
+                                     id.getType().getCode(), id.getName(),
+                                     id.getInterval().toString(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
         }
     }
 
@@ -634,9 +636,9 @@ public class DataAccessImpl implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> findAvailabilityData(String tenantId, MetricId id, long startTime, long endTime) {
-        return rxSession.execute(findAvailabilities.bind(tenantId, MetricType.AVAILABILITY.getCode(), id.getName(), id
-                .getInterval().toString(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+    public Observable<ResultSet> findAvailabilityData(MetricId id, long startTime, long endTime) {
+        return rxSession.execute(findAvailabilities.bind(id.getTenantId(), MetricType.AVAILABILITY.getCode(),
+               id.getName(), id.getInterval().toString(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
     }
 
     @Override

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataRetentionsMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataRetentionsMapper.java
@@ -25,6 +25,7 @@ import com.google.common.base.Function;
 
 import org.hawkular.metrics.core.api.Interval;
 import org.hawkular.metrics.core.api.MetricId;
+import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.Retention;
 
 /**
@@ -32,11 +33,20 @@ import org.hawkular.metrics.core.api.Retention;
  */
 public class DataRetentionsMapper implements Function<ResultSet, Set<Retention>> {
 
+    private final String tenantId;
+    private final MetricType type;
+
+    public DataRetentionsMapper(final String tenantId, final MetricType type) {
+        this.tenantId = tenantId;
+        this.type = type;
+    }
+
     @Override
     public Set<Retention> apply(ResultSet resultSet) {
         Set<Retention> dataRetentions = new HashSet<>();
         for (Row row : resultSet) {
-            dataRetentions.add(new Retention(new MetricId(row.getString(3), Interval.parse(row.getString(2))),
+            dataRetentions.add(new Retention(new MetricId(tenantId, type, row.getString(3), Interval.parse(row.getString
+                    (2))),
                 row.getInt(4)));
         }
         return dataRetentions;

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GenerateRate.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GenerateRate.java
@@ -54,8 +54,7 @@ public class GenerateRate implements Action1<Task> {
         metricsService.findCounterData(id, start, end)
                 .take(1)
                 .map(dataPoint -> dataPoint.getValue().doubleValue() / (end - start) * 1000)
-                .map(rate -> new Metric<>(id,
-                        singletonList(new DataPoint<>(start, rate))))
+                .map(rate -> new Metric<>(id, singletonList(new DataPoint<>(start, rate))))
                 .flatMap(metric -> metricsService.addGaugeData(Observable.just(metric)))
                 .subscribe(
                         aVoid -> {

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GenerateRate.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/GenerateRate.java
@@ -48,13 +48,13 @@ public class GenerateRate implements Action1<Task> {
     @Override
     public void call(Task task) {
         logger.info("Generating rate for {}", task);
-        MetricId id = new MetricId(task.getSources().iterator().next());
+        MetricId id = new MetricId(task.getTenantId(), COUNTER_RATE, task.getSources().iterator().next());
         long start = task.getTimeSlice().getMillis();
         long end = task.getTimeSlice().plus(getDuration(task.getWindow())).getMillis();
-        metricsService.findCounterData(task.getTenantId(), id, start, end)
+        metricsService.findCounterData(id, start, end)
                 .take(1)
                 .map(dataPoint -> dataPoint.getValue().doubleValue() / (end - start) * 1000)
-                .map(rate -> new Metric<>(task.getTenantId(), COUNTER_RATE, id,
+                .map(rate -> new Metric<>(id,
                         singletonList(new DataPoint<>(start, rate))))
                 .flatMap(metric -> metricsService.addGaugeData(Observable.just(metric)))
                 .subscribe(

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
@@ -18,6 +18,7 @@ package org.hawkular.metrics.core.impl;
 
 import static java.util.Comparator.comparingLong;
 
+import static org.hawkular.metrics.core.api.MetricType.AVAILABILITY;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER_RATE;
 import static org.hawkular.metrics.core.api.MetricType.GAUGE;
@@ -97,26 +98,18 @@ public class MetricsServiceImpl implements MetricsService {
     public static final int DEFAULT_TTL = Duration.standardDays(7).toStandardSeconds().getSeconds();
 
     private static class DataRetentionKey {
-        private final String tenantId;
         private final MetricId metricId;
-        private final MetricType type;
 
         public DataRetentionKey(String tenantId, MetricType type) {
-            this.tenantId = tenantId;
-            this.type = type;
-            metricId = new MetricId("[" + type.getText() + "]");
+            metricId = new MetricId(tenantId, type, "[" + type.getText() + "]");
         }
 
-        public DataRetentionKey(String tenantId, MetricId metricId, MetricType type) {
-            this.tenantId = tenantId;
+        public DataRetentionKey(MetricId metricId) {
             this.metricId = metricId;
-            this.type = type;
         }
 
         public DataRetentionKey(Metric metric) {
-            this.tenantId = metric.getTenantId();
             this.metricId = metric.getId();
-            this.type = metric.getType();
         }
 
         @Override
@@ -126,18 +119,12 @@ public class MetricsServiceImpl implements MetricsService {
 
             DataRetentionKey that = (DataRetentionKey) o;
 
-            if (!metricId.equals(that.metricId)) return false;
-            if (!tenantId.equals(that.tenantId)) return false;
-            return type == that.type;
-
+            return metricId.equals(that.metricId);
         }
 
         @Override
         public int hashCode() {
-            int result = tenantId.hashCode();
-            result = 31 * result + metricId.hashCode();
-            result = 31 * result + type.hashCode();
-            return result;
+            return metricId.hashCode();
         }
     }
 
@@ -209,14 +196,16 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     void loadDataRetentions() {
-        DataRetentionsMapper mapper = new DataRetentionsMapper();
         List<String> tenantIds = loadTenantIds();
         CountDownLatch latch = new CountDownLatch(tenantIds.size() * 2);
         for (String tenantId : tenantIds) {
+            DataRetentionsMapper gaugeMapper = new DataRetentionsMapper(tenantId, GAUGE);
+            DataRetentionsMapper availMapper = new DataRetentionsMapper(tenantId, AVAILABILITY);
             ResultSetFuture gaugeFuture = dataAccess.findDataRetentions(tenantId, GAUGE);
             ResultSetFuture availabilityFuture = dataAccess.findDataRetentions(tenantId, MetricType.AVAILABILITY);
-            ListenableFuture<Set<Retention>> gaugeRetentions = Futures.transform(gaugeFuture, mapper, metricsTasks);
-            ListenableFuture<Set<Retention>> availabilityRetentions = Futures.transform(availabilityFuture, mapper,
+            ListenableFuture<Set<Retention>> gaugeRetentions = Futures.transform(gaugeFuture, gaugeMapper,
+                                                                                 metricsTasks);
+            ListenableFuture<Set<Retention>> availabilityRetentions = Futures.transform(availabilityFuture, availMapper,
                     metricsTasks);
             Futures.addCallback(gaugeRetentions,
                     new DataRetentionsLoadedCallback(tenantId, GAUGE, latch));
@@ -290,7 +279,7 @@ public class MetricsServiceImpl implements MetricsService {
         @Override
         public void onSuccess(Set<Retention> dataRetentionsSet) {
             for (Retention r : dataRetentionsSet) {
-                dataRetentions.put(new DataRetentionKey(tenantId, r.getId(), type), r.getValue());
+                dataRetentions.put(new DataRetentionKey(r.getId()), r.getValue());
             }
             latch.countDown();
         }
@@ -324,59 +313,62 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     public Observable<Void> createTenant(final Tenant tenant) {
-        return dataAccess.insertTenant(tenant).flatMap(
-                resultSet -> {
-                    if (!resultSet.wasApplied()) {
-                        throw new TenantAlreadyExistsException(tenant.getId());
-                    }
-                    Map<MetricType, Set<Retention>> retentionsMap = new HashMap<>();
-                    for (RetentionSettings.RetentionKey key : tenant.getRetentionSettings().keySet()) {
-                        Set<Retention> retentions = retentionsMap.get(key.metricType);
-                        if (retentions == null) {
-                            retentions = new HashSet<>();
-                        }
-                        Interval interval = key.interval == null ? Interval.NONE : key.interval;
-                        Hours hours = hours(tenant.getRetentionSettings().get(key));
-                        retentions.add(
-                                new Retention(
-                                        new MetricId("[" + key.metricType.getText() + "]", interval),
-                                        hours.toStandardSeconds().getSeconds()
-                                )
-                        );
-                        retentionsMap.put(key.metricType, retentions);
-                    }
-                    if (retentionsMap.isEmpty()) {
-                        return Observable.from(Collections.singleton(null));
-                    }
-                    List<ResultSetFuture> updateRetentionFutures = new ArrayList<>();
+        return dataAccess.insertTenant(tenant)
+//                .filter(ResultSet::wasApplied)
+                .flatMap(
+                        resultSet -> {
+                            if (!resultSet.wasApplied()) {
+                                throw new TenantAlreadyExistsException(tenant.getId());
+                            }
+                            Map<MetricType, Set<Retention>> retentionsMap = new HashMap<>();
+                            for (RetentionSettings.RetentionKey key : tenant.getRetentionSettings().keySet()) {
+                                Set<Retention> retentions = retentionsMap.get(key.metricType);
+                                if (retentions == null) {
+                                    retentions = new HashSet<>();
+                                }
+                                Interval interval = key.interval == null ? Interval.NONE : key.interval;
+                                Hours hours = hours(tenant.getRetentionSettings().get(key));
+                                retentions.add(
+                                        new Retention(
+                                                new MetricId(tenant.getId(), key.metricType,
+                                                             "[" + key.metricType.getText() + "]", interval),
+                                                hours.toStandardSeconds().getSeconds()
+                                        )
+                                );
+                                retentionsMap.put(key.metricType, retentions);
+                            }
+                            if (retentionsMap.isEmpty()) {
+                                return Observable.from(Collections.singleton(null));
+                            }
+                            List<ResultSetFuture> updateRetentionFutures = new ArrayList<>();
 
-                    for (Map.Entry<MetricType, Set<Retention>> metricTypeSetEntry : retentionsMap.entrySet()) {
-                        updateRetentionFutures.add(
-                                dataAccess.updateRetentionsIndex(
-                                        tenant.getId(),
-                                        metricTypeSetEntry.getKey(),
-                                        metricTypeSetEntry.getValue()
-                                )
-                        );
+                            for (Map.Entry<MetricType, Set<Retention>> metricTypeSetEntry : retentionsMap.entrySet()) {
+                                updateRetentionFutures.add(
+                                        dataAccess.updateRetentionsIndex(
+                                                tenant.getId(),
+                                                metricTypeSetEntry.getKey(),
+                                                metricTypeSetEntry.getValue()
+                                        )
+                                );
 
-                        for (Retention r : metricTypeSetEntry.getValue()) {
-                            dataRetentions.put(
-                                    new DataRetentionKey(tenant.getId(), metricTypeSetEntry.getKey()),
-                                    r.getValue()
+                                for (Retention r : metricTypeSetEntry.getValue()) {
+                                    dataRetentions.put(
+                                            new DataRetentionKey(tenant.getId(), metricTypeSetEntry.getKey()),
+                                            r.getValue()
+                                    );
+                                }
+                            }
+
+                            ListenableFuture<List<ResultSet>> updateRetentionsFuture = Futures
+                                    .allAsList(updateRetentionFutures);
+                            ListenableFuture<Void> transform = Futures.transform(
+                                    updateRetentionsFuture,
+                                    Functions.TO_VOID,
+                                    metricsTasks
                             );
+                            return RxUtil.from(transform, metricsTasks);
                         }
-                    }
-
-                    ListenableFuture<List<ResultSet>> updateRetentionsFuture = Futures
-                            .allAsList(updateRetentionFutures);
-                    ListenableFuture<Void> transform = Futures.transform(
-                            updateRetentionsFuture,
-                            Functions.TO_VOID,
-                            metricsTasks
-                    );
-                    return RxUtil.from(transform, metricsTasks);
-                }
-        );
+                );
     }
 
     @Override
@@ -450,10 +442,10 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    public Observable<Metric> findMetric(final String tenantId, final MetricType type, final MetricId id) {
-        return dataAccess.findMetric(tenantId, type, id)
+    public Observable<Metric> findMetric(final MetricId id) {
+        return dataAccess.findMetric(id)
                 .flatMap(Observable::from)
-                .map(row -> new Metric(tenantId, type, id, row.getMap(2, String.class, String.class),
+                .map(row -> new Metric(id, row.getMap(2, String.class, String.class),
                         row.getInt(3)));
     }
 
@@ -464,7 +456,7 @@ public class MetricsServiceImpl implements MetricsService {
 
         return typeObservable.flatMap(t -> dataAccess.findMetricsInMetricsIndex(tenantId, t))
                 .flatMap(Observable::from)
-                .map(row -> new Metric(tenantId, type, new MetricId(row.getString(0), Interval.parse(row.getString(1))),
+                .map(row -> new Metric(new MetricId(tenantId, type, row.getString(0), Interval.parse(row.getString(1))),
                         row.getMap(2, String.class, String.class), row.getInt(3)));
     }
 
@@ -475,13 +467,13 @@ public class MetricsServiceImpl implements MetricsService {
                 .filter(r -> (type == null && MetricType.userTypes().contains(MetricType.fromCode(r.getInt(0))))
                         || MetricType.fromCode(r.getInt(0)) == type)
                 .distinct(r -> Integer.valueOf(r.getInt(0)).toString() + r.getString(1) + r.getString(2))
-                .flatMap(r -> findMetric(tenantId, MetricType.fromCode(r.getInt(0)), new MetricId(r.getString
-                        (1), Interval.parse(r.getString(2)))));
+                .flatMap(r -> findMetric(new MetricId(tenantId, MetricType.fromCode(r.getInt(0)), r.getString
+                        (1), Interval.parse(r.getString(2))))); // We'll need to fetch type here from the Cassandra..
     }
 
     @Override
-    public Observable<Optional<Map<String, String>>> getMetricTags(String tenantId, MetricType type, MetricId id) {
-        Observable<ResultSet> metricTags = dataAccess.getMetricTags(tenantId, type, id, DataAccessImpl.DPART);
+    public Observable<Optional<Map<String, String>>> getMetricTags(MetricId id) {
+        Observable<ResultSet> metricTags = dataAccess.getMetricTags(id, DataAccessImpl.DPART);
 
         return metricTags.flatMap(Observable::from).take(1).map(row -> Optional.of(row.getMap(0, String.class, String
                 .class)))
@@ -578,37 +570,37 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    public Observable<DataPoint<Long>> findCounterData(String tenantId, MetricId id, long start, long end) {
+    public Observable<DataPoint<Long>> findCounterData(MetricId id, long start, long end) {
         return time(counterReadLatency, () ->
-                dataAccess.findCounterData(tenantId, id, start, end)
+                dataAccess.findCounterData(id, start, end)
                         .flatMap(Observable::from)
                         .map(Functions::getCounterDataPoint));
     }
 
     @Override
-    public Observable<DataPoint<Double>> findRateData(String tenantId, MetricId id, long start, long end) {
+    public Observable<DataPoint<Double>> findRateData(MetricId id, long start, long end) {
         return time(gaugeReadLatency, () ->
-                dataAccess.findData(tenantId, id, COUNTER_RATE, start, end)
+                dataAccess.findData(id, start, end)
                         .flatMap(Observable::from)
                         .map(Functions::getGaugeDataPoint));
     }
 
     @Override
-    public Observable<DataPoint<Double>> findGaugeData(String tenantId, MetricId id, Long start, Long end) {
+    public Observable<DataPoint<Double>> findGaugeData(MetricId id, Long start, Long end) {
         // When we implement date partitioning, dpart will have to be determined based on
         // the start and end params. And it is possible the the date range spans multiple
         // date partitions.
         return time(gaugeReadLatency, () ->
-            dataAccess.findData(tenantId, id, GAUGE, start, end)
+            dataAccess.findData(id, start, end)
                     .flatMap(Observable::from)
                     .map(Functions::getGaugeDataPoint));
     }
 
     @Override
-    public <T> Observable<T> findGaugeData(String tenantId, MetricId id, Long start, Long end,
-            Func1<Observable<DataPoint<Double>>, Observable<T>>... funcs) {
+    public <T> Observable<T> findGaugeData(MetricId id, Long start, Long end,
+                                           Func1<Observable<DataPoint<Double>>, Observable<T>>... funcs) {
 
-        Observable<DataPoint<Double>> dataCache = findGaugeData(tenantId, id, start, end).cache();
+        Observable<DataPoint<Double>> dataCache = findGaugeData(id, start, end).cache();
         return Observable.from(funcs).flatMap(fn -> fn.call(dataCache));
     }
 
@@ -619,7 +611,7 @@ public class MetricsServiceImpl implements MetricsService {
         // When we implement date partitioning, dpart will have to be determined based on
         // the start and end params. And it is possible the the date range spans multiple
         // date partitions.
-        return dataAccess.findData(metric.getTenantId(), metric.getId(), GAUGE, start, end)
+        return dataAccess.findData(metric.getId(), start, end)
                 .flatMap(Observable::from)
                 .map(Functions::getGaugeDataPoint)
                 .toList()
@@ -627,16 +619,16 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    public Observable<DataPoint<AvailabilityType>> findAvailabilityData(String tenantId, MetricId id, long start,
-            long end) {
-        return findAvailabilityData(tenantId, id, start, end, false);
+    public Observable<DataPoint<AvailabilityType>> findAvailabilityData(MetricId id, long start,
+                                                                        long end) {
+        return findAvailabilityData(id, start, end, false);
     }
 
     @Override
-    public Observable<DataPoint<AvailabilityType>> findAvailabilityData(String tenantId, MetricId id, long start,
-            long end, boolean distinct) {
+    public Observable<DataPoint<AvailabilityType>> findAvailabilityData(MetricId id, long start,
+                                                                        long end, boolean distinct) {
         return time(availabilityReadLatency, () -> {
-            Observable<DataPoint<AvailabilityType>> availabilityData = dataAccess.findAvailabilityData(tenantId, id,
+            Observable<DataPoint<AvailabilityType>> availabilityData = dataAccess.findAvailabilityData(id,
                     start, end)
                     .flatMap(Observable::from)
                     .map(Functions::getAvailabilityDataPoint);
@@ -651,7 +643,7 @@ public class MetricsServiceImpl implements MetricsService {
     @Override
     public Observable<BucketedOutput<AvailabilityBucketDataPoint>> findAvailabilityStats(
             Metric<AvailabilityType> metric, long start, long end, Buckets buckets) {
-        return dataAccess.findAvailabilityData(metric.getTenantId(), metric.getId(), start, end)
+        return dataAccess.findAvailabilityData(metric.getId(), start, end)
                 .flatMap(Observable::from)
                 .map(Functions::getAvailabilityDataPoint)
                 .toList()
@@ -674,8 +666,7 @@ public class MetricsServiceImpl implements MetricsService {
     // metrics since they could efficiently be inserted in a single batch statement.
     public Observable<Void> tagGaugeData(Metric<Double> metric, final Map<String, String> tags, long start,
             long end) {
-        Observable<ResultSet> findDataObservable = dataAccess.findData(metric.getTenantId(), metric.getId(), GAUGE,
-                start, end, true);
+        Observable<ResultSet> findDataObservable = dataAccess.findData(metric.getId(), start, end, true);
         return tagGaugeData(findDataObservable, tags, metric);
     }
 
@@ -756,9 +747,9 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    public Observable<List<long[]>> getPeriods(String tenantId, MetricId id, Predicate<Double> predicate,
+    public Observable<List<long[]>> getPeriods(MetricId id, Predicate<Double> predicate,
                                                long start, long end) {
-        return dataAccess.findData(new Metric<>(tenantId, GAUGE, id), start, end,
+        return dataAccess.findData(new Metric<>(id), start, end,
                 Order.ASC)
                 .flatMap(Observable::from)
                 .map(Functions::getGaugeDataPoint)
@@ -789,7 +780,7 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     private int getTTL(Metric metric) {
-        Integer ttl = dataRetentions.get(new DataRetentionKey(metric.getTenantId(), metric.getId(), metric.getType()));
+        Integer ttl = dataRetentions.get(new DataRetentionKey(metric.getId()));
         if (ttl == null) {
             ttl = dataRetentions.get(new DataRetentionKey(metric.getTenantId(), metric.getType()));
             if (ttl == null) {

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
@@ -579,8 +579,9 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     public Observable<DataPoint<Double>> findRateData(MetricId id, long start, long end) {
+        MetricId rateId = new MetricId(id.getTenantId(), COUNTER_RATE, id.getName(), id.getInterval());
         return time(gaugeReadLatency, () ->
-                dataAccess.findData(id, start, end)
+                dataAccess.findData(rateId, start, end)
                         .flatMap(Observable::from)
                         .map(Functions::getGaugeDataPoint));
     }

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/TaggedAvailabilityDataPointMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/TaggedAvailabilityDataPointMapper.java
@@ -65,7 +65,7 @@ public class TaggedAvailabilityDataPointMapper {
     }
 
     private static Metric<AvailabilityType> createMetric(Row row) {
-        return new Metric<>(row.getString(0), AVAILABILITY, new MetricId(row.getString(4),
+        return new Metric<>(new MetricId(row.getString(0), AVAILABILITY, row.getString(4),
                 Interval.parse(row.getString(5))));
     }
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/TaggedGaugeDataPointMapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/TaggedGaugeDataPointMapper.java
@@ -63,7 +63,7 @@ public class TaggedGaugeDataPointMapper {
     }
 
     private static Metric<Double> createMetric(Row row) {
-        return new Metric<>(row.getString(0), MetricType.GAUGE, new MetricId(row.getString(4),
+        return new Metric<>(new MetricId(row.getString(0), MetricType.GAUGE, row.getString(4),
                 Interval.parse(row.getString(5))));
     }
 

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DataAccessITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DataAccessITest.java
@@ -118,7 +118,7 @@ public class DataAccessITest extends MetricsITest {
         DateTime start = now().minusMinutes(10);
         DateTime end = start.plusMinutes(6);
 
-        Metric<Double> metric = new Metric<>("tenant-1", GAUGE, new MetricId("metric-1"), asList(
+        Metric<Double> metric = new Metric<>(new MetricId("tenant-1", GAUGE, "metric-1"), asList(
                 new DataPoint<>(start.getMillis(), 1.23),
                 new DataPoint<>(start.plusMinutes(1).getMillis(), 1.234),
                 new DataPoint<>(start.plusMinutes(2).getMillis(), 1.234),
@@ -127,7 +127,7 @@ public class DataAccessITest extends MetricsITest {
 
         dataAccess.insertData(metric, DEFAULT_TTL).toBlocking().last();
 
-        Observable<ResultSet> observable = dataAccess.findData("tenant-1", new MetricId("metric-1"), GAUGE,
+        Observable<ResultSet> observable = dataAccess.findData(new MetricId("tenant-1", GAUGE, "metric-1"),
                 start.getMillis(), end.getMillis());
         List<DataPoint<Double>> actual = ImmutableList.copyOf(observable
                 .flatMap(Observable::from)
@@ -150,12 +150,12 @@ public class DataAccessITest extends MetricsITest {
         DateTime end = start.plusMinutes(6);
         String tenantId = "tenant-1";
 
-        Metric<Double> metric = new Metric<>(tenantId, GAUGE, new MetricId("metric-1"),
+        Metric<Double> metric = new Metric<>(new MetricId(tenantId, GAUGE, "metric-1"),
                 ImmutableMap.of("units", "KB", "env", "test"), DEFAULT_TTL);
 
         dataAccess.addTagsAndDataRetention(metric).toBlocking().last();
 
-        metric = new Metric<>(tenantId, GAUGE, new MetricId("metric-1"), asList(
+        metric = new Metric<>(new MetricId(tenantId, GAUGE, "metric-1"), asList(
                 new DataPoint<>(start.getMillis(), 1.23),
                 new DataPoint<>(start.plusMinutes(2).getMillis(), 1.234),
                 new DataPoint<>(start.plusMinutes(4).getMillis(), 1.234),
@@ -164,7 +164,7 @@ public class DataAccessITest extends MetricsITest {
 
         dataAccess.insertData(metric, DEFAULT_TTL).toBlocking().last();
 
-        Observable<ResultSet> observable = dataAccess.findData("tenant-1", new MetricId("metric-1"), GAUGE,
+        Observable<ResultSet> observable = dataAccess.findData(new MetricId("tenant-1", GAUGE, "metric-1"),
                 start.getMillis(), end.getMillis());
         List<DataPoint<Double>> actual = ImmutableList.copyOf(observable
                 .flatMap(Observable::from)
@@ -186,13 +186,13 @@ public class DataAccessITest extends MetricsITest {
         DateTime start = now().minusMinutes(10);
         DateTime end = start.plusMinutes(6);
         String tenantId = "avail-test";
-        Metric<AvailabilityType> metric = new Metric<>(tenantId, AVAILABILITY, new MetricId("m1"),
+        Metric<AvailabilityType> metric = new Metric<>(new MetricId(tenantId, AVAILABILITY, "m1"),
                 singletonList(new DataPoint<>(start.getMillis(), UP)));
 
         dataAccess.insertAvailabilityData(metric, 360).toBlocking().lastOrDefault(null);
 
         List<DataPoint<AvailabilityType>> actual = dataAccess
-            .findAvailabilityData(tenantId, new MetricId("m1"), start.getMillis(), end.getMillis())
+            .findAvailabilityData(new MetricId(tenantId, AVAILABILITY, "m1"), start.getMillis(), end.getMillis())
                 .flatMap(Observable::from)
                 .map(Functions::getAvailabilityDataPoint)
                 .toList().toBlocking().lastOrDefault(null);

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
@@ -66,13 +66,13 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> findMetric(String tenantId, MetricType type, MetricId id) {
-        return delegate.findMetric(tenantId, type, id);
+    public Observable<ResultSet> findMetric(MetricId id) {
+        return delegate.findMetric(id);
     }
 
     @Override
-    public Observable<ResultSet> getMetricTags(String tenantId, MetricType type, MetricId id, long dpart) {
-        return delegate.getMetricTags(tenantId, type, id, dpart);
+    public Observable<ResultSet> getMetricTags(MetricId id, long dpart) {
+        return delegate.getMetricTags(id, dpart);
     }
 
     @Override
@@ -122,13 +122,13 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> findCounterData(String tenantId, MetricId id, long startTime, long endTime) {
-        return delegate.findCounterData(tenantId, id, startTime, endTime);
+    public Observable<ResultSet> findCounterData(MetricId id, long startTime, long endTime) {
+        return delegate.findCounterData(id, startTime, endTime);
     }
 
     @Override
-    public Observable<ResultSet> findData(String tenantId, MetricId id, MetricType type, long startTime, long endTime) {
-        return delegate.findData(tenantId, id, type, startTime, endTime);
+    public Observable<ResultSet> findData(MetricId id, long startTime, long endTime) {
+        return delegate.findData(id, startTime, endTime);
     }
 
     @Override
@@ -138,9 +138,9 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> findData(String tenantId, MetricId id, MetricType type, long startTime, long endTime,
+    public Observable<ResultSet> findData(MetricId id, long startTime, long endTime,
             boolean includeWriteTime) {
-        return delegate.findData(tenantId, id, type, startTime, endTime, includeWriteTime);
+        return delegate.findData(id, startTime, endTime, includeWriteTime);
     }
 
     @Override
@@ -209,8 +209,8 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> findAvailabilityData(String tenantId, MetricId id, long startTime, long endTime) {
-        return delegate.findAvailabilityData(tenantId, id, startTime, endTime);
+    public Observable<ResultSet> findAvailabilityData(MetricId id, long startTime, long endTime) {
+        return delegate.findAvailabilityData(id, startTime, endTime);
     }
 
     @Override

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/RatesITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/RatesITest.java
@@ -93,12 +93,11 @@ public class RatesITest extends MetricsITest {
     @Test
     public void generateRates() throws Exception {
         String tenantId = "generate-rates-test";
-        MetricId id = new MetricId("c1");
+        MetricId id = new MetricId(tenantId, COUNTER, "c1");
         DateTime start = dateTimeService.getTimeSlice(now(), standardSeconds(5)).plusSeconds(5);
         DateTime end = start.plusSeconds(30);
 
-
-        Metric<Long> counter = new Metric<>(tenantId, COUNTER, id, asList(
+        Metric<Long> counter = new Metric<>(id, asList(
                 new DataPoint<>(start.plusMillis(50).getMillis(), 11L),
                 new DataPoint<>(start.plusSeconds(1).getMillis(), 17L),
                 new DataPoint<>(start.plusSeconds(11).getMillis(), 29L),
@@ -112,24 +111,24 @@ public class RatesITest extends MetricsITest {
             Thread.sleep(100);
         }
 
-        DataPoint<Double> actual = metricsService.findRateData(tenantId, id, start.getMillis(),
+        DataPoint<Double> actual = metricsService.findRateData(id, start.getMillis(),
                 start.plusSeconds(5).getMillis()).toBlocking().last();
         DataPoint<Double> expected = new DataPoint<>(start.getMillis(), calculateRate(17, start, start.plusSeconds(5)));
         assertEquals(actual, expected, "The rate for " + start + " does not match the expected value");
 
-        actual = metricsService.findRateData(tenantId, id, start.plusSeconds(10).getMillis(),
+        actual = metricsService.findRateData(id, start.plusSeconds(10).getMillis(),
                 start.plusSeconds(15).getMillis()).toBlocking().last();
         expected = new DataPoint<>(start.plusSeconds(10).getMillis(), calculateRate(29, start.plusSeconds(10),
                 start.plusSeconds(15)));
         assertEquals(actual, expected, "The rate for " + start.plusSeconds(10) + " does not match the expected value.");
 
-        actual = metricsService.findRateData(tenantId, id, start.plusSeconds(15).getMillis(),
+        actual = metricsService.findRateData(id, start.plusSeconds(15).getMillis(),
                 start.plusSeconds(20).getMillis()).toBlocking().last();
         expected = new DataPoint<>(start.plusSeconds(15).getMillis(), calculateRate(46, start.plusSeconds(15),
                 start.plusSeconds(20)));
         assertEquals(actual, expected, "The rate for " + start.plusSeconds(15) + " does not match the expected value.");
 
-        actual = metricsService.findRateData(tenantId, id, start.plusSeconds(20).getMillis(),
+        actual = metricsService.findRateData(id, start.plusSeconds(20).getMillis(),
                 start.plusSeconds(25).getMillis()).toBlocking().last();
         expected = new DataPoint<>(start.plusSeconds(20).getMillis(), calculateRate(69, start.plusSeconds(20),
                 start.plusSeconds(25)));


### PR DESCRIPTION
This PR moves the tenantId and MetricType definitions from Metric to MetricId. Metric's getTenantId()  and getType() are marked as deprecated and will return data from the assigned MetricId.