### PR TITLE
HWKMETRICS-322 InfluxDB API: groupby should accept milliseconds unit

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/validation/GroupByTimeRule.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/query/validation/GroupByTimeRule.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.metrics.api.jaxrs.influx.query.validation;
 
+import static org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit.MICROSECONDS;
+import static org.hawkular.metrics.api.jaxrs.influx.InfluxTimeUnit.MILLISECONDS;
+
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.GroupByClause;
 import org.hawkular.metrics.api.jaxrs.influx.query.parse.definition.SelectQueryDefinitions;
 
@@ -27,8 +30,15 @@ public class GroupByTimeRule implements SelectQueryValidationRule {
     @Override
     public void checkQuery(SelectQueryDefinitions queryDefinitions) throws IllegalQueryException {
         GroupByClause groupByClause = queryDefinitions.getGroupByClause();
-        if (groupByClause != null && !groupByClause.getBucketType().equalsIgnoreCase("time")) {
+        if (groupByClause == null) {
+            return;
+        }
+        if (!groupByClause.getBucketType().equalsIgnoreCase("time")) {
             throw new IllegalQueryException("Group by " + groupByClause.getBucketType());
+        }
+        if (groupByClause.getBucketSizeUnit() == MICROSECONDS
+                && groupByClause.getBucketSize() < MICROSECONDS.convert(1, MILLISECONDS)) {
+            throw new IllegalQueryException("Group by bucket size smaller than maximum resolution");
         }
     }
 }

--- a/api/metrics-api-jaxrs/src/test/resources/influx/query/supported-select-queries.iql
+++ b/api/metrics-api-jaxrs/src/test/resources/influx/query/supported-select-queries.iql
@@ -32,3 +32,5 @@ select a.value as b from c as a where '2011-07-28' > a.time and now() + 50w < a.
 select * from test where time > 1501560s and time < 4560546h
 select * from test where time > 1501560 and time < 4560546
 select a.value as b from c as a where '2011-07-28' > a.time and now() + 1156897980 < a.time
+select mean(value) from "london01.web011.example.com.cpu.usage" where time > now()-5m group by time(1235u) order asc
+

--- a/api/metrics-api-jaxrs/src/test/resources/influx/query/unsupported-select-queries.iql
+++ b/api/metrics-api-jaxrs/src/test/resources/influx/query/unsupported-select-queries.iql
@@ -55,3 +55,5 @@ select a.value as b from c as a where time > '2011-07-28' and time > now() + 50w
 select a.value as b from c as a where '2011-07-28' < a.time and now() + 50w < a.time
 -- not a simple time range
 select a.value as b from c as a where '2011-07-28' > a.time and now() + 50w > a.time
+-- group by bucket size smaller than maximum resolution
+select mean(value) from "london01.web011.example.com.cpu.usage" where time > now()-5m group by time(12u) order asc


### PR DESCRIPTION
HWKMETRICS-322 InfluxDB API: groupby should accept milliseconds unit

This is the second part for fixing HWKMETRICS-322.

Add validation rule to make sure bucket size in groupby is bigger than metric resolution
Support subsecond bucket size in #applyMapping
Add tests