### PR TITLE
make terminal event timeout in REST API tests configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 install:
 - mvn -version -B
 script:
-- mvn verify -Dwildfly.logging.console.level=INFO -Djboss-as.logging.console.level=INFO -B
+- mvn verify -Dwildfly.logging.console.level=INFO -Djboss-as.logging.console.level=INFO -Dterminal-event.timeout=25 -B
 after_failure: bash .travis.diagnose.sh
 after_success:
 - PROJECT_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/VirtualClockHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/VirtualClockHandler.java
@@ -95,8 +95,8 @@ public class VirtualClockHandler {
 
         try {
             virtualClock.advanceTimeBy(numMinutes, MINUTES);
-
-            timeSlicesSubscriber.awaitTerminalEvent(10, SECONDS);
+            long timeout = Long.parseLong(System.getProperty("hawkular.terminal-event.timeout", "10"));
+            timeSlicesSubscriber.awaitTerminalEvent(timeout, SECONDS);
             timeSlicesSubscriber.assertNoErrors();
             timeSlicesSubscriber.assertTerminalEvent();
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/VirtualClockHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/VirtualClockHandler.java
@@ -95,8 +95,8 @@ public class VirtualClockHandler {
 
         try {
             virtualClock.advanceTimeBy(numMinutes, MINUTES);
-
-            timeSlicesSubscriber.awaitTerminalEvent(10, SECONDS);
+            long timeout = Long.parseLong(System.getProperty("hawkular.terminal-event.timeout", "10"));
+            timeSlicesSubscriber.awaitTerminalEvent(timeout, SECONDS);
             timeSlicesSubscriber.assertNoErrors();
             timeSlicesSubscriber.assertTerminalEvent();
 

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -194,7 +194,7 @@
                     <javaOpt>-Dcassandra.resetdb</javaOpt>
                     <javaOpt>-Dhawkular.metrics.waitForService</javaOpt>
                     <javaOpt>-Dhawkular.metrics.use-virtual-clock=true</javaOpt>
-                    <javaOpt>-Dhawkular.scheduler.time-units=${scheduler.units}</javaOpt>
+                    <javaOpt>-Dhawkular.terminal-event.timeout=${terminal-event.timeout}</javaOpt>
                     <javaOpt>-Xdebug</javaOpt>
                     <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
                   </javaOpts>
@@ -241,6 +241,7 @@
         <wildfly.management.port>57887</wildfly.management.port>
         <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
         <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
+        <terminal-event.timeout>10</terminal-event.timeout>
       </properties>
       <build>
         <plugins>

--- a/tests/rest-integration-tests-jaxrs-1.1/pom.xml
+++ b/tests/rest-integration-tests-jaxrs-1.1/pom.xml
@@ -37,6 +37,7 @@
     <cassandra.keyspace>hawkular_metrics_rest_tests</cassandra.keyspace>
     <scheduler.units>seconds</scheduler.units>
     <enforcer.skip>true</enforcer.skip>
+    <terminal-event.timeout>10</terminal-event.timeout>
   </properties>
 
   <dependencies>
@@ -215,7 +216,7 @@
                     -Djboss.socket.binding.port-offset=${jboss-as.port.offset}
                     -Djboss.server.config.dir=${project.build.directory}/jboss-as-configuration
                     -Dcassandra.keyspace=${cassandra.keyspace} -Dcassandra.resetdb -Dhawkular.metrics.waitForService
-                    -Dhawkular.metrics.use-virtual-clock=true -Dhawkular.scheduler.time-units=${scheduler.units}
+                    -Dhawkular.metrics.use-virtual-clock=true -Dterminal-event.timeout=${terminal-event.timeout}
                     -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787
                   </jvmArgs>
                 </configuration>


### PR DESCRIPTION
Some REST API tests have been periodically failing on travis builds because of
the timeout value for TestSubscriber.awaitTerminalEvent() being too low in
VirtualClockHandler. This commit makes it configurable via a system property
and increases the timeout for travis builds to 25 seconds.