### PR TITLE
Fix Influx handler log issue (%d used with double value)

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxSeriesHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/influx/InfluxSeriesHandler.java
@@ -465,7 +465,7 @@ public class InfluxSeriesHandler {
                     for (DataPoint<Double> rnm : list) {
                         retVal += rnm.getValue();
                     }
-                    log.debugf("Applying mean mapping, total = %d, size = %d", retVal, size);
+                    log.debugf("Applying mean mapping, total = %f, size = %d", retVal, size);
                     retVal /= size;
                     break;
                 case MAX:


### PR DESCRIPTION
%d cannot be used with double values, the call ends with a runtime exception thrown by String#format 