### PR TITLE
Change percentile95th -> percentile and add percentile query parameter

### DIFF
--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/param/Percentiles.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/param/Percentiles.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import java.util.List;
+
+/**
+ * A wrapping class for List<Double> of percentile requests for JAX-RS
+ *
+ * @author Michael Burman
+ */
+public class Percentiles {
+
+    private List<Double> percentiles;
+
+    public Percentiles(List<Double> percentiles) {
+        this.percentiles = percentiles;
+    }
+
+    public List<Double> getPercentiles() {
+        return percentiles;
+    }
+
+    public void setPercentiles(List<Double> percentiles) {
+        this.percentiles = percentiles;
+    }
+}

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/HawkularMetricsRestApp.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/HawkularMetricsRestApp.java
@@ -46,6 +46,7 @@ import org.hawkular.metrics.api.jaxrs.log.RestLogger;
 import org.hawkular.metrics.api.jaxrs.log.RestLogging;
 import org.hawkular.metrics.api.jaxrs.param.DurationConverter;
 import org.hawkular.metrics.api.jaxrs.param.MetricTypeConverter;
+import org.hawkular.metrics.api.jaxrs.param.PercentilesConverter;
 import org.hawkular.metrics.api.jaxrs.param.TagsConverter;
 
 /**
@@ -116,6 +117,7 @@ public class HawkularMetricsRestApp extends Application {
         classes.add(DurationConverter.class);
         classes.add(MetricTypeConverter.class);
         classes.add(TagsConverter.class);
+        classes.add(PercentilesConverter.class);
 
         return classes;
     }

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -25,6 +25,7 @@ import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.serverError;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -50,6 +51,7 @@ import org.hawkular.metrics.api.jaxrs.model.GaugeDataPoint;
 import org.hawkular.metrics.api.jaxrs.model.MetricDefinition;
 import org.hawkular.metrics.api.jaxrs.param.BucketConfig;
 import org.hawkular.metrics.api.jaxrs.param.Duration;
+import org.hawkular.metrics.api.jaxrs.param.Percentiles;
 import org.hawkular.metrics.api.jaxrs.param.Tags;
 import org.hawkular.metrics.api.jaxrs.param.TimeRange;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
@@ -195,7 +197,8 @@ public class CounterHandler {
             @QueryParam("start") Long start,
             @QueryParam("end") Long end,
             @QueryParam("buckets") Integer bucketsCount,
-            @QueryParam("bucketDuration") Duration bucketDuration
+            @QueryParam("bucketDuration") Duration bucketDuration,
+            @QueryParam("percentiles") Percentiles percentiles
     ) {
         TimeRange timeRange = new TimeRange(start, end);
         if (!timeRange.isValid()) {
@@ -217,12 +220,17 @@ public class CounterHandler {
                         .toBlocking()
                         .lastOrDefault(null);
             } else {
+                if(percentiles == null) {
+                    percentiles = new Percentiles(Collections.<Double>emptyList());
+                }
+
                 return metricsService
-                        .findCounterStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets)
+                        .findCounterStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
+                                percentiles.getPercentiles())
                         .map(ApiUtils::collectionToResponse)
                         .toBlocking()
                         .lastOrDefault(null);
-            }
+           }
         } catch (Exception e) {
             return serverError(e);
         }
@@ -235,7 +243,8 @@ public class CounterHandler {
         @QueryParam("start") Long start,
         @QueryParam("end") Long end,
         @QueryParam("buckets") Integer bucketsCount,
-        @QueryParam("bucketDuration") Duration bucketDuration
+        @QueryParam("bucketDuration") Duration bucketDuration,
+        @QueryParam("percentiles") Percentiles percentiles
     ) {
         TimeRange timeRange = new TimeRange(start, end);
         if (!timeRange.isValid()) {
@@ -258,8 +267,13 @@ public class CounterHandler {
                         .toBlocking()
                         .lastOrDefault(null);
             } else {
+                if(percentiles == null) {
+                    percentiles = new Percentiles(Collections.<Double>emptyList());
+                }
+
                 return metricsService
-                        .findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets)
+                        .findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
+                                percentiles.getPercentiles())
                         .map(ApiUtils::collectionToResponse)
                         .toBlocking()
                         .lastOrDefault(null);

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/param/PercentilesConverter.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/param/PercentilesConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.StringConverter;
+
+/**
+ * A RestEasy StringConverter from number,number,number input string to a Percentiles or vice-versa.
+ *
+ * @author Michael Burman
+ */
+@Provider
+public class PercentilesConverter implements StringConverter<Percentiles> {
+    @Override public Percentiles fromString(String param) {
+        return new Percentiles(Arrays.stream(param.split(",")).map(Double::valueOf).collect(Collectors.toList()));
+    }
+
+    @Override public String toString(Percentiles percentiles) {
+        return percentiles.getPercentiles().stream().map(Object::toString).collect(Collectors.joining(","));
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -26,6 +26,7 @@ import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.valueToResponse;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -55,6 +56,7 @@ import org.hawkular.metrics.api.jaxrs.model.GaugeDataPoint;
 import org.hawkular.metrics.api.jaxrs.model.MetricDefinition;
 import org.hawkular.metrics.api.jaxrs.param.BucketConfig;
 import org.hawkular.metrics.api.jaxrs.param.Duration;
+import org.hawkular.metrics.api.jaxrs.param.Percentiles;
 import org.hawkular.metrics.api.jaxrs.param.Tags;
 import org.hawkular.metrics.api.jaxrs.param.TimeRange;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
@@ -239,7 +241,8 @@ public class CounterHandler {
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
             @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
             @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
-            @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration
+            @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
+            @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles
     ) {
         TimeRange timeRange = new TimeRange(start, end);
         if (!timeRange.isValid()) {
@@ -261,7 +264,12 @@ public class CounterHandler {
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
         } else {
-            metricsService.findCounterStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets)
+            if(percentiles == null) {
+                percentiles = new Percentiles(Collections.<Double>emptyList());
+            }
+
+            metricsService.findCounterStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
+                    percentiles.getPercentiles())
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
         }
@@ -287,7 +295,8 @@ public class CounterHandler {
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
             @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
             @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
-            @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration
+            @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
+            @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles
     ) {
         TimeRange timeRange = new TimeRange(start, end);
         if (!timeRange.isValid()) {
@@ -309,7 +318,12 @@ public class CounterHandler {
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
         } else {
-            metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets)
+            if(percentiles == null) {
+                percentiles = new Percentiles(Collections.<Double>emptyList());
+            }
+
+            metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
+                    percentiles.getPercentiles())
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
         }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/ConvertersProvider.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/ConvertersProvider.java
@@ -42,6 +42,7 @@ public class ConvertersProvider implements ParamConverterProvider {
                 .put(Duration.class, new DurationConverter())
                 .put(Tags.class, new TagsConverter())
                 .put(MetricType.class, new MetricTypeConverter())
+                .put(Percentiles.class, new PercentilesConverter())
                 .build();
     }
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/PercentilesConverter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/PercentilesConverter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.ext.ParamConverter;
+
+/**
+ * A JAX-RS ParamConverter from number,number,number input string to a Percentiles or vice-versa.
+ *
+ * @author Michael Burman
+ */
+public class PercentilesConverter implements ParamConverter<Percentiles> {
+    @Override
+    public Percentiles fromString(String param) {
+        return new Percentiles(Arrays.stream(param.split(",")).map(Double::valueOf).collect(Collectors.toList()));
+    }
+
+    @Override
+    public String toString(Percentiles percentiles) {
+        return percentiles.getPercentiles().stream().map(Object::toString).collect(Collectors.joining(","));
+    }
+}

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -149,7 +149,7 @@ public interface MetricsService {
                                     Func1<Observable<DataPoint<Double>>, Observable<T>>... funcs);
 
     Observable<List<NumericBucketPoint>> findGaugeStats(MetricId<Double> metricId, long start, long end,
-                                                        Buckets buckets);
+                                                        Buckets buckets, List<Double> percentiles);
 
     /**
      * Fetches data points from multiple metrics that are determined by a tags filter query. Down sampling is performed
@@ -165,7 +165,7 @@ public interface MetricsService {
      * @return An {@link Observable} that emits a single list of {@link NumericBucketPoint}
      */
     Observable<List<NumericBucketPoint>> findGaugeStats(String tenantId, Map<String, String> tagFilters, long start,
-                                                        long end, Buckets buckets);
+                                                        long end, Buckets buckets, List<Double> percentiles);
 
     /**
      * Fetches data points from multiple metrics. Down sampling is performed such that data points from all matching
@@ -181,7 +181,7 @@ public interface MetricsService {
      * @return An {@link Observable} that emits a single list of {@link NumericBucketPoint}
      */
     Observable<List<NumericBucketPoint>> findGaugeStats(String tenantId, List<String> metrics, long start, long end,
-                                                        Buckets buckets);
+                                                        Buckets buckets, List<Double> percentiles);
 
     Observable<DataPoint<AvailabilityType>> findAvailabilityData(MetricId<AvailabilityType> id, long start, long end,
                                                                  boolean distinct);
