### PR TITLE
More Grafana compatibility fixes and HWKMETRICS-65

### DIFF
--- a/api/diff.txt
+++ b/api/diff.txt
@@ -201,8 +201,9 @@ diff -r '--exclude=target' api/metrics-api-jaxrs/src/main/java/org/hawkular/metr
 116,117d112
 <         classes.add(CorsResponseFilter.class);
 <         classes.add(CorsRequestFilter.class);
-121,122c116,118
+121,123c116,118
 <         classes.add(ConvertersProvider.class);
+<         classes.add(org.hawkular.metrics.api.jaxrs.influx.param.ConvertersProvider.class);
 <         classes.add(JacksonConfig.class);
 ---
 >         classes.add(DurationConverter.class);

--- a/api/metrics-api-jaxrs/src/main/antlr4/org/hawkular/metrics/api/jaxrs/influx/query/parse/InfluxQuery.g4
+++ b/api/metrics-api-jaxrs/src/main/antlr4/org/hawkular/metrics/api/jaxrs/influx/query/parse/InfluxQuery.g4
@@ -55,8 +55,8 @@ booleanExpression: operand '=' operand #eqExpression
 
 operand: prefix? name #nameOperand
        | TIMESPAN #absoluteMomentOperand
-       | ID '(' ')' DASH TIMESPAN #pastMomentOperand
-       | ID '(' ')' PLUS TIMESPAN #futureMomentOperand
+       | ID '(' ')' DASH (INT|TIMESPAN) #pastMomentOperand
+       | ID '(' ')' PLUS (INT|TIMESPAN) #futureMomentOperand
        | ID '(' ')' #presentMomentOperand
        | DATE_STRING #dateOperand
        | DASH? INT #longOperand

--- a/api/metrics-api-jaxrs/src/main/antlr4/org/hawkular/metrics/api/jaxrs/influx/query/parse/InfluxQuery.g4
+++ b/api/metrics-api-jaxrs/src/main/antlr4/org/hawkular/metrics/api/jaxrs/influx/query/parse/InfluxQuery.g4
@@ -59,7 +59,7 @@ operand: prefix? name #nameOperand
        | ID '(' ')' PLUS TIMESPAN #futureMomentOperand
        | ID '(' ')' #presentMomentOperand
        | DATE_STRING #dateOperand
-       | DASH? INT #integerOperand
+       | DASH? INT #longOperand
        | DASH? FLOAT #doubleOperand
        ;
 
@@ -82,7 +82,7 @@ functionArgumentList: functionArgument (',' functionArgument)*;
 functionArgument: prefix? name #nameFunctionArgument
                 | SINGLE_QUOTED_STRING #stringFunctionArgument
                 | DASH? FLOAT #doubleFunctionArgument
-                | DASH? INT #integerFunctionArgument;
+                | DASH? INT #longFunctionArgument;
 
 LIST: L I S T;
 SERIES: S E R I E S;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/HawkularMetricsRestApp.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/HawkularMetricsRestApp.java
@@ -119,6 +119,7 @@ public class HawkularMetricsRestApp extends Application {
         // Add interceptors and other miscellaneous providers
         classes.add(EmptyPayloadInterceptor.class);
         classes.add(ConvertersProvider.class);
+        classes.add(org.hawkular.metrics.api.jaxrs.influx.param.ConvertersProvider.class);
         classes.add(JacksonConfig.class);
 
         return classes;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxSeriesHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxSeriesHandler.java
@@ -62,7 +62,6 @@ import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.AggregatedCo
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.BooleanExpression;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.FunctionArgument;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.GroupByClause;
-import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.InfluxTimeUnit;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.ListSeriesDefinitionsParser;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.NumberFunctionArgument;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.RegularExpression;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnit.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnit.java
@@ -16,68 +16,65 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Thomas Segismont
  */
 public enum InfluxTimeUnit {
-    /** */
-    MICROSECONDS('u') {
+    MICROSECONDS("u") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.MICROSECONDS);
         }
     },
-    /** */
-    SECONDS('s') {
+    MILLISECONDS("ms") {
+        @Override
+        public long convertTo(TimeUnit targetUnit, long value) {
+            return targetUnit.convert(value, TimeUnit.MILLISECONDS);
+        }
+    },
+    SECONDS("s") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.SECONDS);
         }
     },
-    /** */
-    MINUTES('m') {
+    MINUTES("m") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.MINUTES);
         }
     },
-    /** */
-    HOURS('h') {
+    HOURS("h") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.HOURS);
         }
     },
-    /** */
-    DAYS('d') {
+    DAYS("d") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.DAYS);
         }
     },
-    /** */
-    WEEKS('w') {
+    WEEKS("w") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(7 * value, TimeUnit.DAYS);
         }
     };
 
-    private final char id;
+    private String id;
 
-    InfluxTimeUnit(char id) {
-        if (Character.isUpperCase(id)) {
-            this.id = Character.toLowerCase(id);
-        } else {
-            this.id = id;
-        }
+    InfluxTimeUnit(String id) {
+        this.id = id.toLowerCase();
     }
 
-    public char getId() {
+    public String getId() {
         return id;
     }
 
@@ -86,24 +83,28 @@ public enum InfluxTimeUnit {
      * <code>target</code> {@link java.util.concurrent.TimeUnit}.
      *
      * @param targetUnit the target {@link java.util.concurrent.TimeUnit}
-     * @param value the value in <code>this</code> {@link InfluxTimeUnit}
+     * @param value      the value in <code>this</code> {@link InfluxTimeUnit}
+     *
      * @return the value in the target {@link java.util.concurrent.TimeUnit}
      */
     public abstract long convertTo(TimeUnit targetUnit, long value);
 
-    private static final Map<Character, InfluxTimeUnit> UNIT_BY_ID = new HashMap<Character, InfluxTimeUnit>();
+    private static final Map<String, InfluxTimeUnit> UNIT_BY_ID;
 
     static {
+        ImmutableMap.Builder<String, InfluxTimeUnit> builder = new ImmutableMap.Builder<>();
         for (InfluxTimeUnit influxTimeUnit : values()) {
-            UNIT_BY_ID.put(influxTimeUnit.id, influxTimeUnit);
+            builder.put(influxTimeUnit.id, influxTimeUnit);
         }
+        UNIT_BY_ID = builder.build();
     }
 
     /**
      * @param id time unit id
+     *
      * @return the {@link InfluxTimeUnit} which id is <code>id</code>, null otherwise
      */
-    public static InfluxTimeUnit findById(char id) {
+    public static InfluxTimeUnit findById(String id) {
         return UNIT_BY_ID.get(id);
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnit.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnit.java
@@ -30,11 +30,21 @@ public enum InfluxTimeUnit {
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.MICROSECONDS);
         }
+
+        @Override
+        public long convert(long sourceValue, InfluxTimeUnit sourceUnit) {
+            return sourceUnit.convertTo(TimeUnit.MICROSECONDS, sourceValue);
+        }
     },
     MILLISECONDS("ms") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public long convert(long sourceValue, InfluxTimeUnit sourceUnit) {
+            return sourceUnit.convertTo(TimeUnit.MILLISECONDS, sourceValue);
         }
     },
     SECONDS("s") {
@@ -42,11 +52,21 @@ public enum InfluxTimeUnit {
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.SECONDS);
         }
+
+        @Override
+        public long convert(long sourceValue, InfluxTimeUnit sourceUnit) {
+            return sourceUnit.convertTo(TimeUnit.SECONDS, sourceValue);
+        }
     },
     MINUTES("m") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.MINUTES);
