### PR TITLE
HWKMETRICS-252 Warning about batch size threshold in the logs

### DIFF
--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
@@ -61,9 +61,6 @@ public interface DataAccess {
 
     Observable<ResultSet> deleteTags(Metric metric, Set<String> tags);
 
-    Observable<ResultSet> updateTagsInMetricsIndex(Metric metric, Map<String, String> additions,
-            Set<String> deletions);
-
     <T> Observable<Integer> updateMetricsIndex(Observable<Metric<T>> metrics);
 
     Observable<ResultSet> findMetricsInMetricsIndex(String tenantId, MetricType<?> type);

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/transformers/BatchStatementTransformer.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/transformers/BatchStatementTransformer.java
@@ -32,8 +32,7 @@ import rx.functions.Func0;
  * @author Thomas Segismont
  */
 public class BatchStatementTransformer implements Transformer<Statement, BatchStatement> {
-
-    public static final int MAX_BATCH_SIZE = 1024;
+    public static final int MAX_BATCH_SIZE = 64;
 
     /**
      * Creates {@link com.datastax.driver.core.BatchStatement.Type#UNLOGGED} batch statements.

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
@@ -105,12 +105,6 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> updateTagsInMetricsIndex(Metric metric, Map<String, String> additions,
-            Set<String> deletions) {
-        return delegate.updateTagsInMetricsIndex(metric, additions, deletions);
-    }
-
-    @Override
     public <T> Observable<Integer> updateMetricsIndex(Observable<Metric<T>> metrics) {
         return delegate.updateMetricsIndex(metrics);
     }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -161,13 +161,13 @@ class TagsITest extends RESTTest {
       assertEquals(200, response.status)
       assertTrue(response.data instanceof List)
       assertEquals(2, response.data.size())
-      assertTrue(response.data.contains([
+      assertTrue((response.data ?: []).contains([
         tenantId: tenantId,
         id      : 'N1',
         tags    : ['a1': 'A', 'd1': 'B'],
         type: it.type
       ]))
-      assertTrue(response.data.contains([
+      assertTrue((response.data ?: []).contains([
         tenantId: tenantId,
         id      : 'N2',
         tags    : ['a1': 'A2'],


### PR DESCRIPTION
HWKMETRICS-252 Warning about batch size threshold in the logs

Reduced the number of statements per batch.

Also, removed unused method and batch statement usage where not needed.