@@ -202,7 +202,8 @@ public interface MetricsService {
      *
      * @return an {@link Observable} emitting a single {@link List} of {@link NumericBucketPoint}
      */
-    Observable<List<NumericBucketPoint>> findCounterStats(MetricId<Long> id, long start, long end, Buckets buckets);
+    Observable<List<NumericBucketPoint>> findCounterStats(MetricId<Long> id, long start, long end, Buckets buckets,
+                                                          List<Double> percentiles);
 
     /**
      * Fetches counter data points and calculates per-minute rates.
@@ -226,7 +227,8 @@ public interface MetricsService {
      *
      * @return an {@link Observable} emitting a single {@link List} of {@link NumericBucketPoint}
      */
-    Observable<List<NumericBucketPoint>> findRateStats(MetricId<Long> id, long start, long end, Buckets buckets);
+    Observable<List<NumericBucketPoint>> findRateStats(MetricId<Long> id, long start, long end, Buckets buckets,
+                                                       List<Double> percentiles);
 
     /**
      * <p>

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/NumericBucketPoint.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/NumericBucketPoint.java
@@ -19,6 +19,7 @@ package org.hawkular.metrics.core.api;
 import static java.lang.Double.NaN;
 import static java.lang.Double.isNaN;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -33,15 +34,19 @@ public final class NumericBucketPoint extends BucketPoint {
     private final double median;
     private final double max;
     private final double percentile95th;
+    private int samples;
+    private final List<Percentile> percentiles;
 
     private NumericBucketPoint(long start, long end, double min, double avg, double median, double max, double
-            percentile95th) {
+            percentile95th, List<Percentile> percentiles, int samples) {
         super(start, end);
         this.min = min;
         this.avg = avg;
         this.median = median;
         this.max = max;
         this.percentile95th = percentile95th;
+        this.percentiles = percentiles;
+        this.samples = samples;
     }
 
     public double getMin() {
@@ -64,9 +69,17 @@ public final class NumericBucketPoint extends BucketPoint {
         return percentile95th;
     }
 
+    public List<Percentile> getPercentiles() {
+        return percentiles;
+    }
+
+    public int getSamples() {
+        return samples;
+    }
+
     @Override
     public boolean isEmpty() {
-        return isNaN(min) || isNaN(avg) || isNaN(median) || isNaN(max) || isNaN(percentile95th);
+        return samples == 0 || isNaN(min) || isNaN(avg) || isNaN(median) || isNaN(max) || isNaN(percentile95th);
     }
 
     @Override
@@ -79,6 +92,8 @@ public final class NumericBucketPoint extends BucketPoint {
                 ", median=" + median +
                 ", max=" + max +
                 ", percentile95th=" + percentile95th +
+                ", percentiles=" + percentiles +
+                ", samples=" + samples +
                 ", isEmpty=" + isEmpty() +
                 ']';
     }
@@ -98,6 +113,8 @@ public final class NumericBucketPoint extends BucketPoint {
         private double median = NaN;
         private double max = NaN;
         private double percentile95th = NaN;
+        private List<Percentile> percentiles = new ArrayList<>();
+        private int samples = 0;
 
         /**
          * Creates a builder for an initially empty instance, configurable with the builder setters.
@@ -135,8 +152,18 @@ public final class NumericBucketPoint extends BucketPoint {
             return this;
         }
 
+        public Builder setPercentiles(List<Percentile> percentiles) {
+            this.percentiles = percentiles;
+            return this;
+        }
+
+        public Builder setSamples(int samples) {
+            this.samples = samples;
+            return this;
+        }
+
         public NumericBucketPoint build() {
-            return new NumericBucketPoint(start, end, min, avg, median, max, percentile95th);
+            return new NumericBucketPoint(start, end, min, avg, median, max, percentile95th, percentiles, samples);
         }
     }
 

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/Percentile.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/Percentile.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.api;
+
+/**
+ * @author Michael Burman
+ */
+public class Percentile {
+    private double target;
+    private double value = 0.0;
+
+    public Percentile(double quantile) {
+        this.target = quantile;
+    }
+
+    public Percentile(double quantile, double value) {
+        this.target = quantile;
+        this.value = value;
+    }
+
+    public double getQuantile() {
+        return target;
+    }
+
+    public void setQuantile(double target) {
+        this.target = target;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+}

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/PercentileWrapper.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/PercentileWrapper.java
@@ -26,7 +26,7 @@ package org.hawkular.metrics.core.impl;
  *
  * @author jsanda
  */
-public interface Percentile {
+public interface PercentileWrapper {
 
     void addValue(double value);
 

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
@@ -119,34 +119,37 @@ class GaugeMetricStatisticsITest extends RESTTest {
     def expectedData = [
         [
             start: buckets[0], end: buckets[0] + bucketSize, empty: false, min: 12.22,
-            avg: avg0.getResult(), median: med0.getResult(), max: 15.37, percentile95th: perc95th0.getResult()
+            avg: avg0.getResult(), median: med0.getResult(), max: 15.37, percentile95th: perc95th0.getResult(),
+            samples: 2
         ], [
             start: buckets[1], end: buckets[1] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN
+            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
         ], [
             start: buckets[2], end: buckets[2] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN
+            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
         ], [
             start: buckets[3], end: buckets[3] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN
+            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
         ], [
             start: buckets[4], end: buckets[4] + bucketSize, empty: false, min: 25.0,
-            avg  : 25.0, median: 25.0, max: 25.0, percentile95th: 25.0],
+            avg  : 25.0, median: 25.0, max: 25.0, percentile95th: 25.0, samples: 2
+        ],
         [
             start: buckets[5], end: buckets[5] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN
+            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
         ], [
             start: buckets[6], end: buckets[6] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN
+            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
         ], [
             start: buckets[7], end: buckets[7] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN
+            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
         ], [
             start: buckets[8], end: buckets[8] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN
+            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
         ], [
             start: buckets[9], end: buckets[9] + bucketSize, empty: false, min: 18.367,
-            avg: avg9.getResult(), median: med9.getResult(), max: 19.01, percentile95th: perc95th9.getResult()
+            avg: avg9.getResult(), median: med9.getResult(), max: 19.01, percentile95th: perc95th9.getResult(),
+            samples: 2
         ]
     ]
 
@@ -199,6 +202,7 @@ class GaugeMetricStatisticsITest extends RESTTest {
           median        : median.getResult(),
           max           : max.getResult(),
           percentile95th: perc95th.getResult(),
+          samples       : sampleSize,
           empty         : false
       ])
     }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -162,6 +162,7 @@ Actual: ${actual}
     assertEquals(msg, expected.start, actual.start)
     assertEquals(msg, expected.end, actual.end)
     assertEquals(msg, expected.empty, actual.empty)
+    assertEquals(msg, expected.samples, actual.samples)
     if (!expected.empty) {
       assertDoubleEquals(msg, expected.min, actual.min)
       assertDoubleEquals(msg, expected.avg, actual.avg)


### PR DESCRIPTION
This allows requesting different percentile than 95th to be calculated when requesting buckets. The REST API changes from `percentile95th` -> `percentile` parameter and the new query parameter is called `percentile` (with a default value of 95.00 for old use-cases).

This is necessary for the Initial Resources implementation (it needs configurable percentile), although I'd almost want to see following:

`?buckets=1&percentiles=90,99,99.9` returning:

```javascript
"percentiles": {
  "90": 0.0
  "99": 0.0
  "99.9": 0.0
}
```