### PR TITLE
Dropwizard/Codahale Metrics dependency management

### DIFF
--- a/core/metrics-core-impl/pom.xml
+++ b/core/metrics-core-impl/pom.xml
@@ -63,12 +63,6 @@
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.codahale.metrics</groupId>
-          <artifactId>metrics-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -87,11 +81,6 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>${joda.time.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.codahale.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,6 @@
     <log4j.version>1.2.17</log4j.version>
     <antlr.version>4.5</antlr.version>
     <rxjava.version>1.0.13</rxjava.version>
-    <codahale.metrics.version>3.0.2</codahale.metrics.version>
     <rxjava-math.version>1.0.0</rxjava-math.version>
 
     <findbugs.version>3.0.0</findbugs.version>
@@ -148,11 +147,6 @@
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
         <version>${antlr.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.codahale.metrics</groupId>
-        <artifactId>metrics-core</artifactId>
-        <version>${codahale.metrics.version}</version>
       </dependency>
       <!-- Tests dependencies -->
       <!-- TestNG is not Hawkular default testing tool -->


### PR DESCRIPTION
Opening this PR as I noticed recent changes in Dropwizard Metrics dependency management.

If we should use Codahale Metrics, in the same version as the C* driver, then we shouldn't:
- force a version in parent POM
- exclude/re-include it in core-impl POM

Am I wrong?