### PR TITLE
HWKMETRICS-250 Core-API does not compile on newest JDK 1.8

### DIFF
--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/Aggregate.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/Aggregate.java
@@ -33,24 +33,24 @@ public interface Aggregate {
      * A function that emits a single item, the average of {@link DataPoint data points} as a double.
      */
     Func1<Observable<DataPoint<Double>>, Observable<Double>> Average = data ->
-        MathObservable.averageDouble(data.map(DataPoint::getValue));
+            MathObservable.averageDouble(data.map((DataPoint<Double> dataPoint) -> dataPoint.getValue()));
 
     /**
      * A function that emits a single item, the max of {@link DataPoint data points} as a double.
      */
     Func1<Observable<DataPoint<Double>>, Observable<Double>> Max = data ->
-        MathObservable.max(data.map(DataPoint::getValue));
+            MathObservable.max(data.map((DataPoint<Double> dataPoint) -> dataPoint.getValue()));
 
     /**
      * A function that emits a single item, the min of {@link DataPoint data points} as a double.
      */
     Func1<Observable<DataPoint<Double>>, Observable<Double>> Min = data ->
-        MathObservable.min(data.map(DataPoint::getValue));
+            MathObservable.min(data.map((DataPoint<Double> dataPoint) -> dataPoint.getValue()));
 
     /**
      * A function that emits a single item, the sum of {@link DataPoint data points} as a double.
      */
     Func1<Observable<DataPoint<Double>>, Observable<Double>> Sum = data ->
-        MathObservable.sumDouble(data.map(DataPoint::getValue));
+            MathObservable.sumDouble(data.map((DataPoint<Double> dataPoint) -> dataPoint.getValue()));
 
 }


### PR DESCRIPTION
HWKMETRICS-250 Core-API does not compile on newest JDK 1.8

Helped the compiler to infer generic type