### PR TITLE
HWKMETRICS-83 Create glue code component to integrate with hawkular-bus

### DIFF
--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/ServiceReady.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/ServiceReady.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier used to fire an {@link javax.enterprise.event.Event} when the
+ * {@link org.hawkular.metrics.core.api.MetricsService} is initialized (ready to use).
+ *
+ * @author Thomas Segismont
+ */
+@Qualifier
+@Target({METHOD, FIELD, PARAMETER, TYPE})
+@Retention(RUNTIME)
+public @interface ServiceReady {
+}

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -255,4 +255,9 @@ public interface MetricsService {
      * the predicate matches, and the second element is the end time inclusive for which the predicate matches.
      */
     Observable<List<long[]>> getPeriods(MetricId<Double> id, Predicate<Double> predicate, long start, long end);
+
+    /**
+     * @return a hot {@link Observable} emitting {@link Metric} events after data has been inserted
+     */
+    Observable<Metric<?>> insertedDataEvents();
 }

--- a/hawkular-component/pom.xml
+++ b/hawkular-component/pom.xml
@@ -65,6 +65,23 @@
       <artifactId>hawkular-bus-common</artifactId>
       <version>${version.org.hawkular.bus}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.activemq</groupId>
+          <artifactId>activemq-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.activemq</groupId>
+          <artifactId>activemq-jaas</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Nest provided -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-client</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- Wildfly provided -->
     <!-- No need to set the jboss-logging scope here since Wildfly BOM includes jboss-logging -->
@@ -77,6 +94,10 @@
       <groupId>org.jboss.spec.javax.ejb</groupId>
       <artifactId>jboss-ejb-api_3.2_spec</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.jms</groupId>
+      <artifactId>jboss-jms-api_2.0_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
@@ -109,6 +130,11 @@
     <dependency>
       <groupId>org.codehaus.groovy.modules.http-builder</groupId>
       <artifactId>http-builder</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hawkular-component/pom.xml
