### PR TITLE
Hawkular bus integration fixes

### DIFF
--- a/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/AvailDataPublisher.java
+++ b/hawkular-component/src/main/java/org/hawkular/metrics/component/publish/AvailDataPublisher.java
@@ -88,7 +88,7 @@ public class AvailDataPublisher {
         List<AvailDataMessage.SingleAvail> availList = avail.getDataPoints().stream()
                 .map(dataPoint -> new AvailDataMessage.SingleAvail(availId.getTenantId(), availId.getName(),
                         dataPoint.getTimestamp(),
-                        dataPoint.getValue().getText()))
+                        dataPoint.getValue().getText().toUpperCase()))
                 .collect(toList());
         AvailDataMessage.AvailData metricData = new AvailDataMessage.AvailData();
         metricData.setData(availList);

--- a/hawkular-component/src/test/groovy/org/hawkular/metrics/component/bus/test/InsertedDataITest.groovy
+++ b/hawkular-component/src/test/groovy/org/hawkular/metrics/component/bus/test/InsertedDataITest.groovy
@@ -108,7 +108,7 @@ ${entity}
       }
     })
 
-    def metricName = 'test', timestamp = 13, value = 'up'
+    def metricName = 'test', timestamp = 13, value = 'UP'
 
     def response = hawkularMetrics.post(path: 'availability/data', body: [
         [


### PR DESCRIPTION
HWKMETRICS-315 Bus integration: events randomly or never posted

When Metrics was started after the Pinger, the Pinger would accumulate data to post before sending it all at once eventually.
Because there were not enough threads to handle the peak load, RxJava tried to apply backpressure but PublishSubject does not support it by nature.

The fix consists in:
- buffering inserted metric to avoid submitting too much to the #io scheduler
- adding a buffer-on-backpressure strategy

Note that the problem was emphasized before as we used to schedule sending on a wrapped ManagedExecutorService. Now we use the #io scheduler (change already in master).

I've successfully tested the changes on Hawkular server.