### PR TITLE
HWKMETRICS-274 Missing JBoss logging method on EAP6.4

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -20,7 +20,7 @@ a logger instance with proper category
 The logging `projectCode` is `HAWKMETRICS`.
 
 Note that until we no longer need to support EAP 6.4,
-http://lists.jboss.org/pipermail/hawkular-dev/2015-March/000378.html[we must not use primitive arguments in logging interfaces].
+http://lists.jboss.org/pipermail/hawkular-dev/2015-March/000378.html[we must not use primitive arguments in logging method calls].
 
 Logback is the logging backend for tests. It allows to http://git.io/vnDlr[set log level with a system property]
 while still having a default value. No Maven filtering/replace dance involved.

--- a/task-queue/src/main/java/org/hawkular/metrics/tasks/impl/TaskSchedulerImpl.java
+++ b/task-queue/src/main/java/org/hawkular/metrics/tasks/impl/TaskSchedulerImpl.java
@@ -338,8 +338,10 @@ public class TaskSchedulerImpl implements TaskScheduler {
             // we acquire a lease, we execute all of the tasks for the lease. We check for
             // available leases again only after those tasks have completed.
             try {
-                log.debugf("Loading leases for %s", timeSlice);
-                log.debugf("Timestamp is %s", timeSlice.getTime());
+                if (log.isDebugEnabled()) {
+                    log.debug("Loading leases for " + timeSlice);
+                    log.debug("Timestamp is " + timeSlice.getTime());
+                }
                 List<Lease> leases = findAvailableLeases(timeSlice);
                 while (!leases.isEmpty()) {
                     for (Lease lease : leases) {


### PR DESCRIPTION
Do not use primitive arguments in logging methods calls.