### PR TITLE
Don't throw the full stack trace as it is too noisy and not needed.

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -28,6 +28,11 @@ import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_U
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.TASK_SCHEDULER_TIME_UNITS;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.WAIT_FOR_SERVICE;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.Executors;
@@ -35,12 +40,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
 
 import com.codahale.metrics.MetricRegistry;
 import com.datastax.driver.core.Cluster;
@@ -174,7 +173,8 @@ public class MetricsServiceLifecycle {
             session = createSession();
         } catch (Exception t) {
             Throwable rootCause = Throwables.getRootCause(t);
-            LOG.warn("Could not connect to Cassandra cluster - assuming its not up yet", rootCause);
+            LOG.warn("Could not connect to Cassandra cluster - assuming its not up yet: ",
+                    rootCause.getLocalizedMessage());
             // cycle between original and more wait time - avoid waiting huge amounts of time
             long delay = 1L + ((connectionAttempts - 1L) % 4L);
             LOG.warn("[{}] Retrying connecting to Cassandra cluster in [{}]s...", connectionAttempts, delay);


### PR DESCRIPTION
When the system starts up, there are (expected) messages like below.
As they are sort of expected, the Stack trace does not add any value and is just noisy. We should not show it.

Note that the code has not been tested live.

11:50:52,798 WARN  [org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle] (metricsservice-lifecycle-thread) Could not connect to Cassandra cluster - assuming its not up yet: com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: /127.0.0.1:9042 (com.datastax.driver.core.TransportException: [/127.0.0.1:9042] Cannot connect))
	at com.datastax.driver.core.ControlConnection.reconnectInternal(ControlConnection.java:223)
	at com.datastax.driver.core.ControlConnection.connect(ControlConnection.java:78)
	at com.datastax.driver.core.Cluster$Manager.init(Cluster.java:1272)
	at com.datastax.driver.core.Cluster.init(Cluster.java:158)
	at com.datastax.driver.core.Cluster.connect(Cluster.java:248)
	at com.datastax.driver.core.Cluster.connect(Cluster.java:281)
	at org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle.createSession(MetricsServiceLifecycle.java:231)
	at org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle.startMetricsService(MetricsServiceLifecycle.java:168)
	at org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle$$Lambda$6/138776132.run(Unknown Source)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