+        }
+
+        @Override
+        public long convert(long sourceValue, InfluxTimeUnit sourceUnit) {
+            return sourceUnit.convertTo(TimeUnit.MINUTES, sourceValue);
         }
     },
     HOURS("h") {
@@ -54,17 +74,32 @@ public enum InfluxTimeUnit {
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.HOURS);
         }
+
+        @Override
+        public long convert(long sourceValue, InfluxTimeUnit sourceUnit) {
+            return sourceUnit.convertTo(TimeUnit.HOURS, sourceValue);
+        }
     },
     DAYS("d") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(value, TimeUnit.DAYS);
         }
+
+        @Override
+        public long convert(long sourceValue, InfluxTimeUnit sourceUnit) {
+            return sourceUnit.convertTo(TimeUnit.DAYS, sourceValue);
+        }
     },
     WEEKS("w") {
         @Override
         public long convertTo(TimeUnit targetUnit, long value) {
             return targetUnit.convert(7 * value, TimeUnit.DAYS);
+        }
+
+        @Override
+        public long convert(long sourceValue, InfluxTimeUnit sourceUnit) {
+            return sourceUnit.convertTo(TimeUnit.DAYS, sourceValue) / 7;
         }
     };
 
@@ -88,6 +123,8 @@ public enum InfluxTimeUnit {
      * @return the value in the target {@link java.util.concurrent.TimeUnit}
      */
     public abstract long convertTo(TimeUnit targetUnit, long value);
+
+    public abstract long convert(long sourceValue, InfluxTimeUnit sourceUnit);
 
     private static final Map<String, InfluxTimeUnit> UNIT_BY_ID;
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnit.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnit.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
+package org.hawkular.metrics.api.jaxrs.influx;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/param/ConvertersProvider.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/param/ConvertersProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.api.jaxrs.influx.param;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
+
+import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Provides {@link ParamConverterProvider} instances for Influx endpoint.
+ *
+ * @author Thomas Segismont
+ */
+@Provider
+public class ConvertersProvider implements ParamConverterProvider {
+    private final ImmutableMap<Class<?>, ParamConverter<?>> paramConverters;
+
+    public ConvertersProvider() {
+        ImmutableMap.Builder<Class<?>, ParamConverter<?>> paramConvertersBuilder = ImmutableMap.builder();
+        paramConverters = paramConvertersBuilder
+                .put(InfluxTimeUnit.class, new InfluxTimeUnitConverter())
+                .build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> ParamConverter<T> getConverter(
+            Class<T> rawType, Type genericType, Annotation[] annotations
+    ) {
+        return (ParamConverter<T>) paramConverters.get(rawType);
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/param/InfluxTimeUnitConverter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/param/InfluxTimeUnitConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.api.jaxrs.influx.param;
+
+import javax.ws.rs.ext.ParamConverter;
+
+import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
+
+/**
+ * A JAX-RS {@link ParamConverter} for {@link InfluxTimeUnit} parameters.
+ *
+ * @author Thomas Segismont
+ */
+public class InfluxTimeUnitConverter implements ParamConverter<InfluxTimeUnit> {
+
+    @Override
+    public InfluxTimeUnit fromString(String value) {
+        InfluxTimeUnit timeUnit = InfluxTimeUnit.findById(value);
+        if (timeUnit == null) {
+            throw new IllegalArgumentException(value + "does not represent a time unit");
+        }
+        return timeUnit;
+    }
+
+    @Override
+    public String toString(InfluxTimeUnit value) {
+        return String.valueOf(value.getId());
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/GroupByClause.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/GroupByClause.java
@@ -23,10 +23,10 @@ import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
  */
 public class GroupByClause {
     private final String bucketType;
-    private final int bucketSize;
+    private final long bucketSize;
     private final InfluxTimeUnit bucketSizeUnit;
 
-    public GroupByClause(String bucketType, int bucketSize, InfluxTimeUnit bucketSizeUnit) {
+    public GroupByClause(String bucketType, long bucketSize, InfluxTimeUnit bucketSizeUnit) {
         this.bucketType = bucketType;
         this.bucketSize = bucketSize;
         this.bucketSizeUnit = bucketSizeUnit;
@@ -36,7 +36,7 @@ public class GroupByClause {
         return bucketType;
     }
 
-    public int getBucketSize() {
+    public long getBucketSize() {
         return bucketSize;
     }
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/GroupByClause.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/GroupByClause.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
 
+import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
+
 /**
  * @author Thomas Segismont
  */

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/LongFunctionArgument.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/LongFunctionArgument.java
@@ -19,14 +19,19 @@ package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
 /**
  * @author Thomas Segismont
  */
-public class IntegerOperand implements Operand {
-    private final int value;
+public class LongFunctionArgument implements NumberFunctionArgument {
+    private final long value;
 
-    public IntegerOperand(int value) {
+    public LongFunctionArgument(long value) {
         this.value = value;
     }
 
-    public int getValue() {
+    public long getValue() {
+        return value;
+    }
+
+    @Override
+    public double getDoubleValue() {
         return value;
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/LongOperand.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/LongOperand.java
@@ -19,19 +19,14 @@ package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
 /**
  * @author Thomas Segismont
  */
-public class IntegerFunctionArgument implements NumberFunctionArgument {
-    private final int value;
+public class LongOperand implements Operand {
+    private final long value;
 
-    public IntegerFunctionArgument(int value) {
+    public LongOperand(long value) {
         this.value = value;
     }
 
-    public int getValue() {
-        return value;
-    }
-
-    @Override
-    public double getDoubleValue() {
+    public long getValue() {
         return value;
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/MomentOperand.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/MomentOperand.java
@@ -26,10 +26,10 @@ import org.joda.time.Instant;
  */
 public class MomentOperand implements InstantOperand {
     private final String functionName;
-    private final int timeshift;
+    private final long timeshift;
     private final InfluxTimeUnit timeshiftUnit;
 
-    public MomentOperand(String functionName, int timeshift, InfluxTimeUnit timeshiftUnit) {
+    public MomentOperand(String functionName, long timeshift, InfluxTimeUnit timeshiftUnit) {
         this.functionName = functionName;
         this.timeshift = timeshift;
         this.timeshiftUnit = timeshiftUnit;
@@ -39,7 +39,7 @@ public class MomentOperand implements InstantOperand {
         return functionName;
     }
 
-    public int getTimeshift() {
+    public long getTimeshift() {
         return timeshift;
     }
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/MomentOperand.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/MomentOperand.java
@@ -18,6 +18,7 @@ package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
 
 import java.util.concurrent.TimeUnit;
 
+import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
 import org.joda.time.Instant;
 
 /**

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/OperandUtils.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/OperandUtils.java
@@ -29,6 +29,16 @@ public class OperandUtils {
         return operand instanceof InstantOperand;
     }
 
+    public static boolean isPositiveLongOperand(Operand operand) {
+        if (operand instanceof LongOperand) {
+            LongOperand longOperand = (LongOperand) operand;
+            if (longOperand.getValue() >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private OperandUtils() {
         // Utility class
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryDefinitionsParser.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryDefinitionsParser.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.antlr.v4.runtime.misc.NotNull;
+import org.antlr.v4.runtime.tree.TerminalNode;
 import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryBaseListener;
 import org.joda.time.Instant;
@@ -274,12 +275,20 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
     @Override
     public void exitPastMomentOperand(@NotNull PastMomentOperandContext ctx) {
         String functionName = ctx.ID().getText();
-        String timespan = ctx.TIMESPAN().getText();
-        long timeshift = Long.parseLong(timespan.substring(0, timespan.length() - 1));
-        char unitId = timespan.charAt(timespan.length() - 1);
-        InfluxTimeUnit timeshiftUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
-        if (timeshiftUnit == null) {
-            throw new RuntimeException("Unknown time unit: " + unitId);
+        TerminalNode intNode = ctx.INT();
+        long timeshift;
+        InfluxTimeUnit timeshiftUnit;
+        if (intNode == null) {
+            String timespan = ctx.TIMESPAN().getText();
+            timeshift = Long.parseLong(timespan.substring(0, timespan.length() - 1));
+            char unitId = timespan.charAt(timespan.length() - 1);
+            timeshiftUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
+            if (timeshiftUnit == null) {
+                throw new RuntimeException("Unknown time unit: " + unitId);
+            }
+        } else {
+            timeshift = Long.parseLong(intNode.getText());
+            timeshiftUnit = InfluxTimeUnit.MICROSECONDS;
         }
         operandQueue.addLast(new MomentOperand(functionName, -1 * timeshift, timeshiftUnit));
     }
@@ -287,12 +296,20 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
     @Override
     public void exitFutureMomentOperand(@NotNull FutureMomentOperandContext ctx) {
         String functionName = ctx.ID().getText();
-        String timespan = ctx.TIMESPAN().getText();
-        long timeshift = Long.parseLong(timespan.substring(0, timespan.length() - 1));
-        char unitId = timespan.charAt(timespan.length() - 1);
-        InfluxTimeUnit timeshiftUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
-        if (timeshiftUnit == null) {
-            throw new RuntimeException("Unknown time unit: " + unitId);
+        TerminalNode intNode = ctx.INT();
+        long timeshift;
+        InfluxTimeUnit timeshiftUnit;
+        if (intNode == null) {
+            String timespan = ctx.TIMESPAN().getText();
+            timeshift = Long.parseLong(timespan.substring(0, timespan.length() - 1));
+            char unitId = timespan.charAt(timespan.length() - 1);
+            timeshiftUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
+            if (timeshiftUnit == null) {
+                throw new RuntimeException("Unknown time unit: " + unitId);
+            }
+        } else {
+            timeshift = Long.parseLong(intNode.getText());
+            timeshiftUnit = InfluxTimeUnit.MICROSECONDS;
         }
         operandQueue.addLast(new MomentOperand(functionName, timeshift, timeshiftUnit));
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryDefinitionsParser.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryDefinitionsParser.java
@@ -181,7 +181,7 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
         String timespan = ctx.TIMESPAN().getText();
         int bucketSize = Integer.parseInt(timespan.substring(0, timespan.length() - 1));
         char unitId = timespan.charAt(timespan.length() - 1);
-        InfluxTimeUnit bucketSizeUnit = InfluxTimeUnit.findById(unitId);
+        InfluxTimeUnit bucketSizeUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
         if (bucketSizeUnit == null) {
             throw new RuntimeException("Unknown time unit: " + unitId);
         }
@@ -264,7 +264,7 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
         String timespan = ctx.TIMESPAN().getText();
         int amount = Integer.parseInt(timespan.substring(0, timespan.length() - 1));
         char unitId = timespan.charAt(timespan.length() - 1);
-        InfluxTimeUnit unit = InfluxTimeUnit.findById(unitId);
+        InfluxTimeUnit unit = InfluxTimeUnit.findById(String.valueOf(unitId));
         if (unit == null) {
             throw new RuntimeException("Unknown time unit: " + unitId);
         }
@@ -277,7 +277,7 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
         String timespan = ctx.TIMESPAN().getText();
         int timeshift = Integer.parseInt(timespan.substring(0, timespan.length() - 1));
         char unitId = timespan.charAt(timespan.length() - 1);
-        InfluxTimeUnit timeshiftUnit = InfluxTimeUnit.findById(unitId);
+        InfluxTimeUnit timeshiftUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
         if (timeshiftUnit == null) {
             throw new RuntimeException("Unknown time unit: " + unitId);
         }
@@ -290,7 +290,7 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
         String timespan = ctx.TIMESPAN().getText();
         int timeshift = Integer.parseInt(timespan.substring(0, timespan.length() - 1));
         char unitId = timespan.charAt(timespan.length() - 1);
-        InfluxTimeUnit timeshiftUnit = InfluxTimeUnit.findById(unitId);
+        InfluxTimeUnit timeshiftUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
         if (timeshiftUnit == null) {
             throw new RuntimeException("Unknown time unit: " + unitId);
         }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryDefinitionsParser.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryDefinitionsParser.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.antlr.v4.runtime.misc.NotNull;
+import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryBaseListener;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser;
 import org.joda.time.Instant;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryDefinitionsParser.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryDefinitionsParser.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
 
+import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.AbsoluteMomentOperandContext;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.AggregatedColumnDefinitionContext;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.AliasContext;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.AndExpressionContext;
@@ -32,9 +33,9 @@ import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParse
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.GroupByClauseContext;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.GtExpressionContext;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.IdNameContext;
-import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.IntegerFunctionArgumentContext;
-import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.IntegerOperandContext;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.LimitClauseContext;
+import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.LongFunctionArgumentContext;
+import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.LongOperandContext;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.LtExpressionContext;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.NameFunctionArgumentContext;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser.NameOperandContext;
@@ -58,7 +59,6 @@ import java.util.concurrent.TimeUnit;
 import org.antlr.v4.runtime.misc.NotNull;
 import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryBaseListener;
-import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser;
 import org.joda.time.Instant;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -179,7 +179,7 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
     public void exitGroupByClause(@NotNull GroupByClauseContext ctx) {
         String bucketType = ctx.ID().getText();
         String timespan = ctx.TIMESPAN().getText();
-        int bucketSize = Integer.parseInt(timespan.substring(0, timespan.length() - 1));
+        long bucketSize = Long.parseLong(timespan.substring(0, timespan.length() - 1));
         char unitId = timespan.charAt(timespan.length() - 1);
         InfluxTimeUnit bucketSizeUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
         if (bucketSizeUnit == null) {
@@ -260,9 +260,9 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
     }
 
     @Override
-    public void exitAbsoluteMomentOperand(InfluxQueryParser.AbsoluteMomentOperandContext ctx) {
+    public void exitAbsoluteMomentOperand(AbsoluteMomentOperandContext ctx) {
         String timespan = ctx.TIMESPAN().getText();
-        int amount = Integer.parseInt(timespan.substring(0, timespan.length() - 1));
+        long amount = Long.parseLong(timespan.substring(0, timespan.length() - 1));
         char unitId = timespan.charAt(timespan.length() - 1);
         InfluxTimeUnit unit = InfluxTimeUnit.findById(String.valueOf(unitId));
         if (unit == null) {
@@ -275,7 +275,7 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
     public void exitPastMomentOperand(@NotNull PastMomentOperandContext ctx) {
         String functionName = ctx.ID().getText();
         String timespan = ctx.TIMESPAN().getText();
-        int timeshift = Integer.parseInt(timespan.substring(0, timespan.length() - 1));
+        long timeshift = Long.parseLong(timespan.substring(0, timespan.length() - 1));
         char unitId = timespan.charAt(timespan.length() - 1);
         InfluxTimeUnit timeshiftUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
         if (timeshiftUnit == null) {
@@ -288,7 +288,7 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
     public void exitFutureMomentOperand(@NotNull FutureMomentOperandContext ctx) {
         String functionName = ctx.ID().getText();
         String timespan = ctx.TIMESPAN().getText();
-        int timeshift = Integer.parseInt(timespan.substring(0, timespan.length() - 1));
+        long timeshift = Long.parseLong(timespan.substring(0, timespan.length() - 1));
         char unitId = timespan.charAt(timespan.length() - 1);
         InfluxTimeUnit timeshiftUnit = InfluxTimeUnit.findById(String.valueOf(unitId));
         if (timeshiftUnit == null) {
@@ -311,12 +311,12 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
     }
 
     @Override
-    public void exitIntegerOperand(@NotNull IntegerOperandContext ctx) {
-        int value = Integer.parseInt(ctx.INT().getText());
+    public void exitLongOperand(@NotNull LongOperandContext ctx) {
+        long value = Long.parseLong(ctx.INT().getText());
         if (ctx.DASH() != null) {
             value = -1 * value;
         }
-        operandQueue.addLast(new IntegerOperand(value));
+        operandQueue.addLast(new LongOperand(value));
     }
 
     @Override
@@ -396,12 +396,12 @@ public class SelectQueryDefinitionsParser extends InfluxQueryBaseListener {
     }
 
     @Override
-    public void exitIntegerFunctionArgument(@NotNull IntegerFunctionArgumentContext ctx) {
-        int value = Integer.parseInt(ctx.INT().getText());
+    public void exitLongFunctionArgument(@NotNull LongFunctionArgumentContext ctx) {
+        long value = Long.parseLong(ctx.INT().getText());
         if (ctx.DASH() != null) {
             value = -1 * value;
         }
-        functionArguments.add(new IntegerFunctionArgument(value));
+        functionArguments.add(new LongFunctionArgument(value));
     }
 
     private ColumnDefinitionBuilder getColumnDefinitionBuilder() {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/validation/SimpleTimeRangesOnlyRule.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/validation/SimpleTimeRangesOnlyRule.java
@@ -17,6 +17,7 @@
 package org.hawkular.metrics.api.jaxrs.influx.query.validation;
 
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.OperandUtils.isInstantOperand;
+import static org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.OperandUtils.isPositiveLongOperand;
 import static org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.OperandUtils.isTimeOperand;
 
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.AndBooleanExpression;
@@ -39,11 +40,11 @@ public class SimpleTimeRangesOnlyRule implements SelectQueryValidationRule {
         if (whereClause instanceof LtBooleanExpression) {
             LtBooleanExpression lt = (LtBooleanExpression) whereClause;
             checkOneTimeOperand(lt.getLeftOperand(), lt.getRightOperand());
-            checkOneDateOrMomentOperand(lt.getLeftOperand(), lt.getRightOperand());
+            checkOneInstantOrPositiveLongOperand(lt.getLeftOperand(), lt.getRightOperand());
         } else if (whereClause instanceof GtBooleanExpression) {
             GtBooleanExpression gt = (GtBooleanExpression) whereClause;
             checkOneTimeOperand(gt.getLeftOperand(), gt.getRightOperand());
-            checkOneDateOrMomentOperand(gt.getLeftOperand(), gt.getRightOperand());
+            checkOneInstantOrPositiveLongOperand(gt.getLeftOperand(), gt.getRightOperand());
         } else if (whereClause instanceof AndBooleanExpression) {
             AndBooleanExpression and = (AndBooleanExpression) whereClause;
             BooleanExpression left = and.getLeftExpression();
@@ -51,16 +52,16 @@ public class SimpleTimeRangesOnlyRule implements SelectQueryValidationRule {
             if (left instanceof LtBooleanExpression) {
                 LtBooleanExpression lt = (LtBooleanExpression) left;
                 checkOneTimeOperand(lt.getLeftOperand(), lt.getRightOperand());
-                checkOneDateOrMomentOperand(lt.getLeftOperand(), lt.getRightOperand());
+                checkOneInstantOrPositiveLongOperand(lt.getLeftOperand(), lt.getRightOperand());
                 if (right instanceof GtBooleanExpression) {
                     GtBooleanExpression gt = (GtBooleanExpression) right;
                     checkOneTimeOperand(gt.getLeftOperand(), gt.getRightOperand());
-                    checkOneDateOrMomentOperand(gt.getLeftOperand(), gt.getRightOperand());
+                    checkOneInstantOrPositiveLongOperand(gt.getLeftOperand(), gt.getRightOperand());
                     checkRestrictionIsARange(lt, gt);
                 } else if (right instanceof LtBooleanExpression) {
                     LtBooleanExpression lt2 = (LtBooleanExpression) right;
                     checkOneTimeOperand(lt2.getLeftOperand(), lt2.getRightOperand());
-                    checkOneDateOrMomentOperand(lt2.getLeftOperand(), lt2.getRightOperand());
+                    checkOneInstantOrPositiveLongOperand(lt2.getLeftOperand(), lt2.getRightOperand());
                     checkRestrictionIsARange(lt, lt2);
                 } else {
                     throw new QueryNotSupportedException("Not a simple time range restriction");
@@ -68,16 +69,16 @@ public class SimpleTimeRangesOnlyRule implements SelectQueryValidationRule {
             } else if (left instanceof GtBooleanExpression) {
                 GtBooleanExpression gt = (GtBooleanExpression) left;
                 checkOneTimeOperand(gt.getLeftOperand(), gt.getRightOperand());
-                checkOneDateOrMomentOperand(gt.getLeftOperand(), gt.getRightOperand());
+                checkOneInstantOrPositiveLongOperand(gt.getLeftOperand(), gt.getRightOperand());
                 if (right instanceof LtBooleanExpression) {
                     LtBooleanExpression lt = (LtBooleanExpression) right;
                     checkOneTimeOperand(lt.getLeftOperand(), lt.getRightOperand());
-                    checkOneDateOrMomentOperand(lt.getLeftOperand(), lt.getRightOperand());
+                    checkOneInstantOrPositiveLongOperand(lt.getLeftOperand(), lt.getRightOperand());
                     checkRestrictionIsARange(lt, gt);
                 } else if (right instanceof GtBooleanExpression) {
                     GtBooleanExpression gt2 = (GtBooleanExpression) right;
                     checkOneTimeOperand(gt2.getLeftOperand(), gt2.getRightOperand());
-                    checkOneDateOrMomentOperand(gt2.getLeftOperand(), gt2.getRightOperand());
+                    checkOneInstantOrPositiveLongOperand(gt2.getLeftOperand(), gt2.getRightOperand());
                     checkRestrictionIsARange(gt, gt2);
                 } else {
                     throw new QueryNotSupportedException("Not a simple time range restriction");
@@ -91,31 +92,28 @@ public class SimpleTimeRangesOnlyRule implements SelectQueryValidationRule {
     }
 
     private void checkRestrictionIsARange(LtBooleanExpression lt, GtBooleanExpression gt)
-        throws QueryNotSupportedException {
-
+            throws QueryNotSupportedException {
         // Don't allow "time < y and z > time" or "z > time and time < y"
         if ((isTimeOperand(lt.getLeftOperand()) && isTimeOperand(gt.getRightOperand()))
-            || (isTimeOperand(lt.getRightOperand()) && isTimeOperand(gt.getLeftOperand()))) {
+                || (isTimeOperand(lt.getRightOperand()) && isTimeOperand(gt.getLeftOperand()))) {
             throw new QueryNotSupportedException("Not a simple time range restriction");
         }
     }
 
     private void checkRestrictionIsARange(GtBooleanExpression gt1, GtBooleanExpression gt2)
-        throws QueryNotSupportedException {
-
+            throws QueryNotSupportedException {
         // Don't allow "time > y and time > z" or "y > time and z > time"
         if ((isTimeOperand(gt1.getLeftOperand()) && isTimeOperand(gt2.getLeftOperand()))
-            || (isTimeOperand(gt1.getRightOperand()) && isTimeOperand(gt2.getRightOperand()))) {
+                || (isTimeOperand(gt1.getRightOperand()) && isTimeOperand(gt2.getRightOperand()))) {
             throw new QueryNotSupportedException("Not a simple time range restriction");
         }
     }
 
     private void checkRestrictionIsARange(LtBooleanExpression lt1, LtBooleanExpression lt2)
-        throws QueryNotSupportedException {
-
+            throws QueryNotSupportedException {
         // Don't allow "time < y and time < z" or "y < time and z < time"
         if ((isTimeOperand(lt1.getLeftOperand()) && isTimeOperand(lt2.getLeftOperand()))
-            || (isTimeOperand(lt1.getRightOperand()) && isTimeOperand(lt2.getRightOperand()))) {
+                || (isTimeOperand(lt1.getRightOperand()) && isTimeOperand(lt2.getRightOperand()))) {
             throw new QueryNotSupportedException("Not a simple time range restriction");
         }
     }
@@ -127,12 +125,12 @@ public class SimpleTimeRangesOnlyRule implements SelectQueryValidationRule {
         }
     }
 
-    private void checkOneDateOrMomentOperand(Operand leftOperand, Operand rightOperand)
-        throws QueryNotSupportedException {
-
+    private void checkOneInstantOrPositiveLongOperand(Operand leftOperand, Operand rightOperand) throws
+            QueryNotSupportedException {
         // We want exactly one of the operands to be a date or moment operand
-        if (isInstantOperand(leftOperand) == isInstantOperand(rightOperand)) {
-            throw new QueryNotSupportedException("Expected exactly one time operand");
+        if ((isInstantOperand(leftOperand) || isPositiveLongOperand(leftOperand)) ==
+                (isInstantOperand(rightOperand) || isPositiveLongOperand(rightOperand))) {
+            throw new QueryNotSupportedException("Expected exactly one instant operand");
         }
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/write/validation/DataTypesRule.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/write/validation/DataTypesRule.java
@@ -16,34 +16,14 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.write.validation;
 
-import static com.google.common.base.Predicates.and;
-import static com.google.common.base.Predicates.instanceOf;
-import static com.google.common.base.Predicates.not;
-import static com.google.common.base.Predicates.or;
-
-import java.math.BigDecimal;
 import java.util.List;
-import java.util.ListIterator;
 
 import org.hawkular.metrics.api.jaxrs.influx.InfluxObject;
-
-import com.google.common.base.Predicate;
 
 /**
  * @author Thomas Segismont
  */
 public class DataTypesRule implements InfluxObjectValidationRule {
-    private static final Predicate<Object> IS_INTEGRAL = //
-    and( //
-        instanceOf(Number.class), //
-        not( //
-            or( //
-                instanceOf(BigDecimal.class), //
-                instanceOf(Double.class), //
-                instanceOf(Float.class) //
-            ) //
-        ) //
-    );
 
     @Override
     public void checkInfluxObject(InfluxObject influxObject) throws InvalidObjectException {
@@ -56,23 +36,9 @@ public class DataTypesRule implements InfluxObjectValidationRule {
             if (point.size() < columns.size()) {
                 throw new InvalidObjectException("Object has not enough data in point to match columns");
             }
-            if (columns.size() == 1) {
-                if (!(point.get(0) instanceof Number)) {
-                    throw new InvalidObjectException("Point 'value' is not numerical");
-                }
-            } else {
-                int valueIndex = columns.indexOf("value");
-                for (ListIterator<?> dataIterator = point.listIterator(); dataIterator.hasNext();) {
-                    Object data = dataIterator.next();
-                    if (valueIndex == dataIterator.nextIndex() - 1) {
-                        if (!(data instanceof Number)) {
-                            throw new InvalidObjectException("Point 'value' is not numerical");
-                        }
-                    } else {
-                        if (!IS_INTEGRAL.apply(data)) {
-                            throw new InvalidObjectException("Point 'time' is not integral");
-                        }
-                    }
+            for (Object data : point) {
+                if (!(data instanceof Number)) {
+                    throw new InvalidObjectException(data + " is not numerical");
                 }
             }
         }

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnitTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnitTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
+package org.hawkular.metrics.api.jaxrs.influx;
 
 import static org.junit.Assert.assertEquals;
 

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnitTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/InfluxTimeUnitTest.java
@@ -16,6 +16,12 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx;
 
+import static org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit.DAYS;
+import static org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit.HOURS;
+import static org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit.MICROSECONDS;
+import static org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit.MINUTES;
+import static org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit.SECONDS;
+import static org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit.WEEKS;
 import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.TimeUnit;
@@ -29,11 +35,21 @@ public class InfluxTimeUnitTest {
 
     @Test
     public void testConvertTo() throws Exception {
-        assertEquals(5, InfluxTimeUnit.MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5));
-        assertEquals(5, InfluxTimeUnit.MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5));
-        assertEquals(5, InfluxTimeUnit.MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5));
-        assertEquals(5, InfluxTimeUnit.MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5));
-        assertEquals(7, InfluxTimeUnit.SECONDS.convertTo(TimeUnit.HOURS, 3600 * 7));
-        assertEquals(13 * 1000, InfluxTimeUnit.MICROSECONDS.convertTo(TimeUnit.NANOSECONDS, 13));
+        assertEquals(5 * 7 * 24, WEEKS.convertTo(TimeUnit.HOURS, 5));
+        assertEquals(48, DAYS.convertTo(TimeUnit.HOURS, 2));
+        assertEquals(4 * 3600, HOURS.convertTo(TimeUnit.SECONDS, 4));
+        assertEquals(5, MINUTES.convertTo(TimeUnit.DAYS, 60 * 24 * 5));
+        assertEquals(7, SECONDS.convertTo(TimeUnit.HOURS, 3600 * 7));
+        assertEquals(13 * 1000, MICROSECONDS.convertTo(TimeUnit.NANOSECONDS, 13));
+    }
+
+    @Test
+    public void testConvert() throws Exception {
+        assertEquals(5 * 7 * 24, HOURS.convert(5, WEEKS));
+        assertEquals(48, HOURS.convert(2, DAYS));
+        assertEquals(4 * 3600, SECONDS.convert(4, HOURS));
+        assertEquals(5, DAYS.convert(60 * 24 * 5, MINUTES));
+        assertEquals(7, HOURS.convert(3600 * 7, SECONDS));
+        assertEquals(42, WEEKS.convert(42 * 7 * 24 * 3600, SECONDS));
     }
 }

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/param/InfluxTimeUnitConverterTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/param/InfluxTimeUnitConverterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.api.jaxrs.influx.param;
+
+import static java.util.stream.Collectors.joining;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Thomas Segismont
+ */
+public class InfluxTimeUnitConverterTest {
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private final InfluxTimeUnitConverter converter = new InfluxTimeUnitConverter();
+
+    @Test
+    public void shouldFailIfTextIsAnInvalidUnit() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        converter.fromString(Arrays.stream(InfluxTimeUnit.values()).map(unit -> unit.getId()).collect(joining(",")));
+    }
+
+    @Test
+    public void shouldConvertValidTimeUnits() throws Exception {
+        for (InfluxTimeUnit timeUnit : InfluxTimeUnit.values()) {
+            assertEquals(timeUnit, converter.fromString(String.valueOf(timeUnit.getId())));
+        }
+    }
+}

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryColumnDefinitionsTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryColumnDefinitionsTest.java
@@ -196,9 +196,9 @@ public class SelectQueryColumnDefinitionsTest {
         assertEquals(" f ", nameFunctionArgument.getName());
 
         i++;
-        assertEquals(IntegerFunctionArgument.class, aggregationFunctionArguments.get(i).getClass());
-        IntegerFunctionArgument integerFunctionArgument = (IntegerFunctionArgument) aggregationFunctionArguments.get(i);
-        assertEquals(78, integerFunctionArgument.getValue());
+        assertEquals(LongFunctionArgument.class, aggregationFunctionArguments.get(i).getClass());
+        LongFunctionArgument longFunctionArgument = (LongFunctionArgument) aggregationFunctionArguments.get(i);
+        assertEquals(78, longFunctionArgument.getValue());
 
         i++;
         assertEquals(StringFunctionArgument.class, aggregationFunctionArguments.get(i).getClass());

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryGroupByClauseTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryGroupByClauseTest.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.query.parse.definition;
 
+import static java.util.stream.Collectors.toList;
+
+import static org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -29,9 +32,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
-
 /**
  * @author Thomas Segismont
  */
@@ -40,17 +40,15 @@ public class SelectQueryGroupByClauseTest {
 
     @Parameters(name = "{0}")
     public static Iterable<Object[]> testValidQueries() throws Exception {
-        return FluentIterable //
-            .from(Arrays.asList(InfluxTimeUnit.values())) //
-            .transform(new Function<InfluxTimeUnit, Object[]>() {
-                @Override
-                public Object[] apply(InfluxTimeUnit influxTimeUnit) {
-                    int bucketSize = influxTimeUnit.ordinal() + 15;
-                    return new Object[] {
-                        "select * from a group by time ( " + bucketSize + influxTimeUnit.getId() + " )", bucketSize,
-                        influxTimeUnit };
-                }
-            });
+        return Arrays.stream(InfluxTimeUnit.values())
+                .filter(timeUnit -> timeUnit != MILLISECONDS)
+                .map(timeUnit -> {
+                    int bucketSize = timeUnit.ordinal() + 15;
+                    return new Object[]{
+                            "select * from a group by time ( " + bucketSize + timeUnit.getId() + " )",
+                            bucketSize,
+                            timeUnit};
+                }).collect(toList());
     }
 
     private final SelectQueryDefinitionsParser definitionsParser = new SelectQueryDefinitionsParser();

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryGroupByClauseTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryGroupByClauseTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParserFactory;
 import org.junit.Test;

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryWhereClauseTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryWhereClauseTest.java
@@ -80,7 +80,7 @@ public class SelectQueryWhereClauseTest {
         assertEquals(EqBooleanExpression.class, nestedLeftExpr.getLeftExpression().getClass());
         EqBooleanExpression eqExpr = (EqBooleanExpression) nestedLeftExpr.getLeftExpression();
         assertNameOperand(eqExpr.getLeftOperand(), "a");
-        assertIntegerOperand(eqExpr.getRightOperand(), 2);
+        assertLongOperand(eqExpr.getRightOperand(), 2);
 
         // Inspect ".35 =  '2005-11-09 15:12:01.623'";
         assertEquals(EqBooleanExpression.class, nestedLeftExpr.getRightExpression().getClass());
@@ -112,7 +112,7 @@ public class SelectQueryWhereClauseTest {
         // Inspect "3 = '2005-11-09'";
         assertEquals(EqBooleanExpression.class, deeplyNestedRightExpr.getRightExpression().getClass());
         eqExpr = (EqBooleanExpression) deeplyNestedRightExpr.getRightExpression();
-        assertIntegerOperand(eqExpr.getLeftOperand(), 3);
+        assertLongOperand(eqExpr.getLeftOperand(), 3);
         instant = new MutableDateTime(2005, 11, 9, 0, 0, 0, 0, DateTimeZone.UTC).toInstant();
         assertDateOperand(eqExpr.getRightOperand(), instant);
     }
@@ -123,10 +123,10 @@ public class SelectQueryWhereClauseTest {
         assertEquals(value, doubleOperand.getValue(), 0);
     }
 
-    private void assertIntegerOperand(Operand operand, int value) {
-        assertEquals(IntegerOperand.class, operand.getClass());
-        IntegerOperand integerOperand = (IntegerOperand) operand;
-        assertEquals(value, integerOperand.getValue());
+    private void assertLongOperand(Operand operand, int value) {
+        assertEquals(LongOperand.class, operand.getClass());
+        LongOperand longOperand = (LongOperand) operand;
+        assertEquals(value, longOperand.getValue());
     }
 
     private void assertNameOperand(Operand operand, String name) {

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryWhereClauseTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/influx/query/parse/definition/SelectQueryWhereClauseTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParser;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.InfluxQueryParserFactory;
 import org.joda.time.DateTimeZone;

--- a/api/metrics-api-jaxrs/src/test/resources/influx/query/supported-select-queries.iql
+++ b/api/metrics-api-jaxrs/src/test/resources/influx/query/supported-select-queries.iql
@@ -30,3 +30,5 @@ select a.value as b from c as a where time < '2011-07-28' and time > now() + 50w
 select a.value as b from c as a where '2011-07-28' < a.time and now() + 50w > a.time
 select a.value as b from c as a where '2011-07-28' > a.time and now() + 50w < a.time
 select * from test where time > 1501560s and time < 4560546h
+select * from test where time > 1501560 and time < 4560546
+select a.value as b from c as a where '2011-07-28' > a.time and now() + 1156897980 < a.time

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
@@ -32,6 +32,7 @@ import org.junit.Test
  */
 class InfluxITest extends RESTTest {
   def tenantId = nextTenantId()
+  def timeseriesName = 'test'
 
   @Test
   void testEmptyPayload() {
@@ -48,27 +49,27 @@ class InfluxITest extends RESTTest {
       response.failure = { response ->
         assertEquals(400, response.status)
         assertEquals(TEXT.toString(), response.contentType)
-        assertEquals("Null objects", EntityUtils.toString(response.entity))
+        assertEquals('Null objects', EntityUtils.toString(response.entity))
       }
     }
   }
 
   @Test
   void testListSeries() {
-    postData("serie1", now())
-    postData("serie2", now())
+    postData('serie1', now())
+    postData('serie2', now())
 
-    def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: "list series"])
+    def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: 'list series'])
     assertEquals(200, response.status)
 
     assertEquals(
         [
             [
-                name: "list_series_result",
-                columns: ["time", "name"],
+                name: 'list_series_result',
+                columns: ['time', 'name'],
                 points: [
-                    [0, "serie1"],
-                    [0, "serie2"],
+                    [0, 'serie1'],
+                    [0, 'serie2'],
                 ]
             ]
         ],
@@ -78,34 +79,34 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testListSeriesWithRegularExpression() {
-    postData("serie1", now())
-    postData("serie2", now())
+    postData('serie1', now())
+    postData('serie2', now())
 
-    def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: "list series /rIe\\d/i"])
+    def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: 'list series /rIe\\d/i'])
     assertEquals(200, response.status)
 
     assertEquals(
         [
             [
-                name: "list_series_result",
-                columns: ["time", "name"],
+                name: 'list_series_result',
+                columns: ['time', 'name'],
                 points: [
-                    [0, "serie1"],
-                    [0, "serie2"],
+                    [0, 'serie1'],
+                    [0, 'serie2'],
                 ]
             ]
         ],
         response.data
     )
 
-    response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: "list series /^rIe\\d/i"])
+    response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: 'list series /^rIe\\d/i'])
     assertEquals(200, response.status)
 
     assertEquals(
         [
             [
-                name: "list_series_result",
-                columns: ["time", "name"]
+                name: 'list_series_result',
+                columns: ['time', 'name']
             ]
         ],
         response.data
@@ -114,7 +115,6 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxDataOrderedAsc() {
-    def timeseriesName = "influx.dataasc"
     def start = now().minus(4000)
     postData(timeseriesName, start)
 
@@ -126,7 +126,7 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                columns: ["time", "value"],
+                columns: ['time', 'value'],
                 name: timeseriesName,
                 points: [
                     [start.millis, 40.1],
@@ -143,7 +143,6 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxDataOrderedDescByDefault() {
-    def timeseriesName = "influx.datadesc"
     def start = now().minus(4000)
     postData(timeseriesName, start)
 
@@ -155,7 +154,7 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                columns: ["time", "value"],
+                columns: ['time', 'value'],
                 name: timeseriesName,
                 points: [
                     [start.plus(4000).millis, 44.1],
@@ -172,7 +171,6 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxAddGetOneMetric() {
-    def timeseriesName = "influx.foo"
     def start = now().minus(4000)
     postData(timeseriesName, start)
 
@@ -184,7 +182,7 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                columns: ["time", "mean"],
+                columns: ['time', 'mean'],
                 name: timeseriesName,
                 points: [
                     [start.plus(4000).millis, 42.1]
@@ -197,7 +195,6 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxLimitClause() {
-    def timeseriesName = "influx.limitclause"
     def start = now().minus(4000)
     postData(timeseriesName, start)
 
@@ -209,7 +206,7 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                columns: ["time", "value"],
+                columns: ['time', 'value'],
                 name: timeseriesName,
                 points: [
                     [start.millis, 40.1],
@@ -223,7 +220,6 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxAddGetOneSillyMetric() {
-    def timeseriesName = "influx.foo3"
     def start = now().minus(4000)
     postData(timeseriesName, start)
 
@@ -237,7 +233,7 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                columns: ["time", "mean"],
+                columns: ['time', 'mean'],
                 name: timeseriesName
             ]
         ],
@@ -247,7 +243,6 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testWhereClauseWithoutTimeUnit() {
-    def timeseriesName = "test"
     def start = now().minus(4000)
     postData(timeseriesName, start)
 
@@ -261,7 +256,7 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                columns: ["time", "value"],
+                columns: ['time', 'value'],
                 name: timeseriesName,
                 points: [
                     [start.plus(2000).millis, 42.1],
@@ -275,7 +270,6 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxTop() {
-    def timeseriesName = "influx.top"
     def start = now().minus(4000)
     postData(timeseriesName, start)
 
@@ -287,7 +281,7 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                columns: ["time", "top"],
+                columns: ['time', 'top'],
                 name: timeseriesName,
                 points: [
                     [start.plus(4000).millis, 44.1],
@@ -302,7 +296,6 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxBottom() {
-    def timeseriesName = "influx.bottom"
     def start = now().minus(4000)
     postData(timeseriesName, start)
 
@@ -315,7 +308,7 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                columns: ["time", "bottom"],
+                columns: ['time', 'bottom'],
                 name: timeseriesName,
                 points: [
                     [start.millis, 40.1],
@@ -330,7 +323,6 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxStddev() {
-    def timeseriesName = "influx.stddev"
     def start = now().minus(4000)
     postData(timeseriesName, start)
 
@@ -342,10 +334,62 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                columns: ["time", "stddev"],
+                columns: ['time', 'stddev'],
                 name: timeseriesName,
                 points: [
                     [start.plus(4000).millis, 1.5811388300841898]
+                ]
+            ]
+        ],
+        response.data
+    )
+  }
+
+  @Test
+  void testTimePrecisionQueryParameter() {
+    def response = hawkularMetrics.post(path: "db/${tenantId}/series", query: [time_precision: 's'], body: [
+        [
+            name: timeseriesName,
+            columns: ['time', 'value'],
+            points: [
+                [1, 40.1],
+                [2, 41.1],
+                [3, 42.1],
+            ]
+        ]
+    ])
+    assertEquals(200, response.status)
+
+    def influxQuery = """select * from "${timeseriesName}" where time > 0"""
+
+    response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
+    assertEquals(200, response.status)
+    assertEquals(
+        [
+            [
+                columns: ['time', 'value'],
+                name: timeseriesName,
+                points: [
+                    [3_000, 42.1],
+                    [2_000, 41.1],
+                    [1_000, 40.1],
+                ]
+            ]
+        ],
+        response.data
+    )
+
+    response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery, time_precision: 'u'])
+    assertEquals(200, response.status)
+    assertEquals(
+        [
+            [
+                columns: ['time', 'value'],
+                name: timeseriesName,
+                points: [
+                    [3_000_000, 42.1],
+                    [2_000_000, 41.1],
+                    [1_000_000, 40.1],
                 ]
             ]
         ],
@@ -357,7 +401,7 @@ class InfluxITest extends RESTTest {
     def response = hawkularMetrics.post(path: "db/${tenantId}/series", body: [
         [
             name: timeseriesName,
-            columns: ["time", "value"],
+            columns: ['time', 'value'],
             points: [
                 [start.millis, 40.1],
                 [start.plus(1000).millis, 41.1],

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
@@ -31,11 +31,10 @@ import org.junit.Test
  * @author Thomas Segismont
  */
 class InfluxITest extends RESTTest {
+  def tenantId = nextTenantId()
 
   @Test
   void testEmptyPayload() {
-    def tenantId = nextTenantId()
-
     hawkularMetrics.request(POST) { request ->
       uri.path = "db/${tenantId}/series"
       body = "" /* Empty body */
@@ -56,10 +55,8 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testListSeries() {
-    def tenantId = nextTenantId()
-
-    postData(tenantId, "serie1", now())
-    postData(tenantId, "serie2", now())
+    postData("serie1", now())
+    postData("serie2", now())
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: "list series"])
     assertEquals(200, response.status)
@@ -67,9 +64,9 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                name   : "list_series_result",
+                name: "list_series_result",
                 columns: ["time", "name"],
-                points : [
+                points: [
                     [0, "serie1"],
                     [0, "serie2"],
                 ]
@@ -81,10 +78,8 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testListSeriesWithRegularExpression() {
-    def tenantId = nextTenantId()
-
-    postData(tenantId, "serie1", now())
-    postData(tenantId, "serie2", now())
+    postData("serie1", now())
+    postData("serie2", now())
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: "list series /rIe\\d/i"])
     assertEquals(200, response.status)
@@ -92,9 +87,9 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                name   : "list_series_result",
+                name: "list_series_result",
                 columns: ["time", "name"],
-                points : [
+                points: [
                     [0, "serie1"],
                     [0, "serie2"],
                 ]
@@ -109,7 +104,7 @@ class InfluxITest extends RESTTest {
     assertEquals(
         [
             [
-                name   : "list_series_result",
+                name: "list_series_result",
                 columns: ["time", "name"]
             ]
         ],
@@ -119,12 +114,11 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxDataOrderedAsc() {
-    def tenantId = nextTenantId()
     def timeseriesName = "influx.dataasc"
     def start = now().minus(4000)
-    postData(tenantId, timeseriesName, start)
+    postData(timeseriesName, start)
 
-    def influxQuery = 'select value from "' + timeseriesName + '" order asc'
+    def influxQuery = """select value from "${timeseriesName}" order asc"""
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
     assertEquals(200, response.status)
@@ -133,8 +127,8 @@ class InfluxITest extends RESTTest {
         [
             [
                 columns: ["time", "value"],
-                name   : timeseriesName,
-                points : [
+                name: timeseriesName,
+                points: [
                     [start.millis, 40.1],
                     [start.plus(1000).millis, 41.1],
                     [start.plus(2000).millis, 42.1],
@@ -149,12 +143,11 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxDataOrderedDescByDefault() {
-    def tenantId = nextTenantId()
     def timeseriesName = "influx.datadesc"
     def start = now().minus(4000)
-    postData(tenantId, timeseriesName, start)
+    postData(timeseriesName, start)
 
-    def influxQuery = 'select value from "' + timeseriesName + '"'
+    def influxQuery = """select value from "${timeseriesName}" """
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
     assertEquals(200, response.status)
@@ -163,8 +156,8 @@ class InfluxITest extends RESTTest {
         [
             [
                 columns: ["time", "value"],
-                name   : timeseriesName,
-                points : [
+                name: timeseriesName,
+                points: [
                     [start.plus(4000).millis, 44.1],
                     [start.plus(3000).millis, 43.1],
                     [start.plus(2000).millis, 42.1],
@@ -179,12 +172,11 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxAddGetOneMetric() {
-    def tenantId = nextTenantId()
     def timeseriesName = "influx.foo"
     def start = now().minus(4000)
-    postData(tenantId, timeseriesName, start)
+    postData(timeseriesName, start)
 
-    def influxQuery = 'select mean(value) from "' + timeseriesName + '" where time > now() - 30s group by time(30s) '
+    def influxQuery = """select mean(value) from "${timeseriesName}" where time > now() - 30s group by time(30s)"""
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
     assertEquals(200, response.status)
@@ -193,8 +185,8 @@ class InfluxITest extends RESTTest {
         [
             [
                 columns: ["time", "mean"],
-                name   : timeseriesName,
-                points : [
+                name: timeseriesName,
+                points: [
                     [start.plus(4000).millis, 42.1]
                 ]
             ]
@@ -205,12 +197,11 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxLimitClause() {
-    def tenantId = nextTenantId()
     def timeseriesName = "influx.limitclause"
     def start = now().minus(4000)
-    postData(tenantId, timeseriesName, start)
+    postData(timeseriesName, start)
 
-    def influxQuery = 'select value from "' + timeseriesName + '" limit 2 order asc '
+    def influxQuery = """select value from "${timeseriesName}" limit 2 order asc"""
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
     assertEquals(200, response.status)
@@ -219,8 +210,8 @@ class InfluxITest extends RESTTest {
         [
             [
                 columns: ["time", "value"],
-                name   : timeseriesName,
-                points : [
+                name: timeseriesName,
+                points: [
                     [start.millis, 40.1],
                     [start.plus(1000).millis, 41.1]
                 ]
@@ -232,13 +223,12 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxAddGetOneSillyMetric() {
-    def tenantId = nextTenantId()
     def timeseriesName = "influx.foo3"
     def start = now().minus(4000)
-    postData(tenantId, timeseriesName, start)
+    postData(timeseriesName, start)
 
-    def influxQuery = 'select mean(value) from "' + timeseriesName + '''" where time > '2013-08-12 23:32:01.232'
-                        and time < '2013-08-13' group by time(30s) '''
+    def influxQuery = """select mean(value) from "${timeseriesName}" where time > '2013-08-12 23:32:01.232'
+                         and time < '2013-08-13' group by time(30s)"""
 
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
@@ -248,7 +238,35 @@ class InfluxITest extends RESTTest {
         [
             [
                 columns: ["time", "mean"],
-                name  : timeseriesName
+                name: timeseriesName
+            ]
+        ],
+        response.data
+    )
+  }
+
+  @Test
+  void testWhereClauseWithoutTimeUnit() {
+    def timeseriesName = "test"
+    def start = now().minus(4000)
+    postData(timeseriesName, start)
+
+    def influxQuery = """select * from "${timeseriesName}"
+                         where time > ${start.plus(1000).millis * 1000}
+                         and time < ${start.plus(3000).millis * 1000}"""
+
+    def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
+    assertEquals(200, response.status)
+
+    assertEquals(
+        [
+            [
+                columns: ["time", "value"],
+                name: timeseriesName,
+                points: [
+                    [start.plus(2000).millis, 42.1],
+                    [start.plus(1000).millis, 41.1]
+                ]
             ]
         ],
         response.data
@@ -257,12 +275,11 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxTop() {
-    def tenantId = nextTenantId()
     def timeseriesName = "influx.top"
     def start = now().minus(4000)
-    postData(tenantId, timeseriesName, start)
+    postData(timeseriesName, start)
 
-    def influxQuery = 'select top(value, 3) from "' + timeseriesName + '" where time > now() - 30s group by time(30s)'
+    def influxQuery = """select top(value, 3) from "${timeseriesName}" where time > now() - 30s group by time(30s)"""
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
     assertEquals(200, response.status)
@@ -271,8 +288,8 @@ class InfluxITest extends RESTTest {
         [
             [
                 columns: ["time", "top"],
-                name   : timeseriesName,
-                points : [
+                name: timeseriesName,
+                points: [
                     [start.plus(4000).millis, 44.1],
                     [start.plus(3000).millis, 43.1],
                     [start.plus(2000).millis, 42.1]
@@ -285,13 +302,12 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxBottom() {
-    def tenantId = nextTenantId()
     def timeseriesName = "influx.bottom"
     def start = now().minus(4000)
-    postData(tenantId, timeseriesName, start)
+    postData(timeseriesName, start)
 
-    def influxQuery = 'select bottom(value, 3) from "' + timeseriesName + '" where time > now() - 30s group by time' +
-        '(30s)'
+    def influxQuery = """select bottom(value, 3) from "${timeseriesName}" where time > now() - 30s
+                         group by time(30s)"""
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
     assertEquals(200, response.status)
@@ -300,8 +316,8 @@ class InfluxITest extends RESTTest {
         [
             [
                 columns: ["time", "bottom"],
-                name   : timeseriesName,
-                points : [
+                name: timeseriesName,
+                points: [
                     [start.millis, 40.1],
                     [start.plus(1000).millis, 41.1],
                     [start.plus(2000).millis, 42.1]
@@ -314,12 +330,11 @@ class InfluxITest extends RESTTest {
 
   @Test
   void testInfluxStddev() {
-    def tenantId = nextTenantId()
     def timeseriesName = "influx.stddev"
     def start = now().minus(4000)
-    postData(tenantId, timeseriesName, start)
+    postData(timeseriesName, start)
 
-    def influxQuery = 'select stddev(value) from "' + timeseriesName + '" where time > now() - 30s group by time(30s)'
+    def influxQuery = """select stddev(value) from "${timeseriesName}" where time > now() - 30s group by time(30s)"""
 
     def response = hawkularMetrics.get(path: "db/${tenantId}/series", query: [q: influxQuery])
     assertEquals(200, response.status)
@@ -328,8 +343,8 @@ class InfluxITest extends RESTTest {
         [
             [
                 columns: ["time", "stddev"],
-                name   : timeseriesName,
-                points : [
+                name: timeseriesName,
+                points: [
                     [start.plus(4000).millis, 1.5811388300841898]
                 ]
             ]
@@ -338,7 +353,7 @@ class InfluxITest extends RESTTest {
     )
   }
 
-  private static void postData(String tenantId, String timeseriesName, DateTime start) {
+  void postData(String timeseriesName, DateTime start) {
     def response = hawkularMetrics.post(path: "db/${tenantId}/series", body: [
         [
             name: timeseriesName,


### PR DESCRIPTION
This PR implements "HWKMETRICS-65 Influx endpoint: add suport for timestamp precision query parameter" and fixes some issues for better Grafana compatibility:

- Avoid integer "overflow"

The parser used to store time amounts into int variables. This led to parsing errors if a time range operand was too far in the past.

- In where clause, absolute and relative time operands might have no time unit

The parser used to support explicit time units only, but the in the query language spec (aka the online manual) it is allowed to omit it.
