### PR TITLE
[HWKMETRICS-313] Remove the hardcoded 95th percentile calculation

### DIFF
--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/NumericBucketPoint.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/NumericBucketPoint.java
@@ -33,18 +33,16 @@ public class NumericBucketPoint extends BucketPoint {
     private final double avg;
     private final double median;
     private final double max;
-    private final double percentile95th;
     private int samples;
     private final List<Percentile> percentiles;
 
-    private NumericBucketPoint(long start, long end, double min, double avg, double median, double max, double
-            percentile95th, List<Percentile> percentiles, int samples) {
+    private NumericBucketPoint(long start, long end, double min, double avg, double median, double max,
+                               List<Percentile> percentiles, int samples) {
         super(start, end);
         this.min = min;
         this.avg = avg;
         this.median = median;
         this.max = max;
-        this.percentile95th = percentile95th;
         this.percentiles = percentiles;
         this.samples = samples;
     }
@@ -65,10 +63,6 @@ public class NumericBucketPoint extends BucketPoint {
         return max;
     }
 
-    public double getPercentile95th() {
-        return percentile95th;
-    }
-
     public List<Percentile> getPercentiles() {
         return percentiles;
     }
@@ -79,7 +73,7 @@ public class NumericBucketPoint extends BucketPoint {
 
     @Override
     public boolean isEmpty() {
-        return samples == 0 || isNaN(min) || isNaN(avg) || isNaN(median) || isNaN(max) || isNaN(percentile95th);
+        return samples == 0 || isNaN(min) || isNaN(avg) || isNaN(median) || isNaN(max);
     }
 
     @Override
@@ -91,7 +85,6 @@ public class NumericBucketPoint extends BucketPoint {
                 ", avg=" + avg +
                 ", median=" + median +
                 ", max=" + max +
-                ", percentile95th=" + percentile95th +
                 ", percentiles=" + percentiles +
                 ", samples=" + samples +
                 ", isEmpty=" + isEmpty() +
@@ -112,7 +105,6 @@ public class NumericBucketPoint extends BucketPoint {
         private double avg = NaN;
         private double median = NaN;
         private double max = NaN;
-        private double percentile95th = NaN;
         private List<Percentile> percentiles = new ArrayList<>();
         private int samples = 0;
 
@@ -134,7 +126,6 @@ public class NumericBucketPoint extends BucketPoint {
             this.setAvg(numericBucketPoint.getAvg());
             this.setMedian(numericBucketPoint.getMedian());
             this.setMax(numericBucketPoint.getMax());
-            this.setPercentile95th(numericBucketPoint.getPercentile95th());
         }
 
         public Builder setMin(double min) {
@@ -157,11 +148,6 @@ public class NumericBucketPoint extends BucketPoint {
             return this;
         }
 
-        public Builder setPercentile95th(double percentile95th) {
-            this.percentile95th = percentile95th;
-            return this;
-        }
-
         public Builder setPercentiles(List<Percentile> percentiles) {
             this.percentiles = percentiles;
             return this;
@@ -173,7 +159,7 @@ public class NumericBucketPoint extends BucketPoint {
         }
 
         public NumericBucketPoint build() {
-            return new NumericBucketPoint(start, end, min, avg, median, max, percentile95th, percentiles, samples);
+            return new NumericBucketPoint(start, end, min, avg, median, max, percentiles, samples);
         }
     }
 

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/NumericDataPointCollector.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/NumericDataPointCollector.java
@@ -66,7 +66,6 @@ final class NumericDataPointCollector {
     private Mean average = new Mean();
     private PercentileWrapper median = createPercentile.apply(50.0);
     private Max max = new Max();
-    private PercentileWrapper percentile95th = createPercentile.apply(95.0);
     private List<PSquarePercentile> percentiles;
 
     NumericDataPointCollector(Buckets buckets, int bucketIndex, List<Double> percentileList) {
@@ -82,7 +81,6 @@ final class NumericDataPointCollector {
         average.increment(value.doubleValue());
         median.addValue(value.doubleValue());
         max.increment(value.doubleValue());
-        percentile95th.addValue(value.doubleValue());
         samples++;
         percentiles.stream().forEach(p -> p.increment(value.doubleValue()));
     }
@@ -95,7 +93,6 @@ final class NumericDataPointCollector {
                 .setAvg(average.getResult())
                 .setMedian(median.getResult())
                 .setMax(max.getResult())
-                .setPercentile95th(percentile95th.getResult())
                 .setSamples(samples)
                 .setPercentiles(percentiles.stream()
                         .map(p -> new Percentile(p.quantile(), p.getResult())).collect(Collectors.toList()))

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/SumNumericBucketPointCollector.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/SumNumericBucketPointCollector.java
@@ -30,7 +30,6 @@ final class SumNumericBucketPointCollector {
     private Sum average = new Sum();
     private Sum median = new Sum();
     private Sum max = new Sum();
-    private Sum percentile95th = new Sum();
     private Sum samples = new Sum();
     private Long start;
     private Long end;
@@ -43,7 +42,6 @@ final class SumNumericBucketPointCollector {
         average.increment(bucketPoint.getAvg());
         median.increment(bucketPoint.getMedian());
         max.increment(bucketPoint.getMax());
-        percentile95th.increment(bucketPoint.getPercentile95th());
         samples.increment(1);
 
         start = bucketPoint.getStart();
@@ -61,7 +59,6 @@ final class SumNumericBucketPointCollector {
                 .setAvg(average.getResult())
                 .setMedian(median.getResult())
                 .setMax(max.getResult())
-                .setPercentile95th(percentile95th.getResult())
                 .setSamples(localSamples)
                 .build();
     }

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsServiceITest.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/MetricsServiceITest.java
@@ -615,22 +615,22 @@ public class MetricsServiceITest extends MetricsITest {
             NumericBucketPoint.Builder builder = new NumericBucketPoint.Builder(60_000 * i, 60_000 * (i + 1));
             switch (i) {
                 case 1:
-                    builder.setAvg(100D).setMax(200D).setMedian(0D).setMin(0D).setPercentile95th(0D).setSamples(2);
+                    builder.setAvg(100D).setMax(200D).setMedian(0D).setMin(0D).setSamples(2);
                     break;
                 case 2:
                 case 4:
                 case 6:
                     break;
                 case 3:
-                    builder.setAvg(400D).setMax(400D).setMedian(400D).setMin(400D).setPercentile95th(400D)
+                    builder.setAvg(400D).setMax(400D).setMedian(400D).setMin(400D)
                             .setSamples(1);
                     break;
                 case 5:
-                    builder.setAvg(550D).setMax(550D).setMedian(550D).setMin(550D).setPercentile95th(550D)
+                    builder.setAvg(550D).setMax(550D).setMedian(550D).setMin(550D)
                             .setSamples(1);
                     break;
                 case 7:
-                    builder.setAvg(975D).setMax(1000D).setMedian(950D).setMin(950D).setPercentile95th(950D)
+                    builder.setAvg(975D).setMax(1000D).setMedian(950D).setMin(950D)
                             .setSamples(2);
                     break;
             }
@@ -757,19 +757,19 @@ public class MetricsServiceITest extends MetricsITest {
             switch (i) {
                 case 1:
                     val = 400D;
-                    builder.setAvg(val).setMax(val).setMedian(val).setMin(val).setPercentile95th(val).setSamples(1);
+                    builder.setAvg(val).setMax(val).setMedian(val).setMin(val).setSamples(1);
                     break;
                 case 3:
                     val = 100D;
-                    builder.setAvg(val).setMax(val).setMedian(val).setMin(val).setPercentile95th(val).setSamples(1);
+                    builder.setAvg(val).setMax(val).setMedian(val).setMin(val).setSamples(1);
                     break;
                 case 5:
                     val = 100;
-                    builder.setAvg(val).setMax(val).setMedian(val).setMin(val).setPercentile95th(val).setSamples(1);
+                    builder.setAvg(val).setMax(val).setMedian(val).setMin(val).setSamples(1);
                 case 6:
                     break;
                 case 7:
-                    builder.setAvg(150.0).setMax(200.0).setMin(100.0).setMedian(100.0).setPercentile95th(100.0)
+                    builder.setAvg(150.0).setMax(200.0).setMin(100.0).setMedian(100.0)
                             .setSamples(2);
                 default:
                     break;
@@ -916,13 +916,11 @@ public class MetricsServiceITest extends MetricsITest {
         final Sum average = new Sum();
         final Sum median = new Sum();
         final Sum max = new Sum();
-        final Sum percentile95th = new Sum();
         Observable.just(collectorC1, collectorC2).forEach(d -> {
             min.increment(d.getMin());
             max.increment(d.getMax());
             average.increment(d.getAvg());
             median.increment(d.getMedian());
-            percentile95th.increment(d.getPercentile95th());
         });
         NumericBucketPoint expectedStackedRateBucketPoint = new NumericBucketPoint.Builder(start.getMillis(),
                 start.plusMinutes(5).getMillis())
@@ -930,7 +928,6 @@ public class MetricsServiceITest extends MetricsITest {
                         .setMax(max.getResult())
                         .setAvg(average.getResult())
                         .setMedian(median.getResult())
-                        .setPercentile95th(percentile95th.getResult())
                         .setSamples(2)
                         .build();
         List<NumericBucketPoint> expectedStackedCounterStatsList = new ArrayList<NumericBucketPoint>();
@@ -975,13 +972,11 @@ public class MetricsServiceITest extends MetricsITest {
         final Sum counterRateMax = new Sum();
         final Sum counterRateAverage = new Sum();
         final Sum counterRateMedian = new Sum();
-        final Sum counterRatePercentile95th = new Sum();
         Observable.just(collectorC1Rate, collectorC2Rate).forEach(d -> {
             counterRateMin.increment(d.getMin());
             counterRateMax.increment(d.getMax());
             counterRateAverage.increment(d.getAvg());
             counterRateMedian.increment(d.getMedian());
-            counterRatePercentile95th.increment(d.getPercentile95th());
         });
         NumericBucketPoint expectedStackedCounterRateBucketPoint = new NumericBucketPoint.Builder(start.getMillis(),
                 start.plusMinutes(5).getMillis())
@@ -989,7 +984,6 @@ public class MetricsServiceITest extends MetricsITest {
                         .setMax(counterRateMax.getResult())
                         .setAvg(counterRateAverage.getResult())
                         .setMedian(counterRateMedian.getResult())
-                        .setPercentile95th(counterRatePercentile95th.getResult())
                         .setSamples(2)
                         .build();
         List<NumericBucketPoint> expectedStackedCounterRateStatsList = new ArrayList<NumericBucketPoint>();
@@ -1010,12 +1004,10 @@ public class MetricsServiceITest extends MetricsITest {
                 .get()
                 .getValue();
         PercentileWrapper expectedMedian = NumericDataPointCollector.createPercentile.apply(50.0);
-        PercentileWrapper expectedPercentile95th = NumericDataPointCollector.createPercentile.apply(95.0);
         Mean expectedAverage = new Mean();
         Sum expectedSamples = new Sum();
         combinedData.stream().forEach(arg -> {
             expectedMedian.addValue(arg.getValue().doubleValue());
-            expectedPercentile95th.addValue(arg.getValue().doubleValue());
             expectedAverage.increment(arg.getValue().doubleValue());
             expectedSamples.increment(1);
         });
@@ -1025,7 +1017,6 @@ public class MetricsServiceITest extends MetricsITest {
                 .setMax(expectedMax.doubleValue())
                 .setAvg(expectedAverage.getResult())
                 .setMedian(expectedMedian.getResult())
-                .setPercentile95th(expectedPercentile95th.getResult())
                 .setSamples(new Double(expectedSamples.getResult()).intValue())
                 .build();
     }
@@ -1077,20 +1068,17 @@ public class MetricsServiceITest extends MetricsITest {
         final Sum average = new Sum();
         final Sum median = new Sum();
         final Sum max = new Sum();
-        final Sum percentile95th = new Sum();
         Observable.just(collectorM1, collectorM2).forEach(d -> {
             min.increment(d.getMin());
             max.increment(d.getMax());
             average.increment(d.getAvg());
             median.increment(d.getMedian());
-            percentile95th.increment(d.getPercentile95th());
         });
 
         assertEquals(actual.get(0).get(0).getMin(), min.getResult());
         assertEquals(actual.get(0).get(0).getMax(), max.getResult());
         assertEquals(actual.get(0).get(0).getMedian(), median.getResult());
         assertEquals(actual.get(0).get(0).getAvg(), average.getResult());
-        assertEquals(actual.get(0).get(0).getPercentile95th(), percentile95th.getResult());
     }
 
     @Test
@@ -1182,20 +1170,17 @@ public class MetricsServiceITest extends MetricsITest {
         final Sum average = new Sum();
         final Sum median = new Sum();
         final Sum max = new Sum();
-        final Sum percentile95th = new Sum();
         Observable.just(collectorM1, collectorM2).forEach(d -> {
             min.increment(d.getMin());
             max.increment(d.getMax());
             average.increment(d.getAvg());
             median.increment(d.getMedian());
-            percentile95th.increment(d.getPercentile95th());
         });
 
         assertEquals(actual.get(0).get(0).getMin(), min.getResult());
         assertEquals(actual.get(0).get(0).getMax(), max.getResult());
         assertEquals(actual.get(0).get(0).getMedian(), median.getResult());
         assertEquals(actual.get(0).get(0).getAvg(), average.getResult());
-        assertEquals(actual.get(0).get(0).getPercentile95th(), percentile95th.getResult());
     }
 
     private static void assertNumericBucketsEquals(List<NumericBucketPoint> actual, List<NumericBucketPoint> expected) {
@@ -1218,7 +1203,6 @@ public class MetricsServiceITest extends MetricsITest {
             assertEquals(actual.getMedian(), expected.getMedian(), 0.001, msg);
             assertEquals(actual.getMin(), expected.getMin(), 0.001, msg);
             assertEquals(actual.getSamples(), expected.getSamples(), 0, msg);
-            assertEquals(actual.getPercentile95th(), expected.getPercentile95th(), 0.001, msg);
         }
     }
 

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -351,26 +351,26 @@ class CountersITest extends RESTTest {
       double val;
       switch (i) {
         case 1:
-          bucketPoint.putAll([min: 0D, avg: 100D, median: 0D, max: 200D, percentile95th: 0D, empty: false,
+          bucketPoint.putAll([min: 0D, avg: 100D, median: 0D, max: 200D, empty: false,
           samples: 2] as Map)
           break;
         case 2:
         case 4:
         case 6:
           val = NaN
-          bucketPoint.putAll([min: val, avg: val, median: val, max: val, percentile95th: val, empty: true,
+          bucketPoint.putAll([min: val, avg: val, median: val, max: val, empty: true,
           samples: 0] as Map)
           break;
         case 3:
-          bucketPoint.putAll([min: 400D, avg: 400D, median: 400D, max: 400D, percentile95th: 400D, empty: false,
+          bucketPoint.putAll([min: 400D, avg: 400D, median: 400D, max: 400D, empty: false,
           samples: 1] as Map)
           break;
         case 5:
-          bucketPoint.putAll([min: 550D, avg: 550D, median: 550D, max: 550D, percentile95th: 550D, empty: false,
+          bucketPoint.putAll([min: 550D, avg: 550D, median: 550D, max: 550D, empty: false,
           samples: 1] as Map)
           break;
         case 7:
-          bucketPoint.putAll([min: 950D, avg: 975D, median: 950D, max: 1000D, percentile95th: 950D, empty: false,
+          bucketPoint.putAll([min: 950D, avg: 975D, median: 950D, max: 1000D, empty: false,
           samples: 2] as Map)
           break;
       }
@@ -527,22 +527,22 @@ Actual:   ${response.data}
       switch (i) {
         case 1:
           val = 400D
-          bucketPoint << [min: val, avg: val, median: val, max: val, percentile95th: val, empty: false, samples: 1]
+          bucketPoint << [min: val, avg: val, median: val, max: val, empty: false, samples: 1]
           break
         case 3:
           val = 100D
-          bucketPoint << [min: val, avg: val, median: val, max: val, percentile95th: val, empty: false, samples: 1]
+          bucketPoint << [min: val, avg: val, median: val, max: val, empty: false, samples: 1]
           break
         case 5:
           val = 100D
-          bucketPoint << [min: val, avg: val, median: val, max: val, percentile95th: val, empty: false, samples: 1]
+          bucketPoint << [min: val, avg: val, median: val, max: val, empty: false, samples: 1]
           break
         case 7:
-          bucketPoint << [min: 100.0, max: 200.0, avg: 150.0, median: 100.0, percentile95th: 100.0, empty:false,
+          bucketPoint << [min: 100.0, max: 200.0, avg: 150.0, median: 100.0, empty:false,
                           samples: 2]
           break
         default:
-          bucketPoint << [min: NaN, max: NaN, avg: NaN, median: NaN, percentile95th: NaN, empty: true, samples: 0]
+          bucketPoint << [min: NaN, max: NaN, avg: NaN, median: NaN, empty: true, samples: 0]
           break
       }
       expectedData.push(bucketPoint);
@@ -751,7 +751,6 @@ Actual:   ${response.data}
     assertDoubleEquals("The avg is wrong", avg(c1.collect {it.value}) + avg(c2.collect {it.value}), actualCounterBucketByTag.avg)
     assertEquals("The [empty] property is wrong", false, actualCounterBucketByTag.empty)
     assertTrue("Expected the [median] property to be set", actualCounterBucketByTag.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", actualCounterBucketByTag.percentile95th != null)
 
     response = hawkularMetrics.get(
         path: 'counters/data',
@@ -892,7 +891,6 @@ Actual:   ${response.data}
     assertDoubleEquals("The avg is wrong", avg(combinedData.collect {it.value}), expectedSimpleCounterBucketByTag.avg)
     assertEquals("The [empty] property is wrong", false, expectedSimpleCounterBucketByTag.empty)
     assertTrue("Expected the [median] property to be set", expectedSimpleCounterBucketByTag.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", expectedSimpleCounterBucketByTag.percentile95th != null)
 
     response = hawkularMetrics.get(
         path: 'counters/data',
@@ -916,7 +914,6 @@ Actual:   ${response.data}
     assertDoubleEquals("The avg is wrong", avg(combinedData.collect {it.value}), actualSimpleCounterBucketById.avg)
     assertEquals("The [empty] property is wrong", false, actualSimpleCounterBucketById.empty)
     assertTrue("Expected the [median] property to be set", actualSimpleCounterBucketById.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", actualSimpleCounterBucketById.percentile95th != null)
   }
 
   @Test
@@ -1040,7 +1037,6 @@ Actual:   ${response.data}
     assertDoubleEquals("The avg is wrong", (c1Rates.avg + c2Rates.avg), actualCounterRateBucketByTag.avg)
     assertEquals("The [empty] property is wrong", false, actualCounterRateBucketByTag.empty)
     assertTrue("Expected the [median] property to be set", actualCounterRateBucketByTag.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", actualCounterRateBucketByTag.percentile95th != null)
 
     response = hawkularMetrics.get(
         path: 'counters/data/rate',
@@ -1067,7 +1063,6 @@ Actual:   ${response.data}
     assertDoubleEquals("The avg is wrong", (c1Rates.avg + c2Rates.avg), actualCounterRateBucketById.avg)
     assertEquals("The [empty] property is wrong", false, actualCounterRateBucketById.empty)
     assertTrue("Expected the [median] property to be set", actualCounterRateBucketById.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", actualCounterRateBucketById.percentile95th != null)
   }
 
   @Test
@@ -1191,7 +1186,6 @@ Actual:   ${response.data}
     assertDoubleEquals("The avg is wrong", (c1Rates.avg + c2Rates.avg)/2, actualCounterRateBucketByTag.avg)
     assertEquals("The [empty] property is wrong", false, actualCounterRateBucketByTag.empty)
     assertTrue("Expected the [median] property to be set", actualCounterRateBucketByTag.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", actualCounterRateBucketByTag.percentile95th != null)
 
     response = hawkularMetrics.get(
         path: 'counters/data/rate',
@@ -1218,6 +1212,5 @@ Actual:   ${response.data}
     assertDoubleEquals("The avg is wrong", (c1Rates.avg + c2Rates.avg)/2, actualCounterRateBucketById.avg)
     assertEquals("The [empty] property is wrong", false, actualCounterRateBucketById.empty)
     assertTrue("Expected the [median] property to be set", actualCounterRateBucketById.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", actualCounterRateBucketById.percentile95th != null)
   }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
@@ -119,36 +119,36 @@ class GaugeMetricStatisticsITest extends RESTTest {
     def expectedData = [
         [
             start: buckets[0], end: buckets[0] + bucketSize, empty: false, min: 12.22,
-            avg: avg0.getResult(), median: med0.getResult(), max: 15.37, percentile95th: perc95th0.getResult(),
+            avg: avg0.getResult(), median: med0.getResult(), max: 15.37,
             samples: 2
         ], [
             start: buckets[1], end: buckets[1] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
+            avg  : NaN, median: NaN, max: NaN, samples: 0
         ], [
             start: buckets[2], end: buckets[2] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
+            avg  : NaN, median: NaN, max: NaN, samples: 0
         ], [
             start: buckets[3], end: buckets[3] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
+            avg  : NaN, median: NaN, max: NaN, samples: 0
         ], [
             start: buckets[4], end: buckets[4] + bucketSize, empty: false, min: 25.0,
-            avg  : 25.0, median: 25.0, max: 25.0, percentile95th: 25.0, samples: 2
+            avg  : 25.0, median: 25.0, max: 25.0, samples: 2
         ],
         [
             start: buckets[5], end: buckets[5] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
+            avg  : NaN, median: NaN, max: NaN, samples: 0
         ], [
             start: buckets[6], end: buckets[6] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
+            avg  : NaN, median: NaN, max: NaN, samples: 0
         ], [
             start: buckets[7], end: buckets[7] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
+            avg  : NaN, median: NaN, max: NaN, samples: 0
         ], [
             start: buckets[8], end: buckets[8] + bucketSize, empty: true, min: NaN,
-            avg  : NaN, median: NaN, max: NaN, percentile95th: NaN, samples: 0
+            avg  : NaN, median: NaN, max: NaN, samples: 0
         ], [
             start: buckets[9], end: buckets[9] + bucketSize, empty: false, min: 18.367,
-            avg: avg9.getResult(), median: med9.getResult(), max: 19.01, percentile95th: perc95th9.getResult(),
+            avg: avg9.getResult(), median: med9.getResult(), max: 19.01,
             samples: 2
         ]
     ]
@@ -201,7 +201,6 @@ class GaugeMetricStatisticsITest extends RESTTest {
           avg           : avg.getResult(),
           median        : median.getResult(),
           max           : max.getResult(),
-          percentile95th: perc95th.getResult(),
           samples       : sampleSize,
           empty         : false
       ])
@@ -301,7 +300,6 @@ class GaugeMetricStatisticsITest extends RESTTest {
         avg([37.45, 37.609, 39.11, 44.07, 41.18, 39.55, 40.72, 36.94]), bucket.avg)
     assertEquals("The [empty] property is wrong", false, bucket.empty)
     assertTrue("Expected the [median] property to be set", bucket.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", bucket.percentile95th != null)
   }
 
   @Test
@@ -394,7 +392,6 @@ class GaugeMetricStatisticsITest extends RESTTest {
     assertDoubleEquals("The avg is wrong", avg(m1.collect {it.value}) + avg(m2.collect {it.value}), bucket.avg)
     assertEquals("The [empty] property is wrong", false, bucket.empty)
     assertTrue("Expected the [median] property to be set", bucket.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", bucket.percentile95th != null)
   }
 
   @Test
@@ -488,7 +485,6 @@ class GaugeMetricStatisticsITest extends RESTTest {
     assertDoubleEquals("The avg is wrong", avg(g1.collect {it.value}) + avg(g2.collect {it.value}), bucket.avg)
     assertEquals("The [empty] property is wrong", false, bucket.empty)
     assertTrue("Expected the [median] property to be set", bucket.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", bucket.percentile95th != null)
   }
 
   @Test
@@ -575,7 +571,6 @@ class GaugeMetricStatisticsITest extends RESTTest {
         avg([37.45, 37.609, 39.11, 44.07, 41.18, 39.55, 40.72, 36.94]), bucket.avg)
     assertEquals("The [empty] property is wrong", false, bucket.empty)
     assertTrue("Expected the [median] property to be set", bucket.median != null)
-    assertTrue("Expected the [percentile95th] property to be set", bucket.percentile95th != null)
   }
 
   @Test

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -169,7 +169,6 @@ Actual: ${actual}
       assertDoubleEquals(msg, expected.avg, actual.avg)
       assertDoubleEquals(msg, expected.median, actual.median)
       assertDoubleEquals(msg, expected.max, actual.max)
-      assertDoubleEquals(msg, expected.percentile95th, actual.percentile95th)
     }
   }
 


### PR DESCRIPTION
Removes the old 95th percentile calculation, use the percentiles instead to calculate the necessary percentiles.