### PR TITLE
Minor POM and doc changes.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ This is for advanced users only, if you want to embed the core functionnality in
 Most users will work with the
 https://github.com/hawkular/hawkular-metrics/tree/master/api/metrics-api-jaxrs[web application].
 It exposes a REST/HTTP interface based on the core library. It is implemented with the JAX-RS 2 asynchronous API and
-runs on a http://www.wildfly.org/[Wildfly] server. The data format is JSON.
+runs on a http://www.wildfly.org/[Wildfly 9] server. The data format is JSON.
 
 == Goals
 

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -38,7 +38,6 @@
   <properties>
     <wildfly-maven-plugin.skip>true</wildfly-maven-plugin.skip>
     <cassandra.keyspace>hawkular_metrics_ptrans_integration_tests</cassandra.keyspace>
-    <scheduler.units>seconds</scheduler.units>
     <!-- Configuration files used when starting a development ptrans instance with mvn exec:java -->
     <dev.log4j.configuration>${project.basedir}/log4j-dev.xml</dev.log4j.configuration>
     <dev.ptrans.conf>${project.basedir}/ptrans.conf</dev.ptrans.conf>
@@ -248,7 +247,6 @@
                     <javaOpt>-Dcassandra.keyspace=${cassandra.keyspace}</javaOpt>
                     <javaOpt>-Dcassandra.resetdb</javaOpt>
                     <javaOpt>-Dhawkular.metrics.waitForService</javaOpt>
-                    <javaOpt>-Dhawkular.scheduler.time-units=${scheduler.units}</javaOpt>
                     <javaOpt>-Xdebug</javaOpt>
                     <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
                   </javaOpts>
@@ -294,7 +292,7 @@
         <!-- IMPORTANT: The management port must be the port offset + 9990. -->
         <ptrans.wildfly.management.port>57898</ptrans.wildfly.management.port>
         <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
-        <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
+        <wildfly.logging.file.level>ERROR</wildfly.logging.file.level>
       </properties>
       <build>
         <plugins>

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -247,7 +247,7 @@
         <!-- IMPORTANT: The management port must be the port offset + 9990. -->
         <wildfly.management.port>57887</wildfly.management.port>
         <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
-        <wildfly.logging.file.level>DEBUG</wildfly.logging.file.level>
+        <wildfly.logging.file.level>ERROR</wildfly.logging.file.level>
         <terminal-event.timeout>10</terminal-event.timeout>
       </properties>
       <build>


### PR DESCRIPTION
Some properties still present in ptrans itest config no longer exist in REST module.
By default, keep test server file logging to a minimum (like CONSOLE level).
Update README to precise on Wildfly version to download.