### PR TITLE
[HWKMETRICS-169] Remove superfluous header param from get availability…

### DIFF
--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import static org.hawkular.metrics.api.jaxrs.filter.TenantFilter.TENANT_HEADER_NAME;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.noContent;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToAvailabilities;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToAvailabilityDataPoints;
@@ -49,7 +50,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.hawkular.metrics.api.jaxrs.ApiError;
-import org.hawkular.metrics.api.jaxrs.filter.TenantFilter;
 import org.hawkular.metrics.api.jaxrs.model.Availability;
 import org.hawkular.metrics.api.jaxrs.model.AvailabilityDataPoint;
 import org.hawkular.metrics.api.jaxrs.param.Duration;
@@ -91,7 +91,7 @@ public class AvailabilityHandler {
     @Inject
     private MetricsService metricsService;
 
-    @HeaderParam(TenantFilter.TENANT_HEADER_NAME)
+    @HeaderParam(TENANT_HEADER_NAME)
     private String tenantId;
 
     @POST
@@ -132,7 +132,7 @@ public class AvailabilityHandler {
             @ApiResponse(code = 204, message = "Query was successful, but no metrics definition is set."),
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric's definition.",
                          response = ApiError.class) })
-    public Response getAvailabilityMetric(@HeaderParam("tenantId") String tenantId, @PathParam("id") String id) {
+    public Response getAvailabilityMetric(@PathParam("id") String id) {
         try {
             return metricsService.findMetric(new MetricId(tenantId, AVAILABILITY, id))
                 .map(MetricDefinition::new)

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -127,8 +127,7 @@ public class AvailabilityHandler {
             @ApiResponse(code = 204, message = "Query was successful, but no metrics definition is set."),
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric's definition.",
                          response = ApiError.class) })
-    public void getAvailabilityMetric(@Suspended final AsyncResponse asyncResponse,
-            @HeaderParam("tenantId") String tenantId, @PathParam("id") String id) {
+    public void getAvailabilityMetric(@Suspended final AsyncResponse asyncResponse, @PathParam("id") String id) {
 
         metricsService.findMetric(new MetricId(tenantId, AVAILABILITY, id))
                 .map(MetricDefinition::new)

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
@@ -16,9 +16,11 @@
  */
 package org.hawkular.metrics.rest
 
+import static org.joda.time.DateTime.now
 import static org.junit.Assert.assertEquals
 
 import org.hawkular.metrics.core.api.AvailabilityType
+import org.joda.time.DateTime
 import org.junit.Test
 
 /**
@@ -89,5 +91,21 @@ class AvailabilityITest extends RESTTest {
     def response = hawkularMetrics.post(path: "availability/test/data", headers: [(tenantHeaderName): tenantId],
         body: points)
     assertEquals(200, response.status)
+  }
+
+  @Test
+  void testAvailabilityGet() {
+    DateTime start = now().minusMinutes(20)
+    String tenantId = nextTenantId()
+    String metric = 'A1'
+
+    def response = hawkularMetrics.post(path: "availability/$metric/data", body: [
+        [timestamp: start.millis, value: "up"]], headers: [(tenantHeaderName): tenantId])
+
+    assertEquals(200, response.status)
+
+    response = hawkularMetrics.get(path: "availability/$metric", headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    assertEquals(metric, response.data.id)
   }
 }


### PR DESCRIPTION
… method. Also, added a test to make sure only the regular tenant header is required by the method.