### PR TITLE
HWKMETRICS-66 Influx endpoint: use series name prefix to match a counter or a gauge

### DIFF
--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricTypeFilter.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricTypeFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.api;
+
+import static org.hawkular.metrics.core.api.MetricType.AVAILABILITY;
+import static org.hawkular.metrics.core.api.MetricType.COUNTER;
+import static org.hawkular.metrics.core.api.MetricType.GAUGE;
+
+import rx.Observable;
+import rx.Observable.Transformer;
+
+/**
+ * Filters metrics of a given type. Use with {@link Observable#compose(Transformer)}.
+ *
+ * @author Thomas Segismont
+ */
+public class MetricTypeFilter<T> implements Transformer<Metric<?>, Metric<T>> {
+    public static final MetricTypeFilter<Double> GAUGE_FILTER = new MetricTypeFilter<>(GAUGE);
+    public static final MetricTypeFilter<Long> COUNTER_FILTER = new MetricTypeFilter<>(COUNTER);
+    public static final MetricTypeFilter<AvailabilityType> AVAILABILITY_FILTER = new MetricTypeFilter<>(AVAILABILITY);
+
+    private final MetricType metricType;
+
+    public MetricTypeFilter(MetricType<T> metricType) {
+        this.metricType = metricType;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Observable<Metric<T>> call(Observable<Metric<?>> observable) {
+        return observable.filter(metric -> metric.getId().getType() == metricType).map(metric -> (Metric<T>) metric);
+    }
+}

--- a/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
+++ b/core/metrics-core-api/src/main/java/org/hawkular/metrics/core/api/MetricsService.java
@@ -190,8 +190,10 @@ public interface MetricsService {
     Observable<List<AvailabilityBucketPoint>> findAvailabilityStats(MetricId<AvailabilityType> metricId, long start,
                                                                     long end, Buckets buckets);
 
-    /** Check if a metric with the passed {id} has been stored in the system */
-    Observable<Boolean> idExists(String id);
+    /**
+     * Check if a metric has been stored in the system.
+     */
+    Observable<Boolean> idExists(MetricId<?> metric);
 
     /**
      * Computes stats on a counter.

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccess.java
@@ -89,8 +89,6 @@ public interface DataAccess {
 
     Observable<ResultSet> deleteGaugeMetric(String tenantId, String metric, Interval interval, long dpart);
 
-    Observable<ResultSet> findAllGaugeMetrics();
-
     Observable<Integer> insertAvailabilityData(Metric<AvailabilityType> metric, int ttl);
 
     Observable<ResultSet> findAvailabilityData(MetricId<AvailabilityType> id, long startTime, long endTime);

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccessImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/DataAccessImpl.java
@@ -104,8 +104,6 @@ public class DataAccessImpl implements DataAccess {
 
     private PreparedStatement deleteGaugeMetric;
 
-    private PreparedStatement findGaugeMetrics;
-
     private PreparedStatement insertAvailability;
 
     private PreparedStatement findAvailabilities;
@@ -243,9 +241,6 @@ public class DataAccessImpl implements DataAccess {
         deleteGaugeMetric = session.prepare(
             "DELETE FROM data " +
             "WHERE tenant_id = ? AND type = ? AND metric = ? AND dpart = ?");
-
-        findGaugeMetrics = session.prepare(
-            "SELECT DISTINCT tenant_id, type, metric, dpart FROM data;");
 
         insertAvailability = session.prepare(
             "UPDATE data " +
@@ -491,11 +486,6 @@ public class DataAccessImpl implements DataAccess {
     public Observable<ResultSet> deleteGaugeMetric(String tenantId, String metric, Interval interval, long dpart) {
         return rxSession.execute(deleteGaugeMetric.bind(tenantId, GAUGE.getCode(), metric,
                 interval.toString(), dpart));
-    }
-
-    @Override
-    public Observable<ResultSet> findAllGaugeMetrics() {
-        return rxSession.execute(findGaugeMetrics.bind());
     }
 
     @Override

--- a/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
+++ b/core/metrics-core-impl/src/main/java/org/hawkular/metrics/core/impl/MetricsServiceImpl.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.metrics.core.impl;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 import static org.hawkular.metrics.core.api.MetricType.AVAILABILITY;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER;
 import static org.hawkular.metrics.core.api.MetricType.COUNTER_RATE;
@@ -832,12 +835,10 @@ public class MetricsServiceImpl implements MetricsService, TenantsService {
     }
 
     @Override
-    public Observable<Boolean> idExists(final String id) {
-        return dataAccess.findAllGaugeMetrics().flatMap(Observable::from)
-                .filter(row -> id.equals(row.getString(2)))
-                .take(1)
-                .map(r -> Boolean.TRUE)
-                .defaultIfEmpty(Boolean.FALSE);
+    public Observable<Boolean> idExists(final MetricId<?> metricId) {
+        return findMetrics(metricId.getTenantId(), metricId.getType()).filter(m -> {
+            return metricId.getName().equals(m.getId().getName());
+        }).take(1).map(m -> TRUE).defaultIfEmpty(FALSE);
     }
 
     @Override

--- a/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
+++ b/core/metrics-core-impl/src/test/java/org/hawkular/metrics/core/impl/DelegatingDataAccess.java
@@ -175,11 +175,6 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> findAllGaugeMetrics() {
-        return delegate.findAllGaugeMetrics();
-    }
-
-    @Override
     public Observable<Integer> insertAvailabilityData(Metric<AvailabilityType> metric, int ttl) {
         return delegate.insertAvailabilityData(metric, ttl);
     }


### PR DESCRIPTION
* Updated the "list series" handler so that it returns gauges with the "gauge." prefix and counters with the "counter." prefix.
* Updated the query handler so that it looks at the series name for a known prefix ("gauge." or "counter."); if there's no prefix, it will assume it's a gauge
* Updated the POST handler as well
* Removed old (and buggy) method: DataAccess#findAllGaugeMetrics
* Introduced MetricTypeFilter, to use with Observable#compose