### PR TITLE
rest-tests minor changes

### DIFF
--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/BaseITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/BaseITest.groovy
@@ -35,8 +35,6 @@ class BaseITest extends RESTTest {
     response = hawkularMetrics.get(path: "gauges/$metric/data", query: [start: start, end: end], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    println "response = $response.data"
-
     assertEquals(start + 10, response.data[0].timestamp)
   }
 }

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -42,13 +42,19 @@ class RESTTest {
     hawkularMetrics = new RESTClient("http://$baseURI/", ContentType.JSON)
     defaultFailureHandler = hawkularMetrics.handler.failure
     hawkularMetrics.handler.failure = { resp ->
+      def msg = "Got error response: ${resp.statusLine}"
       if (resp.entity != null && resp.entity.contentLength != 0) {
-        println "Got error response: ${resp.statusLine}"
         def baos = new ByteArrayOutputStream()
         resp.entity.writeTo(baos)
-        println new String(baos.toByteArray(), Charsets.UTF_8)
+        def entity = new String(baos.toByteArray(), Charsets.UTF_8)
+        msg = """${msg}
+=== Response body
+${entity}
+===
+"""
       }
-      defaultFailureHandler(resp)
+      System.err.println(msg)
+      return resp
     }
   }
 


### PR DESCRIPTION
The main change is in the RESTClient failure handler implementation.

There used to be a stranged exception thrown when an error response was unexpected.

Now the status line and body (if present) are printed, and tests methods assertions are executed (like assert response status == 200)
