### PR TITLE
Close C* cluster only when session creation fails

### DIFF
--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -268,14 +268,14 @@ public class MetricsServiceLifecycle {
             clusterBuilder.withSSL();
         }
 
-        Cluster cluster = null;
+        Cluster cluster = clusterBuilder.build();
+        cluster.init();
         Session createdSession = null;
         try {
-            cluster = clusterBuilder.build();
             createdSession = cluster.connect("system");
             return createdSession;
         } finally {
-            if (createdSession == null && cluster != null) {
+            if (createdSession == null) {
                 cluster.close();
             }
         }


### PR DESCRIPTION
While working on another driver issue today,
I realized that we do not need to call cluster#close if cluster init fails.

So I've changed #createSession method a bit to call cluster#close only when necessary.