+++ b/hawkular-component/pom.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.metrics</groupId>
+    <artifactId>hawkular-metrics-parent</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-metrics-component</artifactId>
+  <packaging>war</packaging>
+
+  <name>Hawkular Metrics Component</name>
+  <description>Metrics component within Hawkular suite</description>
+
+  <properties>
+    <version.org.hawkular.bus>0.7.0.Final</version.org.hawkular.bus>
+    <!-- For tests -->
+    <wildfly-maven-plugin.skip>true</wildfly-maven-plugin.skip>
+    <cassandra.keyspace>hawkular_metrics_component_integration_tests</cassandra.keyspace>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>jboss-javaee-7.0-wildfly</artifactId>
+        <version>${version.org.wildfly}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.hawkular.metrics</groupId>
+      <artifactId>hawkular-metrics-api-common</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hawkular.bus</groupId>
+      <artifactId>hawkular-bus-common</artifactId>
+      <version>${version.org.hawkular.bus}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Wildfly provided -->
+    <!-- No need to set the jboss-logging scope here since Wildfly BOM includes jboss-logging -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ejb</groupId>
+      <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+      <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Overlay -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hawkular-metrics-api-jaxrs</artifactId>
+      <version>${project.version}</version>
+      <type>war</type>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy.modules.http-builder</groupId>
+      <artifactId>http-builder</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>hawkular-metrics-component</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
+          <overlays>
+            <overlay>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>hawkular-metrics-api-jaxrs</artifactId>
+            </overlay>
+          </overlays>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/*ITest*</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-maven-plugin</artifactId>
+        <configuration>
+          <groupId>org.hawkular.nest</groupId>
+          <artifactId>hawkular-nest-distro</artifactId>
+          <version>${version.org.hawkular.bus}</version>
+          <classifier>distribution</classifier>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>component-integration-tests</id>
+      <activation>
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <properties>
+        <wildfly-maven-plugin.skip>false</wildfly-maven-plugin.skip>
+        <component.wildfly.port.offset>3</component.wildfly.port.offset>
+        <!-- IMPORTANT: The port must be the port offset + 8080. -->
+        <base-uri>127.0.0.1:8083/hawkular/metrics</base-uri>
+        <!-- IMPORTANT: The port must be the port offset + 62626. -->
+        <broker.url>tcp://localhost:62629</broker.url>
+        <!-- IMPORTANT: The management port must be the port offset + 9990. -->
+        <component.wildfly.management.port>9993</component.wildfly.management.port>
+        <wildfly.logging.console.level>ERROR</wildfly.logging.console.level>
+        <wildfly.logging.file.level>ERROR</wildfly.logging.file.level>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*ITest*</include>
+              </includes>
+              <systemPropertyVariables>
+                <keyspace>${cassandra.keyspace}</keyspace>
+                <hawkular-metrics.base-uri>${base-uri}</hawkular-metrics.base-uri>
+                <hawkular-bus.broker.url>${broker.url}</hawkular-bus.broker.url>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <configuration>
+              <skip>${wildfly-maven-plugin.skip}</skip>
+              <port>${component.wildfly.management.port}</port>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start-wildfly</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+                <configuration>
+                  <javaOpts>
+                    <javaOpt>-Xms64m</javaOpt>
+                    <javaOpt>-Xmx512m</javaOpt>
+                    <javaOpt>-Xss256k</javaOpt>
+                    <javaOpt>-Djava.net.preferIPv4Stack=true</javaOpt>
+                    <javaOpt>-Dsun.rmi.dgc.client.gcInterval=3600000</javaOpt>
+                    <javaOpt>-Dsun.rmi.dgc.server.gcInterval=3600000</javaOpt>
+                    <javaOpt>-Djboss.socket.binding.port-offset=${component.wildfly.port.offset}</javaOpt>
+                    <javaOpt>-Dcassandra.keyspace=${cassandra.keyspace}</javaOpt>
+                    <javaOpt>-Dcassandra.resetdb</javaOpt>
+                    <javaOpt>-Dhawkular.metrics.waitForService</javaOpt>
+                    <javaOpt>-Xdebug</javaOpt>
+                    <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
+                  </javaOpts>
+                </configuration>
+              </execution>
+              <execution>
+                <id>deploy-webapp</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>deploy-only</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop-wildfly</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>shutdown</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>wildfly.deployment</id>
+      <activation>
+        <property>
+          <name>!running.service</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-standalone-test</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <!--
+                    We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
+                    configuration files and override the default configuration directory. See
+                    https://issues.jboss.org/browse/JBASMP-75 for details.
+                  -->
+                  <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
+                  <overwrite>true</overwrite>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
+                  <delimiters>
+                    <delimiter>@@@</delimiter>
+                  </delimiters>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src/test/wildfly-configuration</directory>
+                      <includes>
+                        <include>*</include>
+                      </includes>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/hawkular-component/pom.xml
+++ b/hawkular-component/pom.xml
@@ -203,10 +203,6 @@
           <plugin>
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-maven-plugin</artifactId>
-            <configuration>
-              <skip>${wildfly-maven-plugin.skip}</skip>
-              <port>${component.wildfly.management.port}</port>
-            </configuration>
             <executions>
               <execution>
                 <id>start-wildfly</id>
@@ -215,6 +211,8 @@
                   <goal>start</goal>
                 </goals>
                 <configuration>
+                  <skip>${wildfly-maven-plugin.skip}</skip>
+                  <port>${component.wildfly.management.port}</port>
                   <javaOpts>
                     <javaOpt>-Xms64m</javaOpt>
                     <javaOpt>-Xmx512m</javaOpt>
@@ -237,6 +235,10 @@
                 <goals>
                   <goal>deploy-only</goal>
                 </goals>
+                <configuration>
+                  <skip>${wildfly-maven-plugin.skip}</skip>
+                  <port>${component.wildfly.management.port}</port>
+                </configuration>
               </execution>
               <execution>
                 <id>stop-wildfly</id>
@@ -244,6 +246,10 @@
                 <goals>
                   <goal>shutdown</goal>
                 </goals>
+                <configuration>
+                  <skip>${wildfly-maven-plugin.skip}</skip>
+                  <port>${component.wildfly.management.port}</port>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/hawkular-component/pom.xml
+++ b/hawkular-component/pom.xml
@@ -230,6 +230,30 @@
                 </configuration>
               </execution>
               <execution>
+                <id>configure-loggers</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>execute-commands</goal>
+                </goals>
+                <configuration>
+                  <skip>${wildfly-maven-plugin.skip}</skip>
+                  <port>${component.wildfly.management.port}</port>
+                  <executeCommands>
+                    <commands>
+                      <command>
+                        /subsystem=logging/console-handler=CONSOLE:write-attribute(name="level",value="${wildfly.logging.console.level}")
+                      </command>
+                      <command>
+                        /subsystem=logging/periodic-rotating-file-handler=FILE:write-attribute(name="level",value="${wildfly.logging.file.level}")
+                      </command>
+                      <commmand>
+                        /subsystem=logging/periodic-rotating-file-handler=FILE:write-attribute(name="file",value={path="${project.build.directory}/wildfly-test.log"})
+                      </commmand>
+                    </commands>
+                  </executeCommands>
+                </configuration>
+              </execution>
+              <execution>
                 <id>deploy-webapp</id>
                 <phase>pre-integration-test</phase>
                 <goals>
@@ -257,53 +281,6 @@
       </build>
     </profile>
 
-    <profile>
-      <id>wildfly.deployment</id>
-      <activation>
-        <property>
-          <name>!running.service</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-standalone-test</id>
-                <phase>process-test-resources</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <!--
-                    We cannot specify an arbitrary path to standalone-test.xml, so we include the necessary
-                    configuration files and override the default configuration directory. See
-                    https://issues.jboss.org/browse/JBASMP-75 for details.
-                  -->
-                  <outputDirectory>${project.build.directory}/wildfly-configuration</outputDirectory>
-                  <overwrite>true</overwrite>
-                  <useDefaultDelimiters>false</useDefaultDelimiters>
-                  <delimiters>
-                    <delimiter>@@@</delimiter>
-                  </delimiters>
-                  <resources>
-                    <resource>
-                      <directory>${project.basedir}/src/test/wildfly-configuration</directory>
-                      <includes>
-                        <include>*</include>
-                      </includes>
-                      <filtering>true</filtering>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
 </project>

--- a/hawkular-component/pom.xml
+++ b/hawkular-component/pom.xml
@@ -238,6 +238,7 @@
                 <configuration>
                   <skip>${wildfly-maven-plugin.skip}</skip>
                   <port>${component.wildfly.management.port}</port>
+                  <jbossHome>${project.build.directory}/wildfly-run/wildfly-${version.org.wildfly}</jbossHome>
                   <executeCommands>
                     <commands>
                       <command>

--- a/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/AvailDataMessage.java
+++ b/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/AvailDataMessage.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.component.publish;
+
+import java.util.List;
+
+import org.hawkular.bus.common.AbstractMessage;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * A bus message for messages on HawkularAvailData Topic.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+
+public class AvailDataMessage extends AbstractMessage {
+
+    // the basic message body - it will be exposed to the JSON output
+    @JsonInclude
+    private AvailData availData;
+
+    protected AvailDataMessage() {
+    }
+
+    public AvailDataMessage(AvailData metricData) {
+        this.availData = metricData;
+    }
+
+    public AvailData getAvailData() {
+        return availData;
+    }
+
+    public void setAvailData(AvailData availData) {
+        this.availData = availData;
+    }
+
+    public static class AvailData {
+        @JsonInclude
+        List<SingleAvail> data;
+
+        public AvailData() {
+        }
+
+        public List<SingleAvail> getData() {
+            return data;
+        }
+
+        public void setData(List<SingleAvail> data) {
+            this.data = data;
+        }
+
+        @Override
+        public String toString() {
+            return "AvailData [data=" + data + "]";
+        }
+    }
+
+    /**
+     * This is meant to parse out an instance of <code>org.rhq.metrics.client.common.SingleMetric</code>
+     */
+    public static class SingleAvail {
+        @JsonInclude
+        private String tenantId;
+        @JsonInclude
+        private String id;
+        @JsonInclude
+        private long timestamp;
+        @JsonInclude
+        private String avail;
+
+        public SingleAvail() {
+        }
+
+        public SingleAvail(String tenantId, String id, long timestamp, String avail) {
+            this.tenantId = tenantId;
+            this.id = id;
+            this.timestamp = timestamp;
+            this.avail = avail;
+        }
+
+        public String getTenantId() {
+            return tenantId;
+        }
+
+        public void setTenantId(String tenantId) {
+            this.tenantId = tenantId;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+
+        public void setTimestamp(long timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        public String getAvail() {
+            return avail;
+        }
+
+        public void setAvail(String avail) {
+            this.avail = avail;
+        }
+
+        @Override
+        public String toString() {
+            return "SingleAvail [tenantId=" + tenantId + ", id=" + id + ", timestamp=" + timestamp + ", avail="
+                    + avail + "]";
+        }
+
+    }
+
+}

--- a/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/AvailDataPublisher.java
+++ b/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/AvailDataPublisher.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.component.publish;
+
+import static java.util.stream.Collectors.toList;
+
+import static javax.ejb.ConcurrencyManagementType.BEAN;
+import static javax.ejb.TransactionAttributeType.NEVER;
+
+import static org.hawkular.bus.common.Endpoint.Type.TOPIC;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.ConcurrencyManagement;
+import javax.ejb.Singleton;
+import javax.ejb.TransactionAttribute;
+import javax.jms.JMSException;
+import javax.jms.TopicConnectionFactory;
+
+import org.hawkular.bus.common.BasicMessage;
+import org.hawkular.bus.common.ConnectionContextFactory;
+import org.hawkular.bus.common.Endpoint;
+import org.hawkular.bus.common.MessageProcessor;
+import org.hawkular.bus.common.producer.ProducerConnectionContext;
+import org.hawkular.metrics.core.api.AvailabilityType;
+import org.hawkular.metrics.core.api.Metric;
+import org.hawkular.metrics.core.api.MetricId;
+import org.jboss.logging.Logger;
+
+/**
+ * Publishes {@link AvailDataMessage} messages on the Hawkular bus.
+ *
+ * @author Thomas Segismont
+ */
+@Singleton
+@TransactionAttribute(NEVER)
+@ConcurrencyManagement(BEAN)
+public class AvailDataPublisher {
+    private static final Logger log = Logger.getLogger(AvailDataPublisher.class);
+
+    static final String HAWULAR_AVAIL_DATA_TOPIC = "HawkularAvailData";
+
+    @Resource(mappedName = "java:/HawkularBusConnectionFactory")
+    TopicConnectionFactory topicConnectionFactory;
+
+    private MessageProcessor messageProcessor;
+    private ConnectionContextFactory connectionContextFactory;
+    private ProducerConnectionContext producerConnectionContext;
+
+    @PostConstruct
+    void init() {
+        messageProcessor = new MessageProcessor();
+        try {
+            connectionContextFactory = new ConnectionContextFactory(topicConnectionFactory);
+            Endpoint endpoint = new Endpoint(TOPIC, HAWULAR_AVAIL_DATA_TOPIC);
+            producerConnectionContext = connectionContextFactory.createProducerConnectionContext(endpoint);
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void publish(Metric<AvailabilityType> metric) {
+        BasicMessage basicMessage = createAvailMessage(metric);
+        try {
+            messageProcessor.send(producerConnectionContext, basicMessage);
+            log.tracef("Sent message: %s", basicMessage);
+        } catch (JMSException e) {
+            log.warnf(e, "Could not send metric: %s", metric);
+        }
+    }
+
+    private BasicMessage createAvailMessage(Metric<AvailabilityType> avail) {
+        MetricId<AvailabilityType> availId = avail.getId();
+        List<AvailDataMessage.SingleAvail> availList = avail.getDataPoints().stream()
+                .map(dataPoint -> new AvailDataMessage.SingleAvail(availId.getTenantId(), availId.getName(),
+                        dataPoint.getTimestamp(),
+                        dataPoint.getValue().getText()))
+                .collect(toList());
+        AvailDataMessage.AvailData metricData = new AvailDataMessage.AvailData();
+        metricData.setData(availList);
+        return new AvailDataMessage(metricData);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        if (producerConnectionContext != null) {
+            try {
+                producerConnectionContext.close();
+            } catch (IOException ignored) {
+            }
+        }
+        if (connectionContextFactory != null) {
+            try {
+                connectionContextFactory.close();
+            } catch (JMSException ignored) {
+            }
+        }
+    }
+}

--- a/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/InsertedDataSubscriber.java
+++ b/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/InsertedDataSubscriber.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.component.publish;
+
+import static javax.ejb.ConcurrencyManagementType.BEAN;
+import static javax.ejb.TransactionAttributeType.NEVER;
+
+import static org.hawkular.metrics.core.api.MetricType.AVAILABILITY;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.ConcurrencyManagement;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.TransactionAttribute;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.hawkular.metrics.api.jaxrs.ServiceReady;
+import org.hawkular.metrics.core.api.AvailabilityType;
+import org.hawkular.metrics.core.api.Metric;
+import org.hawkular.metrics.core.api.MetricsService;
+import org.jboss.logging.Logger;
+
+import rx.Observable;
+import rx.Scheduler;
+import rx.Subscription;
+import rx.schedulers.Schedulers;
+
+/**
+ * Subscribes to {@link MetricsService#insertedDataEvents()} and relays metrics to a bus publisher.
+ *
+ * @author Thomas Segismont
+ */
+@Startup
+@Singleton
+@TransactionAttribute(NEVER)
+@ConcurrencyManagement(BEAN)
+public class InsertedDataSubscriber {
+    private static final Logger log = Logger.getLogger(InsertedDataSubscriber.class);
+
+    @Resource
+    ManagedExecutorService executor;
+    @Inject
+    MetricDataPublisher metricDataPublisher;
+    @Inject
+    AvailDataPublisher availDataPublisher;
+
+
+    private Scheduler scheduler;
+    private Subscription subscription;
+
+    @PostConstruct
+    void init() {
+        scheduler = Schedulers.from(executor);
+    }
+
+    @SuppressWarnings("unused")
+    public void onMetricsServiceReady(@Observes @ServiceReady MetricsService metricsService) {
+        Observable<Metric<?>> events = metricsService.insertedDataEvents().observeOn(scheduler);
+        // We may want to buffer events in the future for better performance
+        // events.buffer(50, TimeUnit.MILLISECONDS, 10, scheduler);
+        subscription = events.subscribe(this::onInsertedData);
+    }
+
+    private void onInsertedData(Metric<?> metric) {
+        log.tracef("Inserted metric: %s", metric);
+        if (metric.getId().getType() == AVAILABILITY) {
+            @SuppressWarnings("unchecked")
+            Metric<AvailabilityType> avail = (Metric<AvailabilityType>) metric;
+            availDataPublisher.publish(avail);
+        } else {
+            @SuppressWarnings("unchecked")
+            Metric<? extends Number> numeric = (Metric<? extends Number>) metric;
+            metricDataPublisher.publish(numeric);
+        }
+    }
+
+    @PreDestroy
+    void shutdown() {
+        if (subscription != null) {
+            subscription.unsubscribe();
+        }
+    }
+}

--- a/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/MetricDataMessage.java
+++ b/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/MetricDataMessage.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.component.publish;
+
+
+import java.util.List;
+
+import org.hawkular.bus.common.AbstractMessage;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * A bus message for messages on HawkularMetricData Topic.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+
+public class MetricDataMessage extends AbstractMessage {
+
+    // the basic message body - it will be exposed to the JSON output
+    @JsonInclude
+    private MetricData metricData;
+
+    protected MetricDataMessage() {
+    }
+
+    public MetricDataMessage(MetricData metricData) {
+        this.metricData = metricData;
+    }
+
+    public MetricData getMetricData() {
+        return metricData;
+    }
+
+    public void setMetricData(MetricData metricData) {
+        this.metricData = metricData;
+    }
+
+    public static class MetricData {
+        @JsonInclude
+        String tenantId;
+        @JsonInclude
+        List<SingleMetric> data;
+
+        public MetricData() {
+        }
+
+        public String getTenantId() {
+            return tenantId;
+        }
+
+        public void setTenantId(String tenantId) {
+            this.tenantId = tenantId;
+        }
+
+        public List<SingleMetric> getData() {
+            return data;
+        }
+
+        public void setData(List<SingleMetric> data) {
+            this.data = data;
+        }
+
+        @Override
+        public String toString() {
+            return "MetricData [tenantId=" + tenantId + ", data=" + data + "]";
+        }
+    }
+
+    /**
+     * This is meant to parse out an instance of <code>org.rhq.metrics.client.common.SingleMetric</code>
+     */
+    public static class SingleMetric {
+        @JsonInclude
+        private String source;
+        @JsonInclude
+        private long timestamp;
+        @JsonInclude
+        private double value;
+
+        public SingleMetric() {
+        }
+
+        public SingleMetric(String source, long timestamp, double value) {
+            this.source = source;
+            this.timestamp = timestamp;
+            this.value = value;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public void setSource(String source) {
+            this.source = source;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+
+        public void setTimestamp(long timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        public double getValue() {
+            return value;
+        }
+
+        public void setValue(double value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return "SingleMetric [source=" + source + ", timestamp=" + timestamp + ", value=" + value + "]";
+        }
+    }
+}

--- a/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/MetricDataPublisher.java
+++ b/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/MetricDataPublisher.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.component.publish;
+
+import static java.util.stream.Collectors.toList;
+
+import static javax.ejb.ConcurrencyManagementType.BEAN;
+import static javax.ejb.TransactionAttributeType.NEVER;
+
+import static org.hawkular.bus.common.Endpoint.Type.TOPIC;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.ConcurrencyManagement;
+import javax.ejb.Singleton;
+import javax.ejb.TransactionAttribute;
+import javax.jms.JMSException;
+import javax.jms.TopicConnectionFactory;
+
+import org.hawkular.bus.common.BasicMessage;
+import org.hawkular.bus.common.ConnectionContextFactory;
+import org.hawkular.bus.common.Endpoint;
+import org.hawkular.bus.common.MessageProcessor;
+import org.hawkular.bus.common.producer.ProducerConnectionContext;
+import org.hawkular.metrics.core.api.Metric;
+import org.hawkular.metrics.core.api.MetricId;
+import org.jboss.logging.Logger;
+
+/**
+ * Publishes {@link MetricDataMessage} messages on the Hawkular bus.
+ *
+ * @author Thomas Segismont
+ */
+@Singleton
+@TransactionAttribute(NEVER)
+@ConcurrencyManagement(BEAN)
+public class MetricDataPublisher {
+    private static final Logger log = Logger.getLogger(MetricDataPublisher.class);
+
+    static final String HAWULAR_METRIC_DATA_TOPIC = "HawkularMetricData";
+
+    @Resource(mappedName = "java:/HawkularBusConnectionFactory")
+    TopicConnectionFactory topicConnectionFactory;
+
+    private MessageProcessor messageProcessor;
+    private ConnectionContextFactory connectionContextFactory;
+    private ProducerConnectionContext producerConnectionContext;
+
+    @PostConstruct
+    void init() {
+        messageProcessor = new MessageProcessor();
+        try {
+            connectionContextFactory = new ConnectionContextFactory(topicConnectionFactory);
+            Endpoint endpoint = new Endpoint(TOPIC, HAWULAR_METRIC_DATA_TOPIC);
+            producerConnectionContext = connectionContextFactory.createProducerConnectionContext(endpoint);
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void publish(Metric<? extends Number> metric) {
+        BasicMessage basicMessage = createNumericMessage(metric);
+        try {
+            messageProcessor.send(producerConnectionContext, basicMessage);
+            log.tracef("Sent message: %s", basicMessage);
+        } catch (JMSException e) {
+            log.warnf(e, "Could not send metric: %s", metric);
+        }
+    }
+
+    private BasicMessage createNumericMessage(Metric<? extends Number> numeric) {
+        MetricId<? extends Number> numericId = numeric.getId();
+        List<MetricDataMessage.SingleMetric> numericList = numeric.getDataPoints().stream()
+                .map(dataPoint -> new MetricDataMessage.SingleMetric(numericId.getName(), dataPoint.getTimestamp(),
+                        dataPoint.getValue().doubleValue()))
+                .collect(toList());
+        MetricDataMessage.MetricData metricData = new MetricDataMessage.MetricData();
+        metricData.setTenantId(numericId.getTenantId());
+        metricData.setData(numericList);
+        return new MetricDataMessage(metricData);
+
+    }
+
+    @PreDestroy
+    void shutdown() {
+        if (producerConnectionContext != null) {
+            try {
+                producerConnectionContext.close();
+            } catch (IOException ignored) {
+            }
+        }
+        if (connectionContextFactory != null) {
+            try {
+                connectionContextFactory.close();
+            } catch (JMSException ignored) {
+            }
+        }
+    }
+}

--- a/hawkular-component/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-component/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<jboss-deployment-structure>
+  <deployment>
+    <exclusions>
+      <module name="org.jboss.resteasy.resteasy-jackson-provider"/>
+      <module name="org.jboss.resteasy.resteasy-jettison-provider"/>
+    </exclusions>
+    <dependencies>
+      <module name="org.jboss.resteasy.resteasy-jackson2-provider" services="import"/>
+      <module name="org.hawkular.nest"/>
+    </dependencies>
+  </deployment>
+</jboss-deployment-structure>

--- a/hawkular-component/src/test/groovy/org/hawkular/metrics/component/bus/test/InsertedDataITest.groovy
+++ b/hawkular-component/src/test/groovy/org/hawkular/metrics/component/bus/test/InsertedDataITest.groovy
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.hawkular.metrics.component.bus.test
+
+import static java.util.concurrent.TimeUnit.MINUTES
+import static org.hawkular.bus.common.Endpoint.Type.TOPIC
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.hawkular.bus.common.ConnectionContextFactory
+import org.hawkular.bus.common.Endpoint
+import org.hawkular.bus.common.MessageProcessor
+import org.hawkular.bus.common.consumer.BasicMessageListener
+import org.hawkular.bus.common.consumer.ConsumerConnectionContext
+import org.hawkular.metrics.component.publish.AvailDataMessage
+import org.hawkular.metrics.component.publish.MetricDataMessage
+import org.junit.After
+import org.junit.BeforeClass
+import org.junit.Test
+
+import com.google.common.base.Charsets
+
+import groovyx.net.http.ContentType
+import groovyx.net.http.RESTClient
+
+/**
+ * @author Thomas Segismont
+ */
+class InsertedDataITest {
+  static final String BROKER_URL = System.getProperty("hawkular-bus.broker.url", "tcp://localhost:62626")
+  static baseURI = System.getProperty('hawkular-metrics.base-uri') ?: '127.0.0.1:8080/hawkular/metrics'
+  static final String TENANT_PREFIX = UUID.randomUUID().toString()
+  static final AtomicInteger TENANT_ID_COUNTER = new AtomicInteger(0)
+  static String tenantHeaderName = "Hawkular-Tenant";
+  static RESTClient hawkularMetrics
+  static defaultFailureHandler
+  static final double DELTA = 0.001
+
+  @BeforeClass
+  static void initClient() {
+    hawkularMetrics = new RESTClient("http://$baseURI/", ContentType.JSON)
+    defaultFailureHandler = hawkularMetrics.handler.failure
+    hawkularMetrics.handler.failure = { resp ->
+      def msg = "Got error response: ${resp.statusLine}"
+      if (resp.entity != null && resp.entity.contentLength != 0) {
+        def baos = new ByteArrayOutputStream()
+        resp.entity.writeTo(baos)
+        def entity = new String(baos.toByteArray(), Charsets.UTF_8)
+        msg = """${msg}
+=== Response body
+${entity}
+===
+"""
+      }
+      System.err.println(msg)
+      return resp
+    }
+  }
+
+  static String nextTenantId() {
+    return "T${TENANT_PREFIX}${TENANT_ID_COUNTER.incrementAndGet()}"
+  }
+
+  def tenantId = nextTenantId()
+
+  def consumerFactory = new ConnectionContextFactory(BROKER_URL)
+  ConsumerConnectionContext consumerContext
+  def messageProcessor = new MessageProcessor()
+
+  @After
+  void tearDown() {
+    consumerContext?.close()
+    consumerFactory?.close()
+  }
+
+  @Test
+  void testAvailData() {
+    def endpoint = new Endpoint(TOPIC, 'HawkularAvailData')
+    consumerContext = consumerFactory.createConsumerConnectionContext(endpoint)
+
+    def latch = new CountDownLatch(1)
+    AvailDataMessage actual = null
+    messageProcessor.listen(consumerContext, new BasicMessageListener<AvailDataMessage>() {
+      @Override
+      void onBasicMessage(AvailDataMessage message) {
+        actual = message
+        latch.countDown()
+      }
+    })
+
+    def metricName = 'test', timestamp = 13, value = 'up'
+
+    def response = hawkularMetrics.post(path: 'availability/data', body: [
+        [
+            id  : metricName,
+            data: [[timestamp: timestamp, value: value]]
+        ]
+    ], headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+
+
+    assertTrue('No message received', latch.await(1, MINUTES))
+
+    def data = actual?.availData?.data
+    assertNotNull(data)
+    assertEquals(1, data.size())
+
+    def avail = data[0]
+    assertEquals(tenantId, avail.tenantId)
+    assertEquals(metricName, avail.id)
+    assertEquals(timestamp, avail.timestamp)
+    assertEquals(value, avail.avail)
+  }
+
+  @Test
+  void testNumericData() {
+    def endpoint = new Endpoint(TOPIC, 'HawkularMetricData')
+    consumerContext = consumerFactory.createConsumerConnectionContext(endpoint)
+
+    def latch = new CountDownLatch(1)
+    MetricDataMessage actual = null
+    messageProcessor.listen(consumerContext, new BasicMessageListener<MetricDataMessage>() {
+      @Override
+      void onBasicMessage(MetricDataMessage message) {
+        actual = message
+        latch.countDown()
+      }
+    })
+
+    def metricName = 'test', timestamp = 13, value = 15.3
+
+    def response = hawkularMetrics.post(path: 'gauges/data', body: [
+        [
+            id  : metricName,
+            data: [[timestamp: timestamp, value: value]]
+        ]
+    ], headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+
+
+    assertTrue('No message received', latch.await(1, MINUTES))
+
+    def data = actual?.metricData?.data
+    assertNotNull(data)
+    assertEquals(tenantId, actual.metricData.tenantId)
+    assertEquals(1, data.size())
+
+    def numeric = data[0]
+    assertEquals(metricName, numeric.source)
+    assertEquals(timestamp, numeric.timestamp)
+    assertEquals(value, numeric.value, DELTA)
+  }
+}

--- a/hawkular-component/src/test/resources/logback-test.xml
+++ b/hawkular-component/src/test/resources/logback-test.xml
@@ -1,0 +1,46 @@
+<!--
+
+    Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+  <property name="pattern" value="%-5level %date{ISO8601} [%thread] %class:%M:%L - %message%n"/>
+
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>${test.logging.console.level:-ERROR}</level>
+    </filter>
+    <encoder>
+      <pattern>${pattern}</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="file" class="ch.qos.logback.core.FileAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>${test.logging.file.level:-ERROR}</level>
+    </filter>
+    <file>target/test.log</file>
+    <append>false</append>
+    <encoder>
+      <pattern>${pattern}</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="stdout"/>
+    <appender-ref ref="file"/>
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
         <artifactId>swagger-core</artifactId>
         <version>${version.io.swagger}</version>
       </dependency>
+      <!-- Other -->
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-mapper-asl</artifactId>
@@ -416,6 +417,7 @@
         <module>api/metrics-api-common</module>
         <module>api/metrics-api-jaxrs</module>
         <module>api/metrics-api-jaxrs-1.1</module>
+        <module>hawkular-component</module>
         <module>integration-tests</module>
         <module>clients</module>
         <module>containers</module>


### PR DESCRIPTION
HWKMETRICS-83 Create glue code component to integrate with hawkular-bus

This pull request is comprised of three commits.

* Implement an InsertedDataPoint event stream

The MetricsService interface now exposes an #insertedDataEvents method. The method returns a hot Observable emitting Metric objects, when their data has been succesfully inserted.

Clients can subscribe to this Observable (preferably on a dedicated scheduler!) and they will get notified.

* Fire @ServiceReady event when MetricsService is initialized

The Metrics JAX- RS module now fires a CDI @ServiceReady event.
This event can be observed by a "super"-module in order to know when the MetricsService instance is initialized.

The event is fired just before the MetricsServiceLifecycle status changes to "STARTED", so that clients can subscribe to the #insertedDataEvents observable before new data points are accepted.

* Introduce Hawkular Metrics Component module

There is a new "hawkular-metrics-component" WAR module. It is meant to replace "hawkular-metrics-api-jaxrs" module in Hawkular deployment.

This new WAR is a "super"-module: it uses Maven WAR plugin overlay mechanism to add extra classes to the standalone metrics web application.

The extra classes allow to subscribe to the #insertedDataEvents observable and publish messages on the bus.

In order to make the migration easy, I have shamelessly copied Alerts' AvailDataMessage and MetricDataMessage classes. Theses messages are posted on to the "HawkularAvailData" and "HawkularMetricData" topics, respectively.

After this PR is merged we only need to change the agent code to remove the "double-push" part. And change Hawkular POM to switch to the new Metrics component, that's it.

You may notice that the integration test class borrows a lot from the RESTTest class in rest-tests module. I think we need to introduce a new 'test-utils' module, in a DRY approach. But I wouldn't want to block this PR and would rather do this as a separate PR.