### PR TITLE
[HWKMETRICS-233] Add REST-endpoint to creating any type metric definitions

### DIFF
--- a/api/diff.txt
+++ b/api/diff.txt
@@ -1426,3 +1426,4 @@ Only in api/metrics-api-jaxrs-1.1/src/main/webapp: status.js
 Only in api/metrics-api-jaxrs-1.1/src/main/webapp: welcome.css
 Only in api/metrics-api-jaxrs/src/main: xsl
 Only in api/metrics-api-jaxrs/src: test
+

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/MetricTypeTextConverter.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/MetricTypeTextConverter.java
@@ -24,6 +24,9 @@ import org.hawkular.metrics.core.api.MetricType;
  * @author Michael Burman
  */
 public class MetricTypeTextConverter {
+
+    private MetricTypeTextConverter() { }
+
     public static String getLongForm(MetricType<?> mt) {
 
         if(mt == MetricType.GAUGE) {

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/MetricTypeTextConverter.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/MetricTypeTextConverter.java
@@ -33,8 +33,10 @@ public class MetricTypeTextConverter {
             return "gauges";
         } else if(mt == MetricType.COUNTER) {
             return "counters";
-        } else {
+        } else if(mt == MetricType.AVAILABILITY) {
             return mt.getText();
+        } else {
+            throw new RuntimeException("Unsupported type " + mt.getText());
         }
     }
 }

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/MetricTypeTextConverter.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/MetricTypeTextConverter.java
@@ -19,8 +19,7 @@ package org.hawkular.metrics.api.jaxrs.util;
 import org.hawkular.metrics.core.api.MetricType;
 
 /**
- * Transforms from longForm of the metrics (such as gauges) used by the REST-interface to internal
- * shortForm and vice-versa
+ * Returns the longer path format used by the REST-interface from the given MetricType
  *
  * @author Michael Burman
  */

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/MetricTypeTextConverter.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/MetricTypeTextConverter.java
@@ -14,24 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.api.jaxrs.jackson;
+package org.hawkular.metrics.api.jaxrs.util;
 
-import java.io.IOException;
-
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
 import org.hawkular.metrics.core.api.MetricType;
 
-
 /**
+ * Transforms from longForm of the metrics (such as gauges) used by the REST-interface to internal
+ * shortForm and vice-versa
+ *
  * @author Michael Burman
  */
-public class MetricTypeDeserializer extends JsonDeserializer<MetricType<?>> {
+public class MetricTypeTextConverter {
+    public static String getLongForm(MetricType<?> mt) {
 
-    @Override public MetricType<?> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
-            throws IOException, JsonProcessingException {
-        return MetricType.fromTextCode(jsonParser.getText());
+        if(mt == MetricType.GAUGE) {
+            return "gauges";
+        } else if(mt == MetricType.COUNTER) {
+            return "counters";
+        } else {
+            return mt.getText();
+        }
     }
 }

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -63,6 +63,7 @@ import org.hawkular.metrics.core.api.Buckets;
 import org.hawkular.metrics.core.api.Metric;
 import org.hawkular.metrics.core.api.MetricAlreadyExistsException;
 import org.hawkular.metrics.core.api.MetricId;
+import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,19 +97,23 @@ public class AvailabilityHandler {
 
     @POST
     @Path("/")
-    @ApiOperation(value = "Create availability metric definition. Same notes as creating gauge metric apply.")
+    @ApiOperation(value = "Create availability metric. Same notes as creating gauge metric apply.")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Metric definition created successfully"),
+            @ApiResponse(code = 201, message = "Metric created successfully"),
             @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
             @ApiResponse(code = 409, message = "Availability metric with given id already exists",
                     response = ApiError.class),
-            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error",
+            @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
     public Response createAvailabilityMetric(
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
+        if(metricDefinition.getType() != null && MetricType.AVAILABILITY != metricDefinition.getType()) {
+            return ApiUtils.badRequest(new ApiError("MetricDefinition type does not match " + MetricType
+                    .AVAILABILITY.getText()));
+        }
         URI location = uriInfo.getBaseUriBuilder().path("/availability/{id}").build(metricDefinition.getId());
         Metric<AvailabilityType> metric = new Metric<>(new MetricId<>(tenantId, AVAILABILITY, metricDefinition.getId()),
                 metricDefinition.getTags(), metricDefinition.getDataRetention());

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -51,6 +51,7 @@ import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.api.Metric;
 import org.hawkular.metrics.core.api.MetricAlreadyExistsException;
 import org.hawkular.metrics.core.api.MetricId;
+import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,22 +88,26 @@ public class CounterHandler {
     @POST
     @Path("/")
     @ApiOperation(
-            value = "Create counter metric definition. This operation also causes the rate to be calculated and " +
+            value = "Create counter metric. This operation also causes the rate to be calculated and " +
                     "persisted periodically after raw count data is persisted.",
             notes = "Clients are not required to explicitly create a metric before storing data. Doing so however " +
                     "allows clients to prevent naming collisions and to specify tags and data retention.")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Metric definition created successfully"),
+            @ApiResponse(code = 201, message = "Metric created successfully"),
             @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
             @ApiResponse(code = 409, message = "Counter metric with given id already exists", response = ApiError
                     .class),
-            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error",
+            @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
     public Response createCounter(
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
+        if(metricDefinition.getType() != null && MetricType.COUNTER != metricDefinition.getType()) {
+            return ApiUtils.badRequest(new ApiError("MetricDefinition type does not match " + MetricType
+                    .COUNTER.getText()));
+        }
         Metric<Long> metric = new Metric<>(new MetricId<>(tenantId, COUNTER, metricDefinition.getId()),
                 metricDefinition.getTags(), metricDefinition.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/counters/{id}").build(metric.getId().getName());

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -59,6 +59,7 @@ import org.hawkular.metrics.core.api.Buckets;
 import org.hawkular.metrics.core.api.Metric;
 import org.hawkular.metrics.core.api.MetricAlreadyExistsException;
 import org.hawkular.metrics.core.api.MetricId;
+import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
 
 import com.wordnik.swagger.annotations.Api;
@@ -89,21 +90,25 @@ public class GaugeHandler {
     @POST
     @Produces(APPLICATION_JSON)
     @Path("/")
-    @ApiOperation(value = "Create gauge metric definition.", notes = "Clients are not required to explicitly create "
+    @ApiOperation(value = "Create gauge metric.", notes = "Clients are not required to explicitly create "
             + "a metric before storing data. Doing so however allows clients to prevent naming collisions and to "
             + "specify tags and data retention.")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Metric definition created successfully"),
+            @ApiResponse(code = 201, message = "Metric created successfully"),
             @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
             @ApiResponse(code = 409, message = "Gauge metric with given id already exists",
                     response = ApiError.class),
-            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error",
+            @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
     public Response createGaugeMetric(
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
+        if(metricDefinition.getType() != null && MetricType.GAUGE != metricDefinition.getType()) {
+            return ApiUtils.badRequest(new ApiError("MetricDefinition type does not match " + MetricType
+                    .GAUGE.getText()));
+        }
         Metric<Double> metric = new Metric<>(new MetricId<>(tenantId, GAUGE, metricDefinition.getId()),
                 metricDefinition.getTags(), metricDefinition.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/gauges/{id}").build(metric.getId().getName());

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -90,21 +90,24 @@ public class MetricHandler {
 
     @POST
     @Path("/")
-    @ApiOperation(value = "Create metric definition.", notes = "Clients are not required to explicitly create "
+    @ApiOperation(value = "Create metric.", notes = "Clients are not required to explicitly create "
             + "a metric before storing data. Doing so however allows clients to prevent naming collisions and to "
             + "specify tags and data retention.")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Metric definition created successfully"),
+            @ApiResponse(code = 201, message = "Metric created successfully"),
             @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
             @ApiResponse(code = 409, message = "Metric with given id already exists",
                     response = ApiError.class),
-            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error",
+            @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
     public Response createMetric(
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
+        if(metricDefinition.getType() == null || !metricDefinition.getType().isUserType()) {
+            return ApiUtils.badRequest(new ApiError("MetricDefinition type is invalid"));
+        }
         MetricId<?> id = new MetricId(tenantId, metricDefinition.getType(), metricDefinition.getId());
         Metric<?> metric = new Metric<>(id, metricDefinition.getTags(), metricDefinition.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/{type}/{id}").build(MetricTypeTextConverter.getLongForm(id

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -66,6 +66,7 @@ import org.hawkular.metrics.core.api.AvailabilityType;
 import org.hawkular.metrics.core.api.Buckets;
 import org.hawkular.metrics.core.api.Metric;
 import org.hawkular.metrics.core.api.MetricId;
+import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,6 +114,10 @@ public class AvailabilityHandler {
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
+        if(metricDefinition.getType() != null && metricDefinition.getType() != MetricType.AVAILABILITY) {
+            asyncResponse.resume(badRequest(new ApiError("MetricDefinition type does not match " + MetricType
+                    .AVAILABILITY.getText())));
+        }
         URI location = uriInfo.getBaseUriBuilder().path("/availability/{id}").build(metricDefinition.getId());
         Metric<AvailabilityType> metric = new Metric<>(new MetricId<>(tenantId, AVAILABILITY, metricDefinition.getId()),
                 metricDefinition.getTags(), metricDefinition.getDataRetention());

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -100,13 +100,13 @@ public class AvailabilityHandler {
 
     @POST
     @Path("/")
-    @ApiOperation(value = "Create availability metric definition. Same notes as creating gauge metric apply.")
+    @ApiOperation(value = "Create availability metric. Same notes as creating gauge metric apply.")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Metric definition created successfully"),
+            @ApiResponse(code = 201, message = "Metric created successfully"),
             @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
             @ApiResponse(code = 409, message = "Availability metric with given id already exists",
                     response = ApiError.class),
-            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error",
+            @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
     public void createAvailabilityMetric(
@@ -114,7 +114,7 @@ public class AvailabilityHandler {
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
-        if(metricDefinition.getType() != null && metricDefinition.getType() != MetricType.AVAILABILITY) {
+        if(metricDefinition.getType() != null && MetricType.AVAILABILITY != metricDefinition.getType()) {
             asyncResponse.resume(badRequest(new ApiError("MetricDefinition type does not match " + MetricType
                     .AVAILABILITY.getText())));
         }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import static org.hawkular.metrics.api.jaxrs.filter.TenantFilter.TENANT_HEADER_NAME;
+import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.badRequest;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToCounterDataPoints;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToCounters;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER;
@@ -54,6 +55,7 @@ import org.hawkular.metrics.api.jaxrs.request.MetricDefinition;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.api.Metric;
 import org.hawkular.metrics.core.api.MetricId;
+import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,6 +109,10 @@ public class CounterHandler {
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
+        if(metricDefinition.getType() != null && metricDefinition.getType() != MetricType.COUNTER) {
+            asyncResponse.resume(badRequest(new ApiError("MetricDefinition type does not match " + MetricType
+                    .COUNTER.getText())));
+        }
         Metric<Long> metric = new Metric<>(new MetricId<>(tenantId, COUNTER, metricDefinition.getId()),
                 metricDefinition.getTags(), metricDefinition.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/counters/{id}").build(metric.getId().getName());

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -92,16 +92,16 @@ public class CounterHandler {
     @POST
     @Path("/")
     @ApiOperation(
-            value = "Create counter metric definition. This operation also causes the rate to be calculated and " +
+            value = "Create counter metric. This operation also causes the rate to be calculated and " +
                     "persisted periodically after raw count data is persisted.",
             notes = "Clients are not required to explicitly create a metric before storing data. Doing so however " +
                     "allows clients to prevent naming collisions and to specify tags and data retention.")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Metric definition created successfully"),
+            @ApiResponse(code = 201, message = "Metric created successfully"),
             @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
             @ApiResponse(code = 409, message = "Counter metric with given id already exists", response = ApiError
                     .class),
-            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error",
+            @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
     public void createCounter(
@@ -109,7 +109,7 @@ public class CounterHandler {
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
-        if(metricDefinition.getType() != null && metricDefinition.getType() != MetricType.COUNTER) {
+        if(metricDefinition.getType() != null && MetricType.COUNTER != metricDefinition.getType()) {
             asyncResponse.resume(badRequest(new ApiError("MetricDefinition type does not match " + MetricType
                     .COUNTER.getText())));
         }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -92,15 +92,15 @@ public class GaugeHandler {
 
     @POST
     @Path("/")
-    @ApiOperation(value = "Create gauge metric definition.", notes = "Clients are not required to explicitly create "
+    @ApiOperation(value = "Create gauge metric.", notes = "Clients are not required to explicitly create "
             + "a metric before storing data. Doing so however allows clients to prevent naming collisions and to "
             + "specify tags and data retention.")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Metric definition created successfully"),
+            @ApiResponse(code = 201, message = "Metric created successfully"),
             @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
             @ApiResponse(code = 409, message = "Gauge metric with given id already exists",
                     response = ApiError.class),
-            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error",
+            @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
     public void createGaugeMetric(
@@ -108,7 +108,7 @@ public class GaugeHandler {
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
-        if(metricDefinition.getType() != null && metricDefinition.getType() != MetricType.GAUGE) {
+        if(metricDefinition.getType() != null && MetricType.GAUGE != metricDefinition.getType()) {
             asyncResponse.resume(badRequest(new ApiError("MetricDefinition type does not match " + MetricType
                     .GAUGE.getText())));
         }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -62,6 +62,7 @@ import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.api.Buckets;
 import org.hawkular.metrics.core.api.Metric;
 import org.hawkular.metrics.core.api.MetricId;
+import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
 
 import com.wordnik.swagger.annotations.Api;
@@ -107,6 +108,10 @@ public class GaugeHandler {
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
+        if(metricDefinition.getType() != null && metricDefinition.getType() != MetricType.GAUGE) {
+            asyncResponse.resume(badRequest(new ApiError("MetricDefinition type does not match " + MetricType
+                    .GAUGE.getText())));
+        }
         Metric<Double> metric = new Metric<>(new MetricId<>(tenantId, GAUGE, metricDefinition.getId()),
                 metricDefinition.getTags(), metricDefinition.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/gauges/{id}").build(metric.getId().getName());

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -28,6 +28,7 @@ import static org.hawkular.metrics.core.api.MetricType.AVAILABILITY;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER;
 import static org.hawkular.metrics.core.api.MetricType.GAUGE;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -43,9 +44,12 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import org.hawkular.metrics.api.jaxrs.ApiError;
+import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 import org.hawkular.metrics.api.jaxrs.model.Availability;
 import org.hawkular.metrics.api.jaxrs.model.Counter;
 import org.hawkular.metrics.api.jaxrs.model.Gauge;
@@ -53,7 +57,9 @@ import org.hawkular.metrics.api.jaxrs.param.Tags;
 import org.hawkular.metrics.api.jaxrs.request.MetricDefinition;
 import org.hawkular.metrics.api.jaxrs.request.MixedMetricsRequest;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
+import org.hawkular.metrics.api.jaxrs.util.MetricTypeTextConverter;
 import org.hawkular.metrics.core.api.Metric;
+import org.hawkular.metrics.core.api.MetricId;
 import org.hawkular.metrics.core.api.MetricType;
 import org.hawkular.metrics.core.api.MetricsService;
 
@@ -82,6 +88,31 @@ public class MetricHandler {
 
     @HeaderParam(TENANT_HEADER_NAME)
     private String tenantId;
+
+    @POST
+    @Path("/")
+    @ApiOperation(value = "Create metric definition.", notes = "Clients are not required to explicitly create "
+            + "a metric before storing data. Doing so however allows clients to prevent naming collisions and to "
+            + "specify tags and data retention.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "Metric definition created successfully"),
+            @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
+            @ApiResponse(code = 409, message = "Metric with given id already exists",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error",
+                    response = ApiError.class)
+    })
+    public void createMetric(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(required = true) MetricDefinition metricDefinition,
+            @Context UriInfo uriInfo
+    ) {
+        MetricId<?> id = new MetricId(tenantId, metricDefinition.getType(), metricDefinition.getId());
+        Metric<?> metric = new Metric<>(id, metricDefinition.getTags(), metricDefinition.getDataRetention());
+        URI location = uriInfo.getBaseUriBuilder().path("/{type}/{id}").build(MetricTypeTextConverter.getLongForm(id
+                .getType()), id.getName());
+        metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
+    }
 
     @GET
     @Path("/")

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -91,15 +91,15 @@ public class MetricHandler {
 
     @POST
     @Path("/")
-    @ApiOperation(value = "Create metric definition.", notes = "Clients are not required to explicitly create "
+    @ApiOperation(value = "Create metric.", notes = "Clients are not required to explicitly create "
             + "a metric before storing data. Doing so however allows clients to prevent naming collisions and to "
             + "specify tags and data retention.")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Metric definition created successfully"),
+            @ApiResponse(code = 201, message = "Metric created successfully"),
             @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
             @ApiResponse(code = 409, message = "Metric with given id already exists",
                     response = ApiError.class),
-            @ApiResponse(code = 500, message = "Metric definition creation failed due to an unexpected error",
+            @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
     public void createMetric(
@@ -107,6 +107,9 @@ public class MetricHandler {
             @ApiParam(required = true) MetricDefinition metricDefinition,
             @Context UriInfo uriInfo
     ) {
+        if(metricDefinition.getType() == null || !metricDefinition.getType().isUserType()) {
+            asyncResponse.resume(badRequest(new ApiError("MetricDefinition type is invalid")));
+        }
         MetricId<?> id = new MetricId(tenantId, metricDefinition.getType(), metricDefinition.getId());
         Metric<?> metric = new Metric<>(id, metricDefinition.getTags(), metricDefinition.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/{type}/{id}").build(MetricTypeTextConverter.getLongForm(id

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/jackson/MetricTypeDeserializer.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/jackson/MetricTypeDeserializer.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * @author Michael Burman
@@ -33,7 +32,6 @@ public class MetricTypeDeserializer extends JsonDeserializer<MetricType<?>> {
 
     @Override public MetricType<?> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException, JsonProcessingException {
-        JsonNode jsonNode = jsonParser.getCodec().readTree(jsonParser);
-        return MetricType.fromTextCode(jsonNode.get("type").asText());
+        return MetricType.fromTextCode(jsonParser.getText());
     }
 }

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -460,6 +460,26 @@ class CassandraBackendITest extends RESTTest {
         ],
         response.data
     )
+
+    // Explicitly create metrics with payload type
+    response = hawkularMetrics.post(path: "metrics", body: [
+        id: 'm17',
+        tags: [a10: '10', a11: '11'],
+        dataRetention: 7,
+        type: 'availability'
+    ], headers: [(tenantHeaderName): tenantId])
+    assertEquals(201, response.status)
+
+    // Fetch the metric
+    response = hawkularMetrics.get(path: "availability/m17", headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    assertEquals([
+        id: 'm17',
+        tags: [a10: '10', a11: '11'],
+        dataRetention: 7,
+        type: 'availability',
+        tenantId: tenantId
+    ], response.data)
   }
 
   @Test

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -19,6 +19,7 @@ package org.hawkular.metrics.rest
 import static org.joda.time.DateTime.now
 import static org.joda.time.Seconds.seconds
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
 
 import org.hawkular.metrics.core.api.MetricType
@@ -584,5 +585,38 @@ class CassandraBackendITest extends RESTTest {
             id: 'Empty1',
             type: 'gauge'
     ], response.data)
+  }
+
+  @Test
+  void testCreateTypeChecking() {
+    String tenantId = nextTenantId()
+
+    // Test gauges path
+    badPost(path: "gauges", body: [id: 'N1', type: 'availability'], headers: [(tenantHeaderName): tenantId]) {
+      exception ->
+      assertEquals(400, exception.response.status)
+      assertNotNull(exception.response.data['errorMsg'])
+    }
+
+    // Test availability path
+    badPost(path: "availability", body: [id: 'N1', type: 'gauge'], headers: [(tenantHeaderName): tenantId]) {
+      exception ->
+        assertEquals(400, exception.response.status)
+        assertNotNull(exception.response.data['errorMsg'])
+    }
+
+    // Test counter path
+    badPost(path: "counters", body: [id: 'N1', type: 'availability'], headers: [(tenantHeaderName): tenantId]) {
+      exception ->
+        assertEquals(400, exception.response.status)
+        assertNotNull(exception.response.data['errorMsg'])
+    }
+
+    // Test metrics path without given type
+    badPost(path: "metrics", body: [id: 'N1'], headers: [(tenantHeaderName): tenantId]) {
+      exception ->
+        assertEquals(400, exception.response.status)
+        assertNotNull(exception.response.data['errorMsg'])
+    }
   }
 }


### PR DESCRIPTION
Adds a generic (to /metrics) endpoint with the ability to create a metric definition by defining the type in the payload. Also fix a bug in HWKMETRICS-232 PR (deserialization, added test to prevent regression) and add type checks to type specific handlers