### PR TITLE
[HWKMETRICS-126] Implement timestamp validation for all metrics

### DIFF
--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/Availability.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/Availability.java
@@ -21,6 +21,10 @@ import static java.util.Collections.unmodifiableList;
 import java.util.List;
 import java.util.Objects;
 
+import org.hawkular.metrics.api.jaxrs.validation.Validate;
+import org.hawkular.metrics.api.jaxrs.validation.Validator;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wordnik.swagger.annotations.ApiModel;
 
@@ -31,7 +35,7 @@ import com.wordnik.swagger.annotations.ApiModel;
  * @author jsanda
  */
 @ApiModel(description = "An availability metric with one or more data points")
-public class Availability {
+public class Availability implements Validator {
 
     @JsonProperty
     private String id;
@@ -65,5 +69,12 @@ public class Availability {
         return "Availability{" +
                 "id='" + id + '\'' +
                 '}';
+    }
+
+    @Override
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
+    public boolean isValid() {
+        return Validate.validate(this.getData()).toBlocking().lastOrDefault(false);
     }
 }

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/AvailabilityDataPoint.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/AvailabilityDataPoint.java
@@ -21,9 +21,11 @@ import static java.util.Collections.emptyMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.hawkular.metrics.api.jaxrs.validation.Validator;
 import org.hawkular.metrics.core.api.AvailabilityType;
 import org.hawkular.metrics.core.api.DataPoint;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.wordnik.swagger.annotations.ApiModel;
@@ -32,11 +34,11 @@ import com.wordnik.swagger.annotations.ApiModel;
  * @author jsanda
  */
 @ApiModel(description = "Consists of a timestamp and a value where supported values are \"up\" and \"down\"")
-public class AvailabilityDataPoint {
+public class AvailabilityDataPoint implements Validator {
 
     @JsonProperty
     @org.codehaus.jackson.annotate.JsonProperty
-    private long timestamp;
+    private Long timestamp;
 
     @JsonProperty
     @org.codehaus.jackson.annotate.JsonProperty
@@ -67,7 +69,7 @@ public class AvailabilityDataPoint {
         tags = dataPoint.getTags();
     }
 
-    public long getTimestamp() {
+    public Long getTimestamp() {
         return timestamp;
     }
 
@@ -100,5 +102,20 @@ public class AvailabilityDataPoint {
                 .add("value", value)
                 .add("tags", tags)
                 .toString();
+    }
+
+    @Override
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
+    public boolean isValid() {
+        if (this.getValue() == null || this.getValue().trim().isEmpty()) {
+            return false;
+        }
+
+        if (this.getTimestamp() == null) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/Counter.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/Counter.java
@@ -21,6 +21,10 @@ import static java.util.Collections.unmodifiableList;
 import java.util.List;
 import java.util.Objects;
 
+import org.hawkular.metrics.api.jaxrs.validation.Validate;
+import org.hawkular.metrics.api.jaxrs.validation.Validator;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wordnik.swagger.annotations.ApiModel;
 
@@ -30,7 +34,7 @@ import com.wordnik.swagger.annotations.ApiModel;
  * @author jsanda
  */
 @ApiModel(description = "An counter metric with one or more data points")
-public class Counter {
+public class Counter implements Validator {
 
     @JsonProperty
     @org.codehaus.jackson.map.annotate.JsonSerialize(
@@ -70,6 +74,13 @@ public class Counter {
                 .add("id", id)
                 .add("data", data)
                 .toString();
+    }
+
+    @Override
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
+    public boolean isValid() {
+        return Validate.validate(this.getData()).toBlocking().lastOrDefault(false);
     }
 
 }

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/CounterDataPoint.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/CounterDataPoint.java
@@ -20,8 +20,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import org.hawkular.metrics.api.jaxrs.validation.Validator;
 import org.hawkular.metrics.core.api.DataPoint;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.wordnik.swagger.annotations.ApiModel;
@@ -30,11 +32,11 @@ import com.wordnik.swagger.annotations.ApiModel;
  * @author jsanda
  */
 @ApiModel(description = "A timestamp and a value where the value is interpreted as a signed 64 bit integer")
-public class CounterDataPoint {
+public class CounterDataPoint implements Validator {
 
     @JsonProperty
     @org.codehaus.jackson.annotate.JsonProperty
-    private long timestamp;
+    private Long timestamp;
 
     @JsonProperty
     @org.codehaus.jackson.annotate.JsonProperty
@@ -69,7 +71,7 @@ public class CounterDataPoint {
         return value;
     }
 
-    public long getTimestamp() {
+    public Long getTimestamp() {
         return timestamp;
     }
 
@@ -100,5 +102,20 @@ public class CounterDataPoint {
                 .add("value", value)
                 .add("tags", tags)
                 .toString();
+    }
+
+    @Override
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
+    public boolean isValid() {
+        if (this.getValue() == null) {
+            return false;
+        }
+
+        if (this.getTimestamp() == null) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/Gauge.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/Gauge.java
@@ -21,6 +21,10 @@ import static java.util.Collections.unmodifiableList;
 import java.util.List;
 import java.util.Objects;
 
+import org.hawkular.metrics.api.jaxrs.validation.Validate;
+import org.hawkular.metrics.api.jaxrs.validation.Validator;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wordnik.swagger.annotations.ApiModel;
 
@@ -31,7 +35,7 @@ import com.wordnik.swagger.annotations.ApiModel;
  * @author jsanda
  */
 @ApiModel(description = "A gauge metric with one or more data points")
-public class Gauge {
+public class Gauge implements Validator {
 
     @JsonProperty
     @org.codehaus.jackson.annotate.JsonProperty
@@ -73,5 +77,12 @@ public class Gauge {
                 .add("id", id)
                 .add("data", data)
                 .toString();
+    }
+
+    @Override
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
+    public boolean isValid() {
+        return Validate.validate(this.getData()).toBlocking().lastOrDefault(false);
     }
 }

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/GaugeDataPoint.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/model/GaugeDataPoint.java
@@ -20,8 +20,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import org.hawkular.metrics.api.jaxrs.validation.Validator;
 import org.hawkular.metrics.core.api.DataPoint;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,11 +34,11 @@ import com.wordnik.swagger.annotations.ApiModel;
  * @author jsanda
  */
 @ApiModel(description = "A timestamp and a value where the value is interpreted as a floating point number")
-public class GaugeDataPoint {
+public class GaugeDataPoint implements Validator {
 
     @JsonProperty
     @org.codehaus.jackson.annotate.JsonProperty
-    private long timestamp;
+    private Long timestamp;
 
     @JsonProperty
     @org.codehaus.jackson.annotate.JsonProperty
@@ -74,7 +76,7 @@ public class GaugeDataPoint {
         return value;
     }
 
-    public long getTimestamp() {
+    public Long getTimestamp() {
         return timestamp;
     }
 
@@ -105,5 +107,20 @@ public class GaugeDataPoint {
                 .add("value", value)
                 .add("tags", tags)
                 .toString();
+    }
+
+    @Override
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
+    public boolean isValid() {
+        if (this.getValue() == null) {
+            return false;
+        }
+
+        if (this.getTimestamp() == null) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/validation/Validate.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/validation/Validate.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.validation;
+
+import java.util.List;
+
+import rx.Observable;
+
+public class Validate {
+
+    public static Observable<Boolean> validate(List<? extends Validator> items) {
+        if (items == null || items.size() == 0) {
+            return Observable.just(true);
+        }
+
+        return Observable.from(items).all(item -> item.isValid() == true);
+    }
+}

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/validation/Validator.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/validation/Validator.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.validation;
+
+public interface Validator {
+    boolean isValid();
+}

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -27,6 +27,7 @@ import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.noContent;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToAvailabilities;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToAvailabilityDataPoints;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.serverError;
+import static org.hawkular.metrics.api.jaxrs.validation.Validate.validate;
 import static org.hawkular.metrics.core.api.MetricType.AVAILABILITY;
 
 import java.net.URI;
@@ -225,6 +226,10 @@ public class AvailabilityHandler {
             @PathParam("id") String id,
             @ApiParam(value = "List of availability datapoints", required = true) List<AvailabilityDataPoint> data
     ) {
+        if (!validate(data).toBlocking().lastOrDefault(false)) {
+            return badRequest(new ApiError("Timestamp not provided for data point"));
+        }
+
         Metric<AvailabilityType> metric = new Metric<>(new MetricId<>(tenantId, AVAILABILITY, id),
                 requestToAvailabilityDataPoints(data));
 
@@ -249,6 +254,10 @@ public class AvailabilityHandler {
             @ApiParam(value = "List of availability metrics", required = true)
             List<Availability> availabilities
     ) {
+        if (!validate(availabilities).toBlocking().lastOrDefault(false)) {
+            return badRequest(new ApiError("Timestamp not provided for data point"));
+        }
+
         try {
             metricsService.addDataPoints(AVAILABILITY, requestToAvailabilities(tenantId, availabilities)).toBlocking()
                     .lastOrDefault(null);

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -22,8 +22,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import static org.hawkular.metrics.api.jaxrs.filter.TenantFilter.TENANT_HEADER_NAME;
+import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.badRequest;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToCounterDataPoints;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToCounters;
+import static org.hawkular.metrics.api.jaxrs.validation.Validate.validate;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER;
 
 import java.net.URI;
@@ -149,6 +151,10 @@ public class CounterHandler {
     })
     public Response addData(@ApiParam(value = "List of metrics", required = true) List<Counter> counters
     ) {
+        if (!validate(counters).toBlocking().lastOrDefault(false)) {
+            return badRequest(new ApiError("Timestamp not provided for data point"));
+        }
+
         Observable<Metric<Long>> metrics = requestToCounters(tenantId, counters);
         try {
             metricsService.addDataPoints(COUNTER, metrics).toBlocking().lastOrDefault(null);
@@ -172,6 +178,10 @@ public class CounterHandler {
             @ApiParam(value = "List of data points containing timestamp and value", required = true)
             List<CounterDataPoint> data
     ) {
+        if (!validate(data).toBlocking().lastOrDefault(false)) {
+            return badRequest(new ApiError("Timestamp not provided for data point"));
+        }
+
         Metric<Long> metric = new Metric<>(new MetricId<>(tenantId, COUNTER, id), requestToCounterDataPoints(data));
         try {
             metricsService.addDataPoints(COUNTER, Observable.just(metric)).toBlocking().lastOrDefault(null);

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -25,6 +25,7 @@ import static org.hawkular.metrics.api.jaxrs.filter.TenantFilter.TENANT_HEADER_N
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.badRequest;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToGaugeDataPoints;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToGauges;
+import static org.hawkular.metrics.api.jaxrs.validation.Validate.validate;
 import static org.hawkular.metrics.core.api.MetricType.GAUGE;
 
 import java.net.URI;
@@ -217,6 +218,10 @@ public class GaugeHandler {
             @ApiParam(value = "List of datapoints containing timestamp and value", required = true)
             List<GaugeDataPoint> data
     ) {
+        if (!validate(data).toBlocking().lastOrDefault(false)) {
+            return badRequest(new ApiError("Timestamp not provided for data point"));
+        }
+
         Metric<Double> metric = new Metric<>(new MetricId<>(tenantId, GAUGE, id), requestToGaugeDataPoints(data));
         try {
             metricsService.addDataPoints(GAUGE, Observable.just(metric)).toBlocking().lastOrDefault(null);
@@ -238,6 +243,10 @@ public class GaugeHandler {
     })
     public Response addGaugeData(@ApiParam(value = "List of metrics", required = true) List<Gauge> gauges
     ) {
+        if (!validate(gauges).toBlocking().lastOrDefault(false)) {
+            return badRequest(new ApiError("Timestamp not provided for data point"));
+        }
+
         Observable<Metric<Double>> metrics = requestToGauges(tenantId, gauges);
         try {
             metricsService.addDataPoints(GAUGE, metrics).toBlocking().lastOrDefault(null);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -28,6 +28,7 @@ import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToAvailabiliti
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToAvailabilityDataPoints;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.serverError;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.valueToResponse;
+import static org.hawkular.metrics.api.jaxrs.validation.Validate.validate;
 import static org.hawkular.metrics.core.api.MetricType.AVAILABILITY;
 
 import java.net.URI;
@@ -200,10 +201,17 @@ public class AvailabilityHandler {
             @Suspended final AsyncResponse asyncResponse, @PathParam("id") String id,
             @ApiParam(value = "List of availability datapoints", required = true) List<AvailabilityDataPoint> data
     ) {
-        Metric<AvailabilityType> metric = new Metric<>(new MetricId<>(tenantId, AVAILABILITY, id),
-                requestToAvailabilityDataPoints(data));
-        metricsService.addDataPoints(AVAILABILITY, Observable.just(metric))
-                .subscribe(new ResultSetObserver(asyncResponse));
+        validate(data).lastOrDefault(false).subscribe(valid -> {
+            if (!valid) {
+                asyncResponse.resume(badRequest(new ApiError("Timestamp not provided for data point")));
+                return;
+            }
+
+            Metric<AvailabilityType> metric = new Metric<>(new MetricId<>(tenantId, AVAILABILITY, id),
+                    requestToAvailabilityDataPoints(data));
+            metricsService.addDataPoints(AVAILABILITY, Observable.just(metric))
+                    .subscribe(new ResultSetObserver(asyncResponse));
+        });
     }
 
     @POST
@@ -220,8 +228,15 @@ public class AvailabilityHandler {
             @ApiParam(value = "List of availability metrics", required = true)
             List<Availability> availabilities
     ) {
-        metricsService.addDataPoints(AVAILABILITY, requestToAvailabilities(tenantId, availabilities))
+        validate(availabilities).lastOrDefault(false).subscribe(valid -> {
+            if (!valid) {
+                asyncResponse.resume(badRequest(new ApiError("Timestamp not provided for data point")));
+                return;
+            }
+
+            metricsService.addDataPoints(AVAILABILITY, requestToAvailabilities(tenantId, availabilities))
                 .subscribe(new ResultSetObserver(asyncResponse));
+        });
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -25,6 +25,7 @@ import static org.hawkular.metrics.api.jaxrs.filter.TenantFilter.TENANT_HEADER_N
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.badRequest;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToGaugeDataPoints;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.requestToGauges;
+import static org.hawkular.metrics.api.jaxrs.validation.Validate.validate;
 import static org.hawkular.metrics.core.api.MetricType.GAUGE;
 
 import java.net.URI;
@@ -197,9 +198,16 @@ public class GaugeHandler {
             @ApiParam(value = "List of datapoints containing timestamp and value", required = true)
             List<GaugeDataPoint> data
     ) {
-        Metric<Double> metric = new Metric<>(new MetricId<>(tenantId, GAUGE, id), requestToGaugeDataPoints(data));
-        Observable<Void> observable = metricsService.addDataPoints(GAUGE, Observable.just(metric));
-        observable.subscribe(new ResultSetObserver(asyncResponse));
+        validate(data).lastOrDefault(false).subscribe(valid -> {
+            if (!valid) {
+                asyncResponse.resume(badRequest(new ApiError("Timestamp not provided for data point")));
+                return;
+            }
+
+            Metric<Double> metric = new Metric<>(new MetricId<>(tenantId, GAUGE, id), requestToGaugeDataPoints(data));
+            Observable<Void> observable = metricsService.addDataPoints(GAUGE, Observable.just(metric));
+            observable.subscribe(new ResultSetObserver(asyncResponse));
+        });
     }
 
     @POST
@@ -214,9 +222,16 @@ public class GaugeHandler {
     public void addGaugeData(@Suspended final AsyncResponse asyncResponse,
                              @ApiParam(value = "List of metrics", required = true) List<Gauge> gauges
     ) {
-        Observable<Metric<Double>> metrics = requestToGauges(tenantId, gauges);
-        Observable<Void> observable = metricsService.addDataPoints(GAUGE, metrics);
-        observable.subscribe(new ResultSetObserver(asyncResponse));
+        validate(gauges).lastOrDefault(false).subscribe(valid -> {
+            if (!valid) {
+                asyncResponse.resume(badRequest(new ApiError("Timestamp not provided for data point")));
+                return;
+            }
+
+            Observable<Metric<Double>> metrics = requestToGauges(tenantId, gauges);
+            Observable<Void> observable = metricsService.addDataPoints(GAUGE, metrics);
+            observable.subscribe(new ResultSetObserver(asyncResponse));
+        });
     }
 
     @GET

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
@@ -108,4 +108,35 @@ class AvailabilityITest extends RESTTest {
     assertEquals(200, response.status)
     assertEquals(metric, response.data.id)
   }
+
+  @Test
+  void shouldNotCreateMetricWithEmptyTimestamp() {
+    def tenantId = nextTenantId()
+
+    badPost(path: "availability/data", headers: [(tenantHeaderName): tenantId], body: [
+        [id: 'test1',
+         data: [
+            [timestamp: 123, value: "down"],
+            [timestamp: 124, value: "down"],
+            [timestamp: 125, value: "down"]
+        ]],
+        [id: 'test2',
+         data: [
+            [timestamp: 123, value: "down"],
+            [timestamp: 124, value: "down"],
+            [timestamp: 125, value: "down"],
+            [value: "up"]
+        ]]]) { exception ->
+      assertEquals(400, exception.response.status)
+    }
+
+    badPost(path: "availability/test3/data", headers: [(tenantHeaderName): tenantId], body: [
+            [timestamp: 123, value: "up"],
+            [timestamp: 124, value: "up"],
+            [timestamp: 125, value: "up"],
+            [value: "up"]
+        ]) { exception ->
+      assertEquals(400, exception.response.status)
+    }
+  }
 }

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -400,4 +400,35 @@ class CountersITest extends RESTTest {
         body: points)
     assertEquals(200, response.status)
   }
+
+  @Test
+  void shouldNotCreateMetricWithEmptyTimestamp() {
+    def tenantId = nextTenantId()
+
+    badPost(path: "counters/data", headers: [(tenantHeaderName): tenantId], body: [
+        [id: 'test1',
+         data: [
+            [timestamp: 123, value: 123],
+            [timestamp: 124, value: 124],
+            [timestamp: 125, value: 125]
+        ]],
+        [id: 'test2',
+         data: [
+            [timestamp: 123, value: 123],
+            [timestamp: 124, value: 124],
+            [timestamp: 125, value: 125],
+            [value: 126]
+        ]]]) { exception ->
+      assertEquals(400, exception.response.status)
+    }
+
+    badPost(path: "counters/test3/data", headers: [(tenantHeaderName): tenantId], body: [
+            [timestamp: 123, value: 123],
+            [timestamp: 124, value: 124],
+            [timestamp: 125, value: 125],
+            [value: 126]
+        ]) { exception ->
+      assertEquals(400, exception.response.status)
+    }
+  }
 }

--- a/rest-tests/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
+++ b/rest-tests/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
@@ -86,4 +86,35 @@ class GaugesITest extends RESTTest {
     def response = hawkularMetrics.post(path: "gauges/test/data", headers: [(tenantHeaderName): tenantId], body: points)
     assertEquals(200, response.status)
   }
+
+  @Test
+  void shouldNotCreateMetricWithEmptyTimestamp() {
+    def tenantId = nextTenantId()
+
+    badPost(path: "gauges/data", headers: [(tenantHeaderName): tenantId], body: [
+        [id: 'test1',
+         data: [
+            [timestamp: 123, value: 123],
+            [timestamp: 124, value: 124],
+            [timestamp: 125, value: 125]
+        ]],
+        [id: 'test2',
+         data: [
+            [timestamp: 123, value: 123],
+            [timestamp: 124, value: 124],
+            [timestamp: 125, value: 125],
+            [value: 125]
+        ]]]) { exception ->
+      assertEquals(400, exception.response.status)
+    }
+
+    badPost(path: "gauges/test3/data", headers: [(tenantHeaderName): tenantId], body: [
+            [timestamp: 123, value: 123],
+            [timestamp: 124, value: 124],
+            [timestamp: 125, value: 125],
+            [value: 126]
+        ]) { exception ->
+      assertEquals(400, exception.response.status)
+    }
+  }
 }


### PR DESCRIPTION
A missing timestamp will result in rejecting the entire request before processing it.

Note: this is implement in handler code rather than using JAX-RS framework features beacuse of divergence between the two JAX-RS standards. If/when one of the standards is dropped this code could be revisited although this implementation is simpler and easier to extend.