### PR TITLE
Don't throw the full stack trace as it is too noisy and not needed.

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -174,7 +174,8 @@ public class MetricsServiceLifecycle {
             session = createSession();
         } catch (Exception t) {
             Throwable rootCause = Throwables.getRootCause(t);
-            LOG.warn("Could not connect to Cassandra cluster - assuming its not up yet", rootCause);
+            LOG.warn("Could not connect to Cassandra cluster - assuming its not up yet: ",
+                    rootCause.getLocalizedMessage());
             // cycle between original and more wait time - avoid waiting huge amounts of time
             long delay = 1L + ((connectionAttempts - 1L) % 4L);
             LOG.warn("[{}] Retrying connecting to Cassandra cluster in [{}]s...", connectionAttempts, delay);


### PR DESCRIPTION
See #294 for more details.