### PR TITLE
Exclude Jackson utility classes from CDI scans

### DIFF
--- a/api/metrics-api-common/src/main/resources/META-INF/beans.xml
+++ b/api/metrics-api-common/src/main/resources/META-INF/beans.xml
@@ -19,5 +19,12 @@
 -->
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+       xmlns:weld="http://jboss.org/schema/weld/beans"
+       xsi:schemaLocation="
+          http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd
+          http://jboss.org/schema/weld/beans http://jboss.org/schema/weld/beans_1_1.xsd">
+  <weld:scan>
+    <weld:exclude pattern="org.hawkular.metrics.api.jaxrs.fasterxml.jackson.*"/>
+    <weld:exclude pattern="org.hawkular.metrics.api.jaxrs.codehaus.jackson.*"/>
+  </weld:scan>
 </beans>


### PR DESCRIPTION
Exclude Jackson utility classes from CDI scans

 This is to avoid warnings (classes not available) on EAP6.4 during deployment