### PR TITLE
HWKMETRICS-252 Warning about batch size threshold in the logs

### DIFF
--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/transformers/BatchStatementTransformer.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/transformers/BatchStatementTransformer.java
@@ -32,7 +32,7 @@ import rx.functions.Func0;
  * @author Thomas Segismont
  */
 public class BatchStatementTransformer implements Transformer<Statement, BatchStatement> {
-    public static final int MAX_BATCH_SIZE = 64;
+    public static final int MAX_BATCH_SIZE = 10;
 
     /**
      * Creates {@link com.datastax.driver.core.BatchStatement.Type#UNLOGGED} batch statements.


### PR DESCRIPTION
HWKMETRICS-252 Warning about batch size threshold in the logs

Use more conservative value since warnings are still present on Openshift.