### PR TITLE
[HWKMETRICS-331] Add 'fromEarliest' parameter to return buckets from …

### DIFF
--- a/api/diff.txt
+++ b/api/diff.txt
@@ -810,17 +810,19 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 52,53d48
 < import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 < import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
-63a59
+63c58
+< import org.hawkular.metrics.model.NumericBucketPoint;
+---
 > import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
-70,74d65
+71,75d65
 < import io.swagger.annotations.Api;
 < import io.swagger.annotations.ApiOperation;
 < import io.swagger.annotations.ApiParam;
 < import io.swagger.annotations.ApiResponse;
 < import io.swagger.annotations.ApiResponses;
-84d74
+85d74
 < @Api(tags = "Counter")
-95,110c85,86
+96,111c85,86
 <     @ApiOperation(
 <             value = "Create counter metric.", notes = "This operation also causes the rate to be calculated and " +
 <             "persisted periodically after raw count data is persisted. Clients are not required to explicitly create " +
@@ -840,14 +842,14 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response createCounter(
 >             Metric<Long> metric,
-116,118c92,93
+117,119c92,93
 <             asyncResponse
 <                     .resume(badRequest(new ApiError("Metric type does not match " + MetricType
 <                     .COUNTER.getText())));
 ---
 >             return badRequest(new ApiError("Metric type does not match " + MetricType
 >                     .COUNTER.getText()));
-123c98,107
+124c98,107
 <         metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
 ---
 >         try {
@@ -860,7 +862,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-128,140c112,113
+129,141c112,113
 <     @ApiOperation(value = "Find tenant's counter metric definitions.",
 <                     notes = "Does not include any metric values. ",
 <                     response = Metric.class, responseContainer = "List")
@@ -877,7 +879,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response findCounterMetrics(
 >             @QueryParam("tags") Tags tags) {
-146,155c119,129
+147,156c119,129
 <         metricObservable
 <                 .toList()
 <                 .map(ApiUtils::collectionToResponse)
@@ -900,7 +902,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-160,168c134,136
+161,169c134,136
 <     @ApiOperation(value = "Retrieve a counter definition.", response = Metric.class)
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's definition was successfully retrieved."),
@@ -914,7 +916,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >     public Response getCounter(@PathParam("id") String id) {
 >         try {
 >             return metricsService.findMetric(new MetricId<>(tenantId, COUNTER, id))
-170,171c138,142
+171,172c138,142
 <                 .switchIfEmpty(Observable.just(noContent()))
 <                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
 ---
@@ -923,7 +925,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-176,188c147,154
+177,189c147,154
 <     @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Map.class)
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully retrieved."),
@@ -946,7 +948,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-193,199c159
+194,200c159
 <     @ApiOperation(value = "Update tags associated with the metric definition.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully updated."),
@@ -956,11 +958,11 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response updateMetricTags(
-201c161
+202c161
 <             @ApiParam(required = true) Map<String, String> tags) {
 ---
 >             Map<String, String> tags) {
-203c163,170
+204c163,170
 <         metricsService.addTags(metric, tags).subscribe(new ResultSetObserver(asyncResponse));
 ---
 >         try {
@@ -971,7 +973,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-208,215c175
+209,216c175
 <     @ApiOperation(value = "Delete tags associated with the metric definition.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully deleted."),
@@ -982,7 +984,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response deleteMetricTags(
-217,219c177,184
+218,220c177,184
 <             @ApiParam("Tag list") @PathParam("tags") Tags tags) {
 <         Metric<Long> metric = new Metric<>(new MetricId<>(tenantId, COUNTER, id));
 <         metricsService.deleteTags(metric, tags.getTags()).subscribe(new ResultSetObserver(asyncResponse));
@@ -995,7 +997,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-224,234c189
+225,235c189
 <     @ApiOperation(value = "Add data points for multiple counters.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Adding data points succeeded."),
@@ -1009,7 +1011,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <     ) {
 ---
 >     public Response addData(List<Metric<Long>> counters) {
-236,237c191,196
+237,238c191,196
 <         Observable<Void> observable = metricsService.addDataPoints(COUNTER, metrics);
 <         observable.subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1019,7 +1021,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-242,250c201
+243,251c201
 <     @ApiOperation(value = "Add data for a single counter.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Adding data succeeded."),
@@ -1031,9 +1033,9 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response addData(
-252d202
+253d202
 <             @ApiParam(value = "List of data points containing timestamp and value", required = true)
-256,257c206,211
+257,258c206,211
 <         Observable<Void> observable = metricsService.addDataPoints(COUNTER, metrics);
 <         observable.subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1043,7 +1045,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-262,275c216
+263,276c216
 <     @ApiOperation(value = "Retrieve counter data points.", notes = "When buckets or bucketDuration query parameter " +
 <             "is used, the time range between start and end will be divided in buckets of equal duration, and metric " +
 <             "statistics will be computed for each bucket.", response = DataPoint.class, responseContainer =
@@ -1060,7 +1062,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended AsyncResponse asyncResponse,
 ---
 >     public Response findCounterData(
-277,283c218,223
+278,284c218,223
 <             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
 <             @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
 <             @ApiParam(value = "Use data from earliest received, subject to retention period")
@@ -1075,125 +1077,76 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("buckets") Integer bucketsCount,
 >             @QueryParam("bucketDuration") Duration bucketDuration,
 >             @QueryParam("percentiles") Percentiles percentiles
-286,287c226
-<             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
-<             return;
+291,292c230
+<                 asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
+<                 return;
 ---
->             return badRequest(new ApiError("fromEarliest can only be used without start & end"));
-292,293c231
-<             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
-<             return;
----
->             return badRequest(new ApiError(timeRange.getProblem()));
-297,298c235
-<             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
-<             return;
----
->             return badRequest(new ApiError(bucketConfig.getProblem()));
-302,303c239
-<             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
-<             return;
----
->             return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
-308,342c244,283
-<         if (buckets == null) {
+>                 return badRequest(new ApiError(timeRange.getProblem()));
+295,299c233,241
 <             metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
 <                     .toList()
 <                     .map(ApiUtils::collectionToResponse)
-<                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
-<         } else {
-<             if(percentiles == null) {
-<                 percentiles = new Percentiles(Collections.<Double>emptyList());
-<             }
-< 
-<             Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
-< 
-<             if (Boolean.TRUE.equals(fromEarliest)) {
-<                 observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
-<                     long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
-<                             ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
-<                             : metricsService.getDefaultTTL() * 1000L;
-< 
-<                     long now = System.currentTimeMillis();
-<                     long earliest = now - dataRetention;
-< 
-<                     return new TimeRange(earliest, now);
-<                 });
-<             }
-< 
-<             final Percentiles localPercentiles = percentiles;
-<             observableTimeRange
-<                     .flatMap((localTimeRange) -> metricsService.findCounterStats(metricId, localTimeRange.getStart(),
-<                             localTimeRange.getEnd(), buckets, localPercentiles.getPercentiles()))
-<                     .map((list) -> {
-<                         if (Boolean.TRUE.equals(fromEarliest)) {
-<                             int index = 0;
-<                             for (NumericBucketPoint item : list) {
-<                                 if (!item.isEmpty()) {
-<                                     break;
+<                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
+<             return;
 ---
->         try {
->             if (buckets == null) {
+>             try {
 >                 return metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
 >                         .toList()
 >                         .map(ApiUtils::collectionToResponse)
 >                         .toBlocking()
 >                         .lastOrDefault(null);
->             } else {
->                 if(percentiles == null) {
->                     percentiles = new Percentiles(Collections.<Double>emptyList());
->                 }
-> 
->                 Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
-> 
->                 if (Boolean.TRUE.equals(fromEarliest)) {
->                     observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
->                         long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
->                                 ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
->                                 : metricsService.getDefaultTTL() * 1000L;
-> 
->                         long now = System.currentTimeMillis();
->                         long earliest = now - dataRetention;
-> 
->                         return new TimeRange(earliest, now);
->                     });
->                 }
-> 
->                 final Percentiles localPercentiles = percentiles;
->                 return observableTimeRange
->                         .flatMap((localTimeRange) -> metricsService.findCounterStats(metricId,
->                                 localTimeRange.getStart(), localTimeRange.getEnd(), buckets,
->                                 localPercentiles.getPercentiles()))
->                         .map((list) -> {
->                             if (Boolean.TRUE.equals(fromEarliest)) {
->                                 int index = 0;
->                                 for (NumericBucketPoint item : list) {
->                                     if (!item.isEmpty()) {
->                                         break;
->                                     }
->                                     index++;
-344c285
-<                                 index++;
+>             } catch (Exception e) {
+>                 return serverError(e);
+>             }
+306,307c248
+<                 asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
+<                 return;
 ---
->                                 return list.subList(index, list.size());
-346,347d286
-<                             return list.subList(index, list.size());
-<                         }
-349,352c288,295
-<                         return list;
-<                     })
-<                     .map(ApiUtils::collectionToResponse)
-<                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
+>                 return badRequest(new ApiError("fromEarliest can only be used without start & end"));
+311,312c252
+<                 asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
+<                 return;
 ---
->                             return list;
->                         })
->                         .map(ApiUtils::collectionToResponse)
->                         .toBlocking()
->                         .lastOrDefault(null);
->            }
+>                 return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
+335,336c275
+<                 asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
+<                 return;
+---
+>                 return badRequest(new ApiError(timeRange.getProblem()));
+341,342c280
+<                 asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
+<                 return;
+---
+>                 return badRequest(new ApiError(bucketConfig.getProblem()));
+351,360c289,304
+<         observableConfig
+<                 .flatMap((localBucketConfig) -> metricsService.findCounterStats(metricId,
+<                         localBucketConfig.getTimeRange().getStart(),
+<                         localBucketConfig.getTimeRange().getEnd(),
+<                         localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+<                 .flatMap(Observable::from)
+<                 .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+<                 .toList()
+<                 .map(ApiUtils::collectionToResponse)
+<                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
+---
+>         try {
+>             return observableConfig
+>                     .flatMap((localBucketConfig) -> metricsService.findCounterStats(metricId,
+>                             localBucketConfig.getTimeRange().getStart(),
+>                             localBucketConfig.getTimeRange().getEnd(),
+>                             localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+>                     .flatMap(Observable::from)
+>                     .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+>                     .toList()
+>                     .map(ApiUtils::collectionToResponse)
+>                     .toBlocking()
+>                     .lastOrDefault(null);
+> 
 >         } catch (Exception e) {
 >             return serverError(e);
-358,379c301,307
+>         }
+365,386c309,315
 <     @ApiOperation(
 <             value = "Retrieve counter rate data points.", notes = "When buckets or bucketDuration query parameter is " +
 <             "used, the time range between start and end will be divided in buckets of equal duration, and metric " +
@@ -1224,17 +1177,17 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         @QueryParam("buckets") Integer bucketsCount,
 >         @QueryParam("bucketDuration") Duration bucketDuration,
 >         @QueryParam("percentiles") Percentiles percentiles
-383,384c311
+390,391c319
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-388,389c315
+395,396c323
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-394,401c320,338
+401,409c328,339
 <         if (buckets == null) {
 <             metricsService.findRateData(metricId, timeRange.getStart(), timeRange.getEnd())
 <                     .toList()
@@ -1243,6 +1196,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <         } else {
 <             if(percentiles == null) {
 <                 percentiles = new Percentiles(Collections.<Double>emptyList());
+<             }
 ---
 >         try {
 >             if (buckets == null) {
@@ -1256,23 +1210,22 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                 if(percentiles == null) {
 >                     percentiles = new Percentiles(Collections.<Double>emptyList());
 >                 }
-> 
+411,414c341,349
+<             metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
+<                     percentiles.getPercentiles())
+<                     .map(ApiUtils::collectionToResponse)
+<                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
+---
 >                 return metricsService
 >                         .findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
 >                                 percentiles.getPercentiles())
 >                         .map(ApiUtils::collectionToResponse)
 >                         .toBlocking()
 >                         .lastOrDefault(null);
-403,407c340,341
-< 
-<             metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
-<                     percentiles.getPercentiles())
-<                     .map(ApiUtils::collectionToResponse)
-<                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
----
+>             }
 >         } catch (Exception e) {
 >             return serverError(e);
-413,435c347,355
+420,442c355,363
 <     @ApiOperation(value = "Fetches data points from one or more metrics that are determined using either a tags " +
 <             "filter or a list of metric names. The time range between start and end is divided into buckets of " +
 <             "equal size (i.e., duration) using either the buckets or bucketDuration parameter. Functions  " +
@@ -1306,33 +1259,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-439,440c359
+446,447c367
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-444,446c363
+451,453c371
 <             asyncResponse.resume(badRequest(new ApiError(
-<                     "Either the buckets or bucketsDuration parameter must be used")));
+<                     "Either the buckets or bucketDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-449,450c366
+456,457c374
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-453,454c369
+460,461c377
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-457,458c372
+464,465c380
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-466,467c380,383
+473,474c388,391
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1340,24 +1293,24 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.COUNTER, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-469c385,386
+476c393,394
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-471,472c388,390
+478,479c396,398
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.COUNTER, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-474c392,393
+481c400,401
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-480,502c399,407
+487,509c407,415
 <     @ApiOperation(value = "Fetches data points from one or more metrics that are determined using either a tags " +
 <             "filter or a list of metric names. The time range between start and end is divided into buckets of " +
 <             "equal size (i.e., duration) using either the buckets or bucketDuration parameter. Functions are " +
@@ -1391,33 +1344,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-506,507c411
+513,514c419
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-511,513c415
+518,520c423
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketsDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-516,517c418
+523,524c426
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-520,521c421
+527,528c429
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-524,525c424
+531,532c432
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-533,534c432,435
+540,541c440,443
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER_RATE, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1425,19 +1378,19 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.COUNTER_RATE, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-536c437,438
+543c445,446
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-538,539c440,442
+545,546c448,450
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER_RATE, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.COUNTER_RATE, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-541c444,445
+548c452,453
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
@@ -1451,17 +1404,19 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 51,52d49
 < import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 < import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
-62a60
+61c58
+< import org.hawkular.metrics.model.NumericBucketPoint;
+---
 > import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
-69,73d66
+69,73d65
 < import io.swagger.annotations.Api;
 < import io.swagger.annotations.ApiOperation;
 < import io.swagger.annotations.ApiParam;
 < import io.swagger.annotations.ApiResponse;
 < import io.swagger.annotations.ApiResponses;
-83d75
+83d74
 < @Api(tags = "Gauge")
-94,107c86,87
+94,107c85,86
 <     @ApiOperation(value = "Create gauge metric.", notes = "Clients are not required to explicitly create "
 <             + "a metric before storing data. Doing so however allows clients to prevent naming collisions and to "
 <             + "specify tags and data retention.")
@@ -1479,19 +1434,19 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response createGaugeMetric(
 >             Metric<Double> metric,
-113,114c93,94
+113,114c92,93
 <             asyncResponse.resume(badRequest(new ApiError("Metric type does not match " + MetricType
 <                     .GAUGE.getText())));
 ---
 >             return badRequest(new ApiError("Metric type does not match " + MetricType
 >                     .GAUGE.getText()));
-116,117c96,97
+116,117c95,96
 <         metric = new Metric<>(new MetricId<>(tenantId, GAUGE, metric.getId()), metric.getTags(),
 <                 metric.getDataRetention());
 ---
 >         metric = new Metric<>(new MetricId<>(tenantId, GAUGE, metric.getId()),
 >                 metric.getTags(), metric.getDataRetention());
-119c99,108
+119c98,107
 <         metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
 ---
 >         try {
@@ -1504,7 +1459,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-124,136c113,114
+124,136c112,113
 <     @ApiOperation(value = "Find tenant's metric definitions.",
 <                     notes = "Does not include any metric values. ",
 <                     response = Metric.class, responseContainer = "List")
@@ -1521,7 +1476,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response findGaugeMetrics(
 >             @QueryParam("tags") Tags tags) {
-142,151c120,130
+142,151c119,129
 <         metricObservable
 <                 .toList()
 <                 .map(ApiUtils::collectionToResponse)
@@ -1544,7 +1499,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-156,163c135,137
+156,163c134,136
 <     @ApiOperation(value = "Retrieve single metric definition.", response = Metric.class)
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's definition was successfully retrieved."),
@@ -1557,7 +1512,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >     public Response getGaugeMetric(@PathParam("id") String id) {
 >         try {
 >             return metricsService.findMetric(new MetricId<>(tenantId, GAUGE, id))
-165,166c139,142
+165,166c138,141
 <                 .switchIfEmpty(Observable.just(ApiUtils.noContent()))
 <                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
@@ -1565,7 +1520,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-171,185c147,154
+171,185c146,153
 <     @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Map.class)
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully retrieved."),
@@ -1590,7 +1545,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-190,196c159
+190,196c158
 <     @ApiOperation(value = "Update tags associated with the metric definition.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully updated."),
@@ -1600,12 +1555,12 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response updateMetricTags(
-198,199c161
+198,199c160
 <             @ApiParam(required = true) Map<String, String> tags
 <     ) {
 ---
 >             Map<String, String> tags) {
-201c163,170
+201c162,169
 <         metricsService.addTags(metric, tags).subscribe(new ResultSetObserver(asyncResponse));
 ---
 >         try {
@@ -1616,7 +1571,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-206,213c175
+206,213c174
 <     @ApiOperation(value = "Delete tags associated with the metric definition.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully deleted."),
@@ -1627,11 +1582,11 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response deleteMetricTags(
-215c177
+215c176
 <             @ApiParam("Tag list") @PathParam("tags") Tags tags
 ---
 >             @PathParam("tags") Tags tags
-217,218c179,185
+217,218c178,184
 <         Metric<Double> metric = new Metric<>(new MetricId<>(tenantId, GAUGE, id));
 <         metricsService.deleteTags(metric, tags.getTags()).subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1642,7 +1597,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-223,231c190
+223,231c189
 <     @ApiOperation(value = "Add data for a single gauge metric.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Adding data succeeded."),
@@ -1654,9 +1609,9 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response addDataForMetric(
-233d191
+233d190
 <             @ApiParam(value = "List of datapoints containing timestamp and value", required = true)
-237,238c195,200
+237,238c194,199
 <         Observable<Void> observable = metricsService.addDataPoints(GAUGE, metrics);
 <         observable.subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1666,7 +1621,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-243,252c205,206
+243,252c204,205
 <     @ApiOperation(value = "Add data for multiple gauge metrics in a single call.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Adding data succeeded."),
@@ -1680,7 +1635,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response addGaugeData(
 >             List<Metric<Double>> gauges
-255,256c209,214
+255,256c208,213
 <         Observable<Void> observable = metricsService.addDataPoints(GAUGE, metrics);
 <         observable.subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1690,7 +1645,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-261,273c219
+261,273c218
 <     @ApiOperation(value = "Retrieve gauge data.", notes = "When buckets or bucketDuration query parameter is used, " +
 <             "the time range between start and end will be divided in buckets of equal duration, and metric statistics" +
 <             " will be computed for each bucket.", response = DataPoint.class, responseContainer = "List")
@@ -1706,7 +1661,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended AsyncResponse asyncResponse,
 ---
 >     public Response findGaugeData(
-275,282c221,227
+275,282c220,226
 <             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
 <             @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
 <             @ApiParam(value = "Use data from earliest received, subject to retention period")
@@ -1723,125 +1678,74 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("bucketDuration") Duration bucketDuration,
 >             @QueryParam("percentiles") Percentiles percentiles
 >     ) {
-284,285c229
-<             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
-<             return;
+288,289c232
+<                 asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
+<                 return;
 ---
->             return badRequest(new ApiError("fromEarliest can only be used without start & end"));
-290,291c234
-<             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
-<             return;
----
->             return badRequest(new ApiError(timeRange.getProblem()));
-295,296c238
-<             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
-<             return;
----
->             return badRequest(new ApiError(bucketConfig.getProblem()));
-300,301c242
-<             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
-<             return;
----
->             return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
-306,340c247,286
-<         if (buckets == null) {
+>                 return badRequest(new ApiError(timeRange.getProblem()));
+292c235,236
 <             metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
-<                     .toList()
-<                     .map(ApiUtils::collectionToResponse)
+---
+>             try{
+>             return metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
+295,296c239,243
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
-<         } else {
-<             if(percentiles == null) {
-<                 percentiles = new Percentiles(Collections.<Double>emptyList());
-<             }
-< 
-<             Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
-< 
-<             if (Boolean.TRUE.equals(fromEarliest)) {
-<                 observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
-<                     long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
-<                             ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
-<                             : metricsService.getDefaultTTL() * 1000L;
-< 
-<                     long now = System.currentTimeMillis();
-<                     long earliest = now - dataRetention;
-< 
-<                     return new TimeRange(earliest, now);
-<                 });
-<             }
-< 
-<             final Percentiles localPercentiles = percentiles;
-<             observableTimeRange
-<                     .flatMap((localTimeRange) -> metricsService.findGaugeStats(metricId, localTimeRange.getStart(),
-<                             localTimeRange.getEnd(), buckets, localPercentiles.getPercentiles()))
-<                     .map((list) -> {
-<                         if (Boolean.TRUE.equals(fromEarliest)) {
-<                             int index = 0;
-<                             for (NumericBucketPoint item : list) {
-<                                 if (!item.isEmpty()) {
-<                                     break;
+<             return;
+---
+>                     .toBlocking()
+>                     .lastOrDefault(null);
+>             } catch (Exception e) {
+>                 return serverError(e);
+>             }
+303,304c250
+<                 asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
+<                 return;
+---
+>                 return badRequest(new ApiError("fromEarliest can only be used without start & end"));
+308,309c254
+<                 asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
+<                 return;
+---
+>                 return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
+332,333c277
+<                 asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
+<                 return;
+---
+>                 return badRequest(new ApiError(timeRange.getProblem()));
+338,339c282
+<                 asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
+<                 return;
+---
+>                 return badRequest(new ApiError(bucketConfig.getProblem()));
+348,357c291,306
+<         observableConfig
+<                 .flatMap((localBucketConfig) -> metricsService.findGaugeStats(metricId,
+<                         localBucketConfig.getTimeRange().getStart(),
+<                         localBucketConfig.getTimeRange().getEnd(),
+<                         localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+<                 .flatMap(Observable::from)
+<                 .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+<                 .toList()
+<                 .map(ApiUtils::collectionToResponse)
+<                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
 ---
 >         try {
->             if (buckets == null) {
->                 return metricsService
->                         .findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
->                         .toList()
->                         .map(ApiUtils::collectionToResponse)
->                         .toBlocking()
->                         .lastOrDefault(null);
->             } else {
->                 if (percentiles == null) {
->                     percentiles = new Percentiles(Collections.<Double>emptyList());
->                 }
+>             return observableConfig
+>                     .flatMap((localBucketConfig) -> metricsService.findGaugeStats(metricId,
+>                             localBucketConfig.getTimeRange().getStart(),
+>                             localBucketConfig.getTimeRange().getEnd(),
+>                             localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+>                     .flatMap(Observable::from)
+>                     .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+>                     .toList()
+>                     .map(ApiUtils::collectionToResponse)
+>                     .toBlocking()
+>                     .lastOrDefault(null);
 > 
->                 Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
-> 
->                 if (Boolean.TRUE.equals(fromEarliest)) {
->                     observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
->                         long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
->                                 ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
->                                 : metricsService.getDefaultTTL() * 1000L;
-> 
->                         long now = System.currentTimeMillis();
->                         long earliest = now - dataRetention;
-> 
->                         return new TimeRange(earliest, now);
->                     });
->                 }
-> 
->                 final Percentiles localPercentiles = percentiles;
->                 return observableTimeRange
->                         .flatMap((localTimeRange) -> metricsService.findGaugeStats(metricId, localTimeRange.getStart(),
->                                 localTimeRange.getEnd(), buckets, localPercentiles.getPercentiles()))
->                         .map((list) -> {
->                             if (Boolean.TRUE.equals(fromEarliest)) {
->                                 int index = 0;
->                                 for (NumericBucketPoint item : list) {
->                                     if (!item.isEmpty()) {
->                                         break;
->                                     }
->                                     index++;
-342c288
-<                                 index++;
----
->                                 return list.subList(index, list.size());
-344,345d289
-<                             return list.subList(index, list.size());
-<                         }
-347,350c291,298
-<                         return list;
-<                     })
-<                     .map(ApiUtils::collectionToResponse)
-<                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
----
->                             return list;
->                         })
->                         .map(ApiUtils::collectionToResponse)
->                         .toBlocking()
->                         .lastOrDefault(null);
->             }
 >         } catch (Exception e) {
 >             return serverError(e);
-356,380c304,312
+>         }
+362,386c311,319
 <     @ApiOperation(value = "Find stats for multiple metrics.", notes = "Fetches data points from one or more metrics"
 <             + " that are determined using either a tags filter or a list of metric names. The time range between " +
 <             "start and end is divided into buckets of equal size (i.e., duration) using either the buckets or " +
@@ -1877,33 +1781,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-384,385c316
+390,391c323
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-389,391c320
+395,397c327
 <             asyncResponse.resume(badRequest(new ApiError(
-<                     "Either the buckets or bucketsDuration parameter must be used")));
+<                     "Either the buckets or bucketDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-394,395c323
+400,401c330
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-398,399c326
+404,405c333
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-402,403c329
+408,409c336
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-411,412c337,340
+417,418c344,347
 <             metricsService.findNumericStats(tenantId, MetricType.GAUGE, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1911,24 +1815,24 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.GAUGE, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-414c342,343
+420c349,350
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-416,417c345,347
+422,423c352,354
 <             metricsService.findNumericStats(tenantId, MetricType.GAUGE, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.GAUGE, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-419c349,350
+425c356,357
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-425,433c356
+431,439c363
 <     @ApiOperation(value = "Find condition periods.", notes = "Retrieve periods for which the condition holds true for" +
 <             " each consecutive data point.", response = List.class)
 <     @ApiResponses(value = {
@@ -1940,22 +1844,22 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response findPeriods(
-435,437c358,359
+441,443c365,366
 <             @ApiParam(value = "Defaults to now - 8 hours", required = false) @QueryParam("start") Long start,
 <             @ApiParam(value = "Defaults to now", required = false) @QueryParam("end") Long end,
 <             @ApiParam(value = "A threshold against which values are compared", required = true)
 ---
 >             @QueryParam("start") final Long start,
 >             @QueryParam("end") final Long end,
-439,440d360
+445,446d367
 <             @ApiParam(value = "A comparison operation to perform between values and the threshold.", required = true,
 <                     allowableValues = "ge, gte, lt, lte, eq, neq")
-445,446c365
+451,452c372
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-474,479c393,394
+480,485c400,401
 <             asyncResponse.resume(badRequest(
 <                     new ApiError(
 <                             "Invalid value for op parameter. Supported values are lt, "
@@ -1965,7 +1869,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >             return badRequest(
 >                     new ApiError("Invalid value for op parameter. Supported values are lt, lte, eq, gt, gte."));
-481,484c396,403
+487,490c403,410
 <             MetricId<Double> metricId = new MetricId<>(tenantId, GAUGE, id);
 <             metricsService.getPeriods(metricId, predicate, timeRange.getStart(), timeRange.getEnd())
 <                     .map(ApiUtils::collectionToResponse)

--- a/api/diff.txt
+++ b/api/diff.txt
@@ -32,7 +32,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/pom.xml api/met
 >   </repositories>
 40,42c55,57
 <         <groupId>org.wildfly.bom</groupId>
-<         <artifactId>jboss-javaee-7.0-wildfly</artifactId>
+<         <artifactId>wildfly-javaee7</artifactId>
 <         <version>${version.org.wildfly}</version>
 ---
 >         <groupId>org.jboss.bom.eap</groupId>
@@ -810,19 +810,17 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 52,53d48
 < import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 < import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
-63c58
-< import org.hawkular.metrics.model.NumericBucketPoint;
----
+63a59
 > import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
-70,74d64
+70,74d65
 < import io.swagger.annotations.Api;
 < import io.swagger.annotations.ApiOperation;
 < import io.swagger.annotations.ApiParam;
 < import io.swagger.annotations.ApiResponse;
 < import io.swagger.annotations.ApiResponses;
-84d73
+84d74
 < @Api(tags = "Counter")
-95,110c84,85
+95,110c85,86
 <     @ApiOperation(
 <             value = "Create counter metric.", notes = "This operation also causes the rate to be calculated and " +
 <             "persisted periodically after raw count data is persisted. Clients are not required to explicitly create " +
@@ -842,14 +840,14 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response createCounter(
 >             Metric<Long> metric,
-116,118c91,92
+116,118c92,93
 <             asyncResponse
 <                     .resume(badRequest(new ApiError("Metric type does not match " + MetricType
 <                     .COUNTER.getText())));
 ---
 >             return badRequest(new ApiError("Metric type does not match " + MetricType
 >                     .COUNTER.getText()));
-123c97,106
+123c98,107
 <         metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
 ---
 >         try {
@@ -862,7 +860,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-128,140c111,112
+128,140c112,113
 <     @ApiOperation(value = "Find tenant's counter metric definitions.",
 <                     notes = "Does not include any metric values. ",
 <                     response = Metric.class, responseContainer = "List")
@@ -879,7 +877,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response findCounterMetrics(
 >             @QueryParam("tags") Tags tags) {
-146,155c118,128
+146,155c119,129
 <         metricObservable
 <                 .toList()
 <                 .map(ApiUtils::collectionToResponse)
@@ -902,7 +900,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-160,168c133,135
+160,168c134,136
 <     @ApiOperation(value = "Retrieve a counter definition.", response = Metric.class)
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's definition was successfully retrieved."),
@@ -916,7 +914,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >     public Response getCounter(@PathParam("id") String id) {
 >         try {
 >             return metricsService.findMetric(new MetricId<>(tenantId, COUNTER, id))
-170,171c137,141
+170,171c138,142
 <                 .switchIfEmpty(Observable.just(noContent()))
 <                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
 ---
@@ -925,7 +923,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-176,188c146,153
+176,188c147,154
 <     @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Map.class)
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully retrieved."),
@@ -948,7 +946,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-193,199c158
+193,199c159
 <     @ApiOperation(value = "Update tags associated with the metric definition.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully updated."),
@@ -958,11 +956,11 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response updateMetricTags(
-201c160
+201c161
 <             @ApiParam(required = true) Map<String, String> tags) {
 ---
 >             Map<String, String> tags) {
-203c162,169
+203c163,170
 <         metricsService.addTags(metric, tags).subscribe(new ResultSetObserver(asyncResponse));
 ---
 >         try {
@@ -973,7 +971,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-208,215c174
+208,215c175
 <     @ApiOperation(value = "Delete tags associated with the metric definition.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully deleted."),
@@ -984,7 +982,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response deleteMetricTags(
-217,219c176,183
+217,219c177,184
 <             @ApiParam("Tag list") @PathParam("tags") Tags tags) {
 <         Metric<Long> metric = new Metric<>(new MetricId<>(tenantId, COUNTER, id));
 <         metricsService.deleteTags(metric, tags.getTags()).subscribe(new ResultSetObserver(asyncResponse));
@@ -997,7 +995,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-224,234c188
+224,234c189
 <     @ApiOperation(value = "Add data points for multiple counters.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Adding data points succeeded."),
@@ -1011,7 +1009,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <     ) {
 ---
 >     public Response addData(List<Metric<Long>> counters) {
-236,237c190,195
+236,237c191,196
 <         Observable<Void> observable = metricsService.addDataPoints(COUNTER, metrics);
 <         observable.subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1021,7 +1019,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-242,250c200
+242,250c201
 <     @ApiOperation(value = "Add data for a single counter.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Adding data succeeded."),
@@ -1033,9 +1031,9 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response addData(
-252d201
+252d202
 <             @ApiParam(value = "List of data points containing timestamp and value", required = true)
-256,257c205,210
+256,257c206,211
 <         Observable<Void> observable = metricsService.addDataPoints(COUNTER, metrics);
 <         observable.subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1045,7 +1043,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-262,275c215
+262,275c216
 <     @ApiOperation(value = "Retrieve counter data points.", notes = "When buckets or bucketDuration query parameter " +
 <             "is used, the time range between start and end will be divided in buckets of equal duration, and metric " +
 <             "statistics will be computed for each bucket.", response = DataPoint.class, responseContainer =
@@ -1062,29 +1060,37 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended AsyncResponse asyncResponse,
 ---
 >     public Response findCounterData(
-277,281c217,221
+277,283c218,223
 <             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
 <             @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
+<             @ApiParam(value = "Use data from earliest received, subject to retention period")
+<                 @QueryParam("fromEarliest") Boolean fromEarliest,
 <             @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
 <             @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
 <             @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles
 ---
 >             @QueryParam("start") Long start,
 >             @QueryParam("end") Long end,
+>             @QueryParam("fromEarliest") Boolean fromEarliest,
 >             @QueryParam("buckets") Integer bucketsCount,
 >             @QueryParam("bucketDuration") Duration bucketDuration,
 >             @QueryParam("percentiles") Percentiles percentiles
-285,286c225
+287,288c227
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-290,291c229
+292,293c231
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-296,309c234,254
+297,298c235
+<             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
+<             return;
+---
+>             return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
+303,332c240,274
 <         if (buckets == null) {
 <             metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
 <                     .toList()
@@ -1095,10 +1101,26 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <                 percentiles = new Percentiles(Collections.<Double>emptyList());
 <             }
 < 
-<             metricsService.findCounterStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
-<                     percentiles.getPercentiles())
-<                     .map(ApiUtils::collectionToResponse)
-<                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
+<             Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
+< 
+<             if (Boolean.TRUE.equals(fromEarliest)) {
+<                 metricsService.findMetric(metricId).first().map((metric) -> {
+<                     long now = System.currentTimeMillis();
+<                     long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+<                     return new TimeRange(earliest, now);
+<                 });
+<             }
+< 
+<             final Percentiles localPercentiles = percentiles;
+<             observableTimeRange
+<                     .flatMap((localTimeRange) -> metricsService.findCounterStats(metricId, localTimeRange.getStart(),
+<                             localTimeRange.getEnd(), buckets, localPercentiles.getPercentiles()))
+<                     .map((list) -> {
+<                         if (Boolean.TRUE.equals(fromEarliest)) {
+<                             int index = 0;
+<                             for (NumericBucketPoint item : list) {
+<                                 if (!item.isEmpty()) {
+<                                     break;
 ---
 >         try {
 >             if (buckets == null) {
@@ -1112,16 +1134,51 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     percentiles = new Percentiles(Collections.<Double>emptyList());
 >                 }
 > 
->                 return metricsService
->                         .findCounterStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
->                                 percentiles.getPercentiles())
+>                 Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
+> 
+>                 if (Boolean.TRUE.equals(fromEarliest)) {
+>                     metricsService.findMetric(metricId).first().map((metric) -> {
+>                         long now = System.currentTimeMillis();
+>                         long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+>                         return new TimeRange(earliest, now);
+>                     });
+>                 }
+> 
+>                 final Percentiles localPercentiles = percentiles;
+>                 return observableTimeRange
+>                         .flatMap((localTimeRange) -> metricsService.findCounterStats(metricId,
+>                                 localTimeRange.getStart(), localTimeRange.getEnd(), buckets,
+>                                 localPercentiles.getPercentiles()))
+>                         .map((list) -> {
+>                             if (Boolean.TRUE.equals(fromEarliest)) {
+>                                 int index = 0;
+>                                 for (NumericBucketPoint item : list) {
+>                                     if (!item.isEmpty()) {
+>                                         break;
+>                                     }
+>                                     index++;
+334c276
+<                                 index++;
+---
+>                                 return list.subList(index, list.size());
+336,337d277
+<                             return list.subList(index, list.size());
+<                         }
+339,342c279,286
+<                         return list;
+<                     })
+<                     .map(ApiUtils::collectionToResponse)
+<                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
+---
+>                             return list;
+>                         })
 >                         .map(ApiUtils::collectionToResponse)
 >                         .toBlocking()
 >                         .lastOrDefault(null);
 >            }
 >         } catch (Exception e) {
 >             return serverError(e);
-315,336c260,266
+348,369c292,298
 <     @ApiOperation(
 <             value = "Retrieve counter rate data points.", notes = "When buckets or bucketDuration query parameter is " +
 <             "used, the time range between start and end will be divided in buckets of equal duration, and metric " +
@@ -1152,17 +1209,17 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         @QueryParam("buckets") Integer bucketsCount,
 >         @QueryParam("bucketDuration") Duration bucketDuration,
 >         @QueryParam("percentiles") Percentiles percentiles
-340,341c270
+373,374c302
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-345,346c274
+378,379c306
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-351,358c279,297
+384,391c311,329
 <         if (buckets == null) {
 <             metricsService.findRateData(metricId, timeRange.getStart(), timeRange.getEnd())
 <                     .toList()
@@ -1191,7 +1248,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                         .map(ApiUtils::collectionToResponse)
 >                         .toBlocking()
 >                         .lastOrDefault(null);
-360,364c299,300
+393,397c331,332
 < 
 <             metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
 <                     percentiles.getPercentiles())
@@ -1200,7 +1257,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >         } catch (Exception e) {
 >             return serverError(e);
-370,392c306,314
+403,425c338,346
 <     @ApiOperation(value = "Fetches data points from one or more metrics that are determined using either a tags " +
 <             "filter or a list of metric names. The time range between start and end is divided into buckets of " +
 <             "equal size (i.e., duration) using either the buckets or bucketDuration parameter. Functions  " +
@@ -1234,33 +1291,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-396,397c318
+429,430c350
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-401,403c322
+434,436c354
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketsDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-406,407c325
+439,440c357
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-410,411c328
+443,444c360
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-414,415c331
+447,448c363
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-423,424c339,342
+456,457c371,374
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1268,24 +1325,24 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.COUNTER, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-426c344,345
+459c376,377
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-428,429c347,349
+461,462c379,381
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.COUNTER, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-431c351,352
+464c383,384
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-437,459c358,366
+470,492c390,398
 <     @ApiOperation(value = "Fetches data points from one or more metrics that are determined using either a tags " +
 <             "filter or a list of metric names. The time range between start and end is divided into buckets of " +
 <             "equal size (i.e., duration) using either the buckets or bucketDuration parameter. Functions are " +
@@ -1319,33 +1376,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-463,464c370
+496,497c402
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-468,470c374
+501,503c406
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketsDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-473,474c377
+506,507c409
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-477,478c380
+510,511c412
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-481,482c383
+514,515c415
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-490,491c391,394
+523,524c423,426
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER_RATE, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1353,19 +1410,19 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.COUNTER_RATE, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-493c396,397
+526c428,429
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-495,496c399,401
+528,529c431,433
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER_RATE, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.COUNTER_RATE, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-498c403,404
+531c435,436
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
@@ -1379,19 +1436,17 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 51,52d49
 < import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 < import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
-62c59
-< import org.hawkular.metrics.model.NumericBucketPoint;
----
+62a60
 > import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
-69,73d65
+69,73d66
 < import io.swagger.annotations.Api;
 < import io.swagger.annotations.ApiOperation;
 < import io.swagger.annotations.ApiParam;
 < import io.swagger.annotations.ApiResponse;
 < import io.swagger.annotations.ApiResponses;
-83d74
+83d75
 < @Api(tags = "Gauge")
-94,107c85,86
+94,107c86,87
 <     @ApiOperation(value = "Create gauge metric.", notes = "Clients are not required to explicitly create "
 <             + "a metric before storing data. Doing so however allows clients to prevent naming collisions and to "
 <             + "specify tags and data retention.")
@@ -1409,19 +1464,19 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response createGaugeMetric(
 >             Metric<Double> metric,
-113,114c92,93
+113,114c93,94
 <             asyncResponse.resume(badRequest(new ApiError("Metric type does not match " + MetricType
 <                     .GAUGE.getText())));
 ---
 >             return badRequest(new ApiError("Metric type does not match " + MetricType
 >                     .GAUGE.getText()));
-116,117c95,96
+116,117c96,97
 <         metric = new Metric<>(new MetricId<>(tenantId, GAUGE, metric.getId()), metric.getTags(),
 <                 metric.getDataRetention());
 ---
 >         metric = new Metric<>(new MetricId<>(tenantId, GAUGE, metric.getId()),
 >                 metric.getTags(), metric.getDataRetention());
-119c98,107
+119c99,108
 <         metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
 ---
 >         try {
@@ -1434,7 +1489,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-124,136c112,113
+124,136c113,114
 <     @ApiOperation(value = "Find tenant's metric definitions.",
 <                     notes = "Does not include any metric values. ",
 <                     response = Metric.class, responseContainer = "List")
@@ -1451,7 +1506,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response findGaugeMetrics(
 >             @QueryParam("tags") Tags tags) {
-142,151c119,129
+142,151c120,130
 <         metricObservable
 <                 .toList()
 <                 .map(ApiUtils::collectionToResponse)
@@ -1474,7 +1529,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-156,163c134,136
+156,163c135,137
 <     @ApiOperation(value = "Retrieve single metric definition.", response = Metric.class)
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's definition was successfully retrieved."),
@@ -1487,7 +1542,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >     public Response getGaugeMetric(@PathParam("id") String id) {
 >         try {
 >             return metricsService.findMetric(new MetricId<>(tenantId, GAUGE, id))
-165,166c138,141
+165,166c139,142
 <                 .switchIfEmpty(Observable.just(ApiUtils.noContent()))
 <                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
@@ -1495,7 +1550,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-171,185c146,153
+171,185c147,154
 <     @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Map.class)
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully retrieved."),
@@ -1520,7 +1575,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-190,196c158
+190,196c159
 <     @ApiOperation(value = "Update tags associated with the metric definition.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully updated."),
@@ -1530,12 +1585,12 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response updateMetricTags(
-198,199c160
+198,199c161
 <             @ApiParam(required = true) Map<String, String> tags
 <     ) {
 ---
 >             Map<String, String> tags) {
-201c162,169
+201c163,170
 <         metricsService.addTags(metric, tags).subscribe(new ResultSetObserver(asyncResponse));
 ---
 >         try {
@@ -1546,7 +1601,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-206,213c174
+206,213c175
 <     @ApiOperation(value = "Delete tags associated with the metric definition.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Metric's tags were successfully deleted."),
@@ -1557,11 +1612,11 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response deleteMetricTags(
-215c176
+215c177
 <             @ApiParam("Tag list") @PathParam("tags") Tags tags
 ---
 >             @PathParam("tags") Tags tags
-217,218c178,184
+217,218c179,185
 <         Metric<Double> metric = new Metric<>(new MetricId<>(tenantId, GAUGE, id));
 <         metricsService.deleteTags(metric, tags.getTags()).subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1572,7 +1627,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-223,231c189
+223,231c190
 <     @ApiOperation(value = "Add data for a single gauge metric.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Adding data succeeded."),
@@ -1584,9 +1639,9 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response addDataForMetric(
-233d190
+233d191
 <             @ApiParam(value = "List of datapoints containing timestamp and value", required = true)
-237,238c194,199
+237,238c195,200
 <         Observable<Void> observable = metricsService.addDataPoints(GAUGE, metrics);
 <         observable.subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1596,7 +1651,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-243,252c204,205
+243,252c205,206
 <     @ApiOperation(value = "Add data for multiple gauge metrics in a single call.")
 <     @ApiResponses(value = {
 <             @ApiResponse(code = 200, message = "Adding data succeeded."),
@@ -1610,7 +1665,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     public Response addGaugeData(
 >             List<Metric<Double>> gauges
-255,256c208,213
+255,256c209,214
 <         Observable<Void> observable = metricsService.addDataPoints(GAUGE, metrics);
 <         observable.subscribe(new ResultSetObserver(asyncResponse));
 ---
@@ -1620,7 +1675,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-261,273c218
+261,273c219
 <     @ApiOperation(value = "Retrieve gauge data.", notes = "When buckets or bucketDuration query parameter is used, " +
 <             "the time range between start and end will be divided in buckets of equal duration, and metric statistics" +
 <             " will be computed for each bucket.", response = DataPoint.class, responseContainer = "List")
@@ -1636,30 +1691,38 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended AsyncResponse asyncResponse,
 ---
 >     public Response findGaugeData(
-275,279c220,225
+275,281c221,227
 <             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
 <             @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
+<             @ApiParam(value = "Use data from earliest received, subject to retention period")
+<                 @QueryParam("fromEarliest") Boolean fromEarliest,
 <             @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
 <             @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
 <             @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles) {
 ---
 >             @QueryParam("start") final Long start,
 >             @QueryParam("end") final Long end,
+>             @QueryParam("fromEarliest") Boolean fromEarliest,
 >             @QueryParam("buckets") Integer bucketsCount,
 >             @QueryParam("bucketDuration") Duration bucketDuration,
 >             @QueryParam("percentiles") Percentiles percentiles
 >     ) {
-282,283c228
+284,285c230
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-287,288c232
+289,290c234
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-293,300c237,255
+294,295c238
+<             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
+<             return;
+---
+>             return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
+300,329c243,277
 <         if (buckets == null) {
 <             metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
 <                     .toList()
@@ -1668,6 +1731,28 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <         } else {
 <             if(percentiles == null) {
 <                 percentiles = new Percentiles(Collections.<Double>emptyList());
+<             }
+< 
+<             Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
+< 
+<             if (Boolean.TRUE.equals(fromEarliest)) {
+<                 metricsService.findMetric(metricId).first().map((metric) -> {
+<                     long now = System.currentTimeMillis();
+<                     long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+<                     return new TimeRange(earliest, now);
+<                 });
+<             }
+< 
+<             final Percentiles localPercentiles = percentiles;
+<             observableTimeRange
+<                     .flatMap((localTimeRange) -> metricsService.findGaugeStats(metricId, localTimeRange.getStart(),
+<                             localTimeRange.getEnd(), buckets, localPercentiles.getPercentiles()))
+<                     .map((list) -> {
+<                         if (Boolean.TRUE.equals(fromEarliest)) {
+<                             int index = 0;
+<                             for (NumericBucketPoint item : list) {
+<                                 if (!item.isEmpty()) {
+<                                     break;
 ---
 >         try {
 >             if (buckets == null) {
@@ -1682,22 +1767,50 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     percentiles = new Percentiles(Collections.<Double>emptyList());
 >                 }
 > 
->                 return metricsService
->                         .findGaugeStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
->                                 percentiles.getPercentiles())
->                         .map(ApiUtils::collectionToResponse)
->                         .toBlocking()
->                         .lastOrDefault(null);
-302,306c257,258
-< 
-<             metricsService.findGaugeStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
-<                     percentiles.getPercentiles())
+>                 Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
+> 
+>                 if (Boolean.TRUE.equals(fromEarliest)) {
+>                     metricsService.findMetric(metricId).first().map((metric) -> {
+>                         long now = System.currentTimeMillis();
+>                         long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+>                         return new TimeRange(earliest, now);
+>                     });
+>                 }
+> 
+>                 final Percentiles localPercentiles = percentiles;
+>                 return observableTimeRange
+>                         .flatMap((localTimeRange) -> metricsService.findGaugeStats(metricId, localTimeRange.getStart(),
+>                                 localTimeRange.getEnd(), buckets, localPercentiles.getPercentiles()))
+>                         .map((list) -> {
+>                             if (Boolean.TRUE.equals(fromEarliest)) {
+>                                 int index = 0;
+>                                 for (NumericBucketPoint item : list) {
+>                                     if (!item.isEmpty()) {
+>                                         break;
+>                                     }
+>                                     index++;
+331c279
+<                                 index++;
+---
+>                                 return list.subList(index, list.size());
+333,334d280
+<                             return list.subList(index, list.size());
+<                         }
+336,339c282,289
+<                         return list;
+<                     })
 <                     .map(ApiUtils::collectionToResponse)
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
+>                             return list;
+>                         })
+>                         .map(ApiUtils::collectionToResponse)
+>                         .toBlocking()
+>                         .lastOrDefault(null);
+>             }
 >         } catch (Exception e) {
 >             return serverError(e);
-312,336c264,272
+345,369c295,303
 <     @ApiOperation(value = "Find stats for multiple metrics.", notes = "Fetches data points from one or more metrics"
 <             + " that are determined using either a tags filter or a list of metric names. The time range between " +
 <             "start and end is divided into buckets of equal size (i.e., duration) using either the buckets or " +
@@ -1733,33 +1846,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-340,341c276
+373,374c307
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-345,347c280
+378,380c311
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketsDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-350,351c283
+383,384c314
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-354,355c286
+387,388c317
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-358,359c289
+391,392c320
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-367,368c297,300
+400,401c328,331
 <             metricsService.findNumericStats(tenantId, MetricType.GAUGE, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1767,24 +1880,24 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.GAUGE, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-370c302,303
+403c333,334
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-372,373c305,307
+405,406c336,338
 <             metricsService.findNumericStats(tenantId, MetricType.GAUGE, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.GAUGE, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-375c309,310
+408c340,341
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-381,389c316
+414,422c347
 <     @ApiOperation(value = "Find condition periods.", notes = "Retrieve periods for which the condition holds true for" +
 <             " each consecutive data point.", response = List.class)
 <     @ApiResponses(value = {
@@ -1796,22 +1909,22 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response findPeriods(
-391,393c318,319
+424,426c349,350
 <             @ApiParam(value = "Defaults to now - 8 hours", required = false) @QueryParam("start") Long start,
 <             @ApiParam(value = "Defaults to now", required = false) @QueryParam("end") Long end,
 <             @ApiParam(value = "A threshold against which values are compared", required = true)
 ---
 >             @QueryParam("start") final Long start,
 >             @QueryParam("end") final Long end,
-395,396d320
+428,429d351
 <             @ApiParam(value = "A comparison operation to perform between values and the threshold.", required = true,
 <                     allowableValues = "ge, gte, lt, lte, eq, neq")
-401,402c325
+434,435c356
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-430,435c353,354
+463,468c384,385
 <             asyncResponse.resume(badRequest(
 <                     new ApiError(
 <                             "Invalid value for op parameter. Supported values are lt, "
@@ -1821,7 +1934,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >             return badRequest(
 >                     new ApiError("Invalid value for op parameter. Supported values are lt, lte, eq, gt, gte."));
-437,440c356,363
+470,473c387,394
 <             MetricId<Double> metricId = new MetricId<>(tenantId, GAUGE, id);
 <             metricsService.getPeriods(metricId, predicate, timeRange.getStart(), timeRange.getEnd())
 <                     .map(ApiUtils::collectionToResponse)

--- a/api/diff.txt
+++ b/api/diff.txt
@@ -1075,22 +1075,27 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("buckets") Integer bucketsCount,
 >             @QueryParam("bucketDuration") Duration bucketDuration,
 >             @QueryParam("percentiles") Percentiles percentiles
-287,288c227
+286,287c226
+<             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
+<             return;
+---
+>             return badRequest(new ApiError("fromEarliest can only be used without start & end"));
+292,293c231
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-292,293c231
+297,298c235
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-297,298c235
+302,303c239
 <             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
 <             return;
 ---
 >             return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
-303,332c240,274
+308,342c244,283
 <         if (buckets == null) {
 <             metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
 <                     .toList()
@@ -1104,9 +1109,14 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
 < 
 <             if (Boolean.TRUE.equals(fromEarliest)) {
-<                 metricsService.findMetric(metricId).first().map((metric) -> {
+<                 observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
+<                     long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
+<                             ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
+<                             : metricsService.getDefaultTTL() * 1000L;
+< 
 <                     long now = System.currentTimeMillis();
-<                     long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+<                     long earliest = now - dataRetention;
+< 
 <                     return new TimeRange(earliest, now);
 <                 });
 <             }
@@ -1137,9 +1147,14 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                 Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
 > 
 >                 if (Boolean.TRUE.equals(fromEarliest)) {
->                     metricsService.findMetric(metricId).first().map((metric) -> {
+>                     observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
+>                         long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
+>                                 ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
+>                                 : metricsService.getDefaultTTL() * 1000L;
+> 
 >                         long now = System.currentTimeMillis();
->                         long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+>                         long earliest = now - dataRetention;
+> 
 >                         return new TimeRange(earliest, now);
 >                     });
 >                 }
@@ -1157,14 +1172,14 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                                         break;
 >                                     }
 >                                     index++;
-334c276
+344c285
 <                                 index++;
 ---
 >                                 return list.subList(index, list.size());
-336,337d277
+346,347d286
 <                             return list.subList(index, list.size());
 <                         }
-339,342c279,286
+349,352c288,295
 <                         return list;
 <                     })
 <                     .map(ApiUtils::collectionToResponse)
@@ -1178,7 +1193,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >            }
 >         } catch (Exception e) {
 >             return serverError(e);
-348,369c292,298
+358,379c301,307
 <     @ApiOperation(
 <             value = "Retrieve counter rate data points.", notes = "When buckets or bucketDuration query parameter is " +
 <             "used, the time range between start and end will be divided in buckets of equal duration, and metric " +
@@ -1209,17 +1224,17 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         @QueryParam("buckets") Integer bucketsCount,
 >         @QueryParam("bucketDuration") Duration bucketDuration,
 >         @QueryParam("percentiles") Percentiles percentiles
-373,374c302
+383,384c311
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-378,379c306
+388,389c315
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-384,391c311,329
+394,401c320,338
 <         if (buckets == null) {
 <             metricsService.findRateData(metricId, timeRange.getStart(), timeRange.getEnd())
 <                     .toList()
@@ -1248,7 +1263,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                         .map(ApiUtils::collectionToResponse)
 >                         .toBlocking()
 >                         .lastOrDefault(null);
-393,397c331,332
+403,407c340,341
 < 
 <             metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
 <                     percentiles.getPercentiles())
@@ -1257,7 +1272,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >         } catch (Exception e) {
 >             return serverError(e);
-403,425c338,346
+413,435c347,355
 <     @ApiOperation(value = "Fetches data points from one or more metrics that are determined using either a tags " +
 <             "filter or a list of metric names. The time range between start and end is divided into buckets of " +
 <             "equal size (i.e., duration) using either the buckets or bucketDuration parameter. Functions  " +
@@ -1291,33 +1306,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-429,430c350
+439,440c359
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-434,436c354
+444,446c363
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketsDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-439,440c357
+449,450c366
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-443,444c360
+453,454c369
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-447,448c363
+457,458c372
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-456,457c371,374
+466,467c380,383
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1325,24 +1340,24 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.COUNTER, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-459c376,377
+469c385,386
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-461,462c379,381
+471,472c388,390
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.COUNTER, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-464c383,384
+474c392,393
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-470,492c390,398
+480,502c399,407
 <     @ApiOperation(value = "Fetches data points from one or more metrics that are determined using either a tags " +
 <             "filter or a list of metric names. The time range between start and end is divided into buckets of " +
 <             "equal size (i.e., duration) using either the buckets or bucketDuration parameter. Functions are " +
@@ -1376,33 +1391,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-496,497c402
+506,507c411
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-501,503c406
+511,513c415
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketsDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-506,507c409
+516,517c418
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-510,511c412
+520,521c421
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-514,515c415
+524,525c424
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-523,524c423,426
+533,534c432,435
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER_RATE, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1410,19 +1425,19 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.COUNTER_RATE, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-526c428,429
+536c437,438
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-528,529c431,433
+538,539c440,442
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER_RATE, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.COUNTER_RATE, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-531c435,436
+541c444,445
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
@@ -1691,7 +1706,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended AsyncResponse asyncResponse,
 ---
 >     public Response findGaugeData(
-275,281c221,227
+275,282c221,227
 <             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
 <             @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
 <             @ApiParam(value = "Use data from earliest received, subject to retention period")
@@ -1699,6 +1714,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
 <             @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
 <             @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles) {
+< 
 ---
 >             @QueryParam("start") final Long start,
 >             @QueryParam("end") final Long end,
@@ -1707,22 +1723,27 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("bucketDuration") Duration bucketDuration,
 >             @QueryParam("percentiles") Percentiles percentiles
 >     ) {
-284,285c230
+284,285c229
+<             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
+<             return;
+---
+>             return badRequest(new ApiError("fromEarliest can only be used without start & end"));
+290,291c234
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-289,290c234
+295,296c238
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-294,295c238
+300,301c242
 <             asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
 <             return;
 ---
 >             return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
-300,329c243,277
+306,340c247,286
 <         if (buckets == null) {
 <             metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
 <                     .toList()
@@ -1736,9 +1757,14 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
 < 
 <             if (Boolean.TRUE.equals(fromEarliest)) {
-<                 metricsService.findMetric(metricId).first().map((metric) -> {
+<                 observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
+<                     long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
+<                             ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
+<                             : metricsService.getDefaultTTL() * 1000L;
+< 
 <                     long now = System.currentTimeMillis();
-<                     long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+<                     long earliest = now - dataRetention;
+< 
 <                     return new TimeRange(earliest, now);
 <                 });
 <             }
@@ -1770,9 +1796,14 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                 Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
 > 
 >                 if (Boolean.TRUE.equals(fromEarliest)) {
->                     metricsService.findMetric(metricId).first().map((metric) -> {
+>                     observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
+>                         long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
+>                                 ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
+>                                 : metricsService.getDefaultTTL() * 1000L;
+> 
 >                         long now = System.currentTimeMillis();
->                         long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+>                         long earliest = now - dataRetention;
+> 
 >                         return new TimeRange(earliest, now);
 >                     });
 >                 }
@@ -1789,14 +1820,14 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                                         break;
 >                                     }
 >                                     index++;
-331c279
+342c288
 <                                 index++;
 ---
 >                                 return list.subList(index, list.size());
-333,334d280
+344,345d289
 <                             return list.subList(index, list.size());
 <                         }
-336,339c282,289
+347,350c291,298
 <                         return list;
 <                     })
 <                     .map(ApiUtils::collectionToResponse)
@@ -1810,7 +1841,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             }
 >         } catch (Exception e) {
 >             return serverError(e);
-345,369c295,303
+356,380c304,312
 <     @ApiOperation(value = "Find stats for multiple metrics.", notes = "Fetches data points from one or more metrics"
 <             + " that are determined using either a tags filter or a list of metric names. The time range between " +
 <             "start and end is divided into buckets of equal size (i.e., duration) using either the buckets or " +
@@ -1846,33 +1877,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-373,374c307
+384,385c316
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-378,380c311
+389,391c320
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketsDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-383,384c314
+394,395c323
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-387,388c317
+398,399c326
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-391,392c320
+402,403c329
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-400,401c328,331
+411,412c337,340
 <             metricsService.findNumericStats(tenantId, MetricType.GAUGE, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1880,24 +1911,24 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.GAUGE, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-403c333,334
+414c342,343
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-405,406c336,338
+416,417c345,347
 <             metricsService.findNumericStats(tenantId, MetricType.GAUGE, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.GAUGE, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-408c340,341
+419c349,350
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-414,422c347
+425,433c356
 <     @ApiOperation(value = "Find condition periods.", notes = "Retrieve periods for which the condition holds true for" +
 <             " each consecutive data point.", response = List.class)
 <     @ApiResponses(value = {
@@ -1909,22 +1940,22 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response findPeriods(
-424,426c349,350
+435,437c358,359
 <             @ApiParam(value = "Defaults to now - 8 hours", required = false) @QueryParam("start") Long start,
 <             @ApiParam(value = "Defaults to now", required = false) @QueryParam("end") Long end,
 <             @ApiParam(value = "A threshold against which values are compared", required = true)
 ---
 >             @QueryParam("start") final Long start,
 >             @QueryParam("end") final Long end,
-428,429d351
+439,440d360
 <             @ApiParam(value = "A comparison operation to perform between values and the threshold.", required = true,
 <                     allowableValues = "ge, gte, lt, lte, eq, neq")
-434,435c356
+445,446c365
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-463,468c384,385
+474,479c393,394
 <             asyncResponse.resume(badRequest(
 <                     new ApiError(
 <                             "Invalid value for op parameter. Supported values are lt, "
@@ -1934,7 +1965,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >             return badRequest(
 >                     new ApiError("Invalid value for op parameter. Supported values are lt, lte, eq, gt, gte."));
-470,473c387,394
+481,484c396,403
 <             MetricId<Double> metricId = new MetricId<>(tenantId, GAUGE, id);
 <             metricsService.getPeriods(metricId, predicate, timeRange.getStart(), timeRange.getEnd())
 <                     .map(ApiUtils::collectionToResponse)

--- a/api/diff.txt
+++ b/api/diff.txt
@@ -1120,10 +1120,10 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                 return badRequest(new ApiError(bucketConfig.getProblem()));
 351,360c289,304
 <         observableConfig
-<                 .flatMap((localBucketConfig) -> metricsService.findCounterStats(metricId,
-<                         localBucketConfig.getTimeRange().getStart(),
-<                         localBucketConfig.getTimeRange().getEnd(),
-<                         localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+<                 .flatMap((config) -> metricsService.findCounterStats(metricId,
+<                         config.getTimeRange().getStart(),
+<                         config.getTimeRange().getEnd(),
+<                         config.getBuckets(), lPercentiles.getPercentiles()))
 <                 .flatMap(Observable::from)
 <                 .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
 <                 .toList()
@@ -1132,10 +1132,10 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >         try {
 >             return observableConfig
->                     .flatMap((localBucketConfig) -> metricsService.findCounterStats(metricId,
->                             localBucketConfig.getTimeRange().getStart(),
->                             localBucketConfig.getTimeRange().getEnd(),
->                             localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+>                     .flatMap((config) -> metricsService.findCounterStats(metricId,
+>                             config.getTimeRange().getStart(),
+>                             config.getTimeRange().getEnd(),
+>                             config.getBuckets(), lPercentiles.getPercentiles()))
 >                     .flatMap(Observable::from)
 >                     .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
 >                     .toList()
@@ -1719,10 +1719,10 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                 return badRequest(new ApiError(bucketConfig.getProblem()));
 348,357c291,306
 <         observableConfig
-<                 .flatMap((localBucketConfig) -> metricsService.findGaugeStats(metricId,
-<                         localBucketConfig.getTimeRange().getStart(),
-<                         localBucketConfig.getTimeRange().getEnd(),
-<                         localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+<                 .flatMap((config) -> metricsService.findGaugeStats(metricId,
+<                         config.getTimeRange().getStart(),
+<                         config.getTimeRange().getEnd(),
+<                         config.getBuckets(), lPercentiles.getPercentiles()))
 <                 .flatMap(Observable::from)
 <                 .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
 <                 .toList()
@@ -1731,10 +1731,10 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >         try {
 >             return observableConfig
->                     .flatMap((localBucketConfig) -> metricsService.findGaugeStats(metricId,
->                             localBucketConfig.getTimeRange().getStart(),
->                             localBucketConfig.getTimeRange().getEnd(),
->                             localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+>                     .flatMap((config) -> metricsService.findGaugeStats(metricId,
+>                             config.getTimeRange().getStart(),
+>                             config.getTimeRange().getEnd(),
+>                             config.getBuckets(), lPercentiles.getPercentiles()))
 >                     .flatMap(Observable::from)
 >                     .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
 >                     .toList()

--- a/api/diff.txt
+++ b/api/diff.txt
@@ -1108,17 +1108,17 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <                 return;
 ---
 >                 return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
-335,336c275
+332,333c272
 <                 asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <                 return;
 ---
 >                 return badRequest(new ApiError(timeRange.getProblem()));
-341,342c280
+338,339c277
 <                 asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <                 return;
 ---
 >                 return badRequest(new ApiError(bucketConfig.getProblem()));
-351,360c289,304
+348,357c286,301
 <         observableConfig
 <                 .flatMap((config) -> metricsService.findCounterStats(metricId,
 <                         config.getTimeRange().getStart(),
@@ -1146,7 +1146,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-365,386c309,315
+362,383c306,312
 <     @ApiOperation(
 <             value = "Retrieve counter rate data points.", notes = "When buckets or bucketDuration query parameter is " +
 <             "used, the time range between start and end will be divided in buckets of equal duration, and metric " +
@@ -1177,17 +1177,17 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         @QueryParam("buckets") Integer bucketsCount,
 >         @QueryParam("bucketDuration") Duration bucketDuration,
 >         @QueryParam("percentiles") Percentiles percentiles
-390,391c319
+387,388c316
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-395,396c323
+392,393c320
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-401,409c328,339
+398,406c325,336
 <         if (buckets == null) {
 <             metricsService.findRateData(metricId, timeRange.getStart(), timeRange.getEnd())
 <                     .toList()
@@ -1210,7 +1210,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                 if(percentiles == null) {
 >                     percentiles = new Percentiles(Collections.<Double>emptyList());
 >                 }
-411,414c341,349
+408,411c338,346
 <             metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
 <                     percentiles.getPercentiles())
 <                     .map(ApiUtils::collectionToResponse)
@@ -1225,7 +1225,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             }
 >         } catch (Exception e) {
 >             return serverError(e);
-420,442c355,363
+417,439c352,360
 <     @ApiOperation(value = "Fetches data points from one or more metrics that are determined using either a tags " +
 <             "filter or a list of metric names. The time range between start and end is divided into buckets of " +
 <             "equal size (i.e., duration) using either the buckets or bucketDuration parameter. Functions  " +
@@ -1259,33 +1259,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-446,447c367
+443,444c364
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-451,453c371
+448,450c368
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-456,457c374
+453,454c371
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-460,461c377
+457,458c374
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-464,465c380
+461,462c377
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-473,474c388,391
+470,471c385,388
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1293,24 +1293,24 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.COUNTER, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-476c393,394
+473c390,391
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-478,479c396,398
+475,476c393,395
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.COUNTER, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-481c400,401
+478c397,398
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-487,509c407,415
+484,506c404,412
 <     @ApiOperation(value = "Fetches data points from one or more metrics that are determined using either a tags " +
 <             "filter or a list of metric names. The time range between start and end is divided into buckets of " +
 <             "equal size (i.e., duration) using either the buckets or bucketDuration parameter. Functions are " +
@@ -1344,33 +1344,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-513,514c419
+510,511c416
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-518,520c423
+515,517c420
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketsDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-523,524c426
+520,521c423
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-527,528c429
+524,525c426
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-531,532c432
+528,529c429
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-540,541c440,443
+537,538c437,440
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER_RATE, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1378,19 +1378,19 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.COUNTER_RATE, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-543c445,446
+540c442,443
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-545,546c448,450
+542,543c445,447
 <             metricsService.findNumericStats(tenantId, MetricType.COUNTER_RATE, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.COUNTER_RATE, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-548c452,453
+545c449,450
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
@@ -1707,17 +1707,17 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <                 return;
 ---
 >                 return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
-332,333c277
+329,330c274
 <                 asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <                 return;
 ---
 >                 return badRequest(new ApiError(timeRange.getProblem()));
-338,339c282
+335,336c279
 <                 asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <                 return;
 ---
 >                 return badRequest(new ApiError(bucketConfig.getProblem()));
-348,357c291,306
+345,354c288,303
 <         observableConfig
 <                 .flatMap((config) -> metricsService.findGaugeStats(metricId,
 <                         config.getTimeRange().getStart(),
@@ -1745,7 +1745,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >         } catch (Exception e) {
 >             return serverError(e);
 >         }
-362,386c311,319
+359,383c308,316
 <     @ApiOperation(value = "Find stats for multiple metrics.", notes = "Fetches data points from one or more metrics"
 <             + " that are determined using either a tags filter or a list of metric names. The time range between " +
 <             "start and end is divided into buckets of equal size (i.e., duration) using either the buckets or " +
@@ -1781,33 +1781,33 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >             @QueryParam("percentiles") Percentiles percentiles,
 >             @QueryParam("metrics") List<String> metricNames,
 >             @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-390,391c323
+387,388c320
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-395,397c327
+392,394c324
 <             asyncResponse.resume(badRequest(new ApiError(
 <                     "Either the buckets or bucketDuration parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either the buckets or bucketsDuration parameter must be used"));
-400,401c330
+397,398c327
 <             asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(bucketConfig.getProblem()));
-404,405c333
+401,402c330
 <             asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
 <             return;
 ---
 >             return badRequest(new ApiError("Either metrics or tags parameter must be used"));
-408,409c336
+405,406c333
 <             asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
 <             return;
 ---
 >             return badRequest(new ApiError("Cannot use both the metrics and tags parameters"));
-417,418c344,347
+414,415c341,344
 <             metricsService.findNumericStats(tenantId, MetricType.GAUGE, tags.getTags(), timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
@@ -1815,24 +1815,24 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 >                     .findNumericStats(tenantId, MetricType.GAUGE, tags.getTags(), timeRange.getStart(),
 >                             timeRange.getEnd(),
 >                             bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-420c349,350
+417c346,347
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-422,423c352,354
+419,420c349,351
 <             metricsService.findNumericStats(tenantId, MetricType.GAUGE, metricNames, timeRange.getStart(),
 <                     timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
 ---
 >             return metricsService
 >                     .findNumericStats(tenantId, MetricType.GAUGE, metricNames, timeRange.getStart(),
 >                             timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-425c356,357
+422c353,354
 <                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
 ---
 >                     .toBlocking()
 >                     .lastOrDefault(null);
-431,439c363
+428,436c360
 <     @ApiOperation(value = "Find condition periods.", notes = "Retrieve periods for which the condition holds true for" +
 <             " each consecutive data point.", response = List.class)
 <     @ApiResponses(value = {
@@ -1844,22 +1844,22 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 <             @Suspended final AsyncResponse asyncResponse,
 ---
 >     public Response findPeriods(
-441,443c365,366
+438,440c362,363
 <             @ApiParam(value = "Defaults to now - 8 hours", required = false) @QueryParam("start") Long start,
 <             @ApiParam(value = "Defaults to now", required = false) @QueryParam("end") Long end,
 <             @ApiParam(value = "A threshold against which values are compared", required = true)
 ---
 >             @QueryParam("start") final Long start,
 >             @QueryParam("end") final Long end,
-445,446d367
+442,443d364
 <             @ApiParam(value = "A comparison operation to perform between values and the threshold.", required = true,
 <                     allowableValues = "ge, gte, lt, lte, eq, neq")
-451,452c372
+448,449c369
 <             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
 <             return;
 ---
 >             return badRequest(new ApiError(timeRange.getProblem()));
-480,485c400,401
+477,482c397,398
 <             asyncResponse.resume(badRequest(
 <                     new ApiError(
 <                             "Invalid value for op parameter. Supported values are lt, "
@@ -1869,7 +1869,7 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >             return badRequest(
 >                     new ApiError("Invalid value for op parameter. Supported values are lt, lte, eq, gt, gte."));
-487,490c403,410
+484,487c400,407
 <             MetricId<Double> metricId = new MetricId<>(tenantId, GAUGE, id);
 <             metricsService.getPeriods(metricId, predicate, timeRange.getStart(), timeRange.getEnd())
 <                     .map(ApiUtils::collectionToResponse)

--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/ApiUtils.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/util/ApiUtils.java
@@ -26,6 +26,7 @@ import javax.ws.rs.core.Response;
 import org.hawkular.metrics.api.jaxrs.log.RestLogger;
 import org.hawkular.metrics.api.jaxrs.log.RestLogging;
 import org.hawkular.metrics.model.ApiError;
+import org.hawkular.metrics.model.exception.RuntimeApiError;
 
 import com.google.common.base.Throwables;
 
@@ -41,6 +42,15 @@ public class ApiUtils {
 
     public static Response mapToResponse(Map<?, ?> map) {
         return map.isEmpty() ? noContent() : Response.ok(map).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    public static Response error(Throwable t) {
+        if(t instanceof RuntimeApiError) {
+            return badRequest(t);
+        } else {
+            return serverError(t);
+        }
+
     }
 
     public static Response serverError(Throwable t, String message) {

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -55,8 +55,8 @@ import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
-import org.hawkular.metrics.model.NumericBucketPoint;
 import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
+import org.hawkular.metrics.model.exception.RuntimeApiError;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
 import org.hawkular.metrics.model.param.Percentiles;
@@ -222,75 +222,83 @@ public class CounterHandler {
             @QueryParam("bucketDuration") Duration bucketDuration,
             @QueryParam("percentiles") Percentiles percentiles
     ) {
-        if (Boolean.TRUE.equals(fromEarliest) && (start != null || end != null)) {
-            return badRequest(new ApiError("fromEarliest can only be used without start & end"));
-        }
-
-        TimeRange timeRange = new TimeRange(start, end);
-        if (!timeRange.isValid()) {
-            return badRequest(new ApiError(timeRange.getProblem()));
-        }
-        BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
-        if (!bucketConfig.isValid()) {
-            return badRequest(new ApiError(bucketConfig.getProblem()));
-        }
-
-        if (bucketConfig.getBuckets() == null && Boolean.TRUE.equals(fromEarliest)) {
-            return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
-        }
-
         MetricId<Long> metricId = new MetricId<>(tenantId, COUNTER, id);
-        Buckets buckets = bucketConfig.getBuckets();
-        try {
-            if (buckets == null) {
+
+        if (bucketsCount == null && bucketDuration == null && !Boolean.TRUE.equals(fromEarliest)) {
+            TimeRange timeRange = new TimeRange(start, end);
+            if (!timeRange.isValid()) {
+                return badRequest(new ApiError(timeRange.getProblem()));
+            }
+
+            try {
                 return metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
                         .toList()
                         .map(ApiUtils::collectionToResponse)
                         .toBlocking()
                         .lastOrDefault(null);
-            } else {
-                if(percentiles == null) {
-                    percentiles = new Percentiles(Collections.<Double>emptyList());
+            } catch (Exception e) {
+                return serverError(e);
+            }
+        }
+
+        Observable<BucketConfig> observableConfig = null;
+
+        if (Boolean.TRUE.equals(fromEarliest)) {
+            if (start != null || end != null) {
+                return badRequest(new ApiError("fromEarliest can only be used without start & end"));
+            }
+
+            if (bucketsCount == null && bucketDuration == null) {
+                return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
+            }
+
+            observableConfig = metricsService.findMetric(metricId).first().map((metric) -> {
+                long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
+                        ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
+                        : metricsService.getDefaultTTL() * 1000L;
+
+                long now = System.currentTimeMillis();
+                long earliest = now - dataRetention;
+
+                BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration,
+                        new TimeRange(earliest, now));
+
+                if (!bucketConfig.isValid()) {
+                    throw new RuntimeApiError(bucketConfig.getProblem());
                 }
 
-                Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
+                return bucketConfig;
+            });
+        } else {
+            TimeRange timeRange = new TimeRange(start, end);
+            if (!timeRange.isValid()) {
+                return badRequest(new ApiError(timeRange.getProblem()));
+            }
 
-                if (Boolean.TRUE.equals(fromEarliest)) {
-                    observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
-                        long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
-                                ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
-                                : metricsService.getDefaultTTL() * 1000L;
+            BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
+            if (!bucketConfig.isValid()) {
+                return badRequest(new ApiError(bucketConfig.getProblem()));
+            }
 
-                        long now = System.currentTimeMillis();
-                        long earliest = now - dataRetention;
+            observableConfig = Observable.just(bucketConfig);
+        }
 
-                        return new TimeRange(earliest, now);
-                    });
-                }
+        final Percentiles localPercentiles = percentiles != null ? percentiles
+                : new Percentiles(Collections.<Double> emptyList());
 
-                final Percentiles localPercentiles = percentiles;
-                return observableTimeRange
-                        .flatMap((localTimeRange) -> metricsService.findCounterStats(metricId,
-                                localTimeRange.getStart(), localTimeRange.getEnd(), buckets,
-                                localPercentiles.getPercentiles()))
-                        .map((list) -> {
-                            if (Boolean.TRUE.equals(fromEarliest)) {
-                                int index = 0;
-                                for (NumericBucketPoint item : list) {
-                                    if (!item.isEmpty()) {
-                                        break;
-                                    }
-                                    index++;
-                                }
-                                return list.subList(index, list.size());
-                            }
+        try {
+            return observableConfig
+                    .flatMap((localBucketConfig) -> metricsService.findCounterStats(metricId,
+                            localBucketConfig.getTimeRange().getStart(),
+                            localBucketConfig.getTimeRange().getEnd(),
+                            localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+                    .flatMap(Observable::from)
+                    .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+                    .toList()
+                    .map(ApiUtils::collectionToResponse)
+                    .toBlocking()
+                    .lastOrDefault(null);
 
-                            return list;
-                        })
-                        .map(ApiUtils::collectionToResponse)
-                        .toBlocking()
-                        .lastOrDefault(null);
-           }
         } catch (Exception e) {
             return serverError(e);
         }

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -55,6 +55,7 @@ import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
+import org.hawkular.metrics.model.NumericBucketPoint;
 import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
@@ -216,6 +217,7 @@ public class CounterHandler {
             @PathParam("id") String id,
             @QueryParam("start") Long start,
             @QueryParam("end") Long end,
+            @QueryParam("fromEarliest") Boolean fromEarliest,
             @QueryParam("buckets") Integer bucketsCount,
             @QueryParam("bucketDuration") Duration bucketDuration,
             @QueryParam("percentiles") Percentiles percentiles
@@ -227,6 +229,10 @@ public class CounterHandler {
         BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
         if (!bucketConfig.isValid()) {
             return badRequest(new ApiError(bucketConfig.getProblem()));
+        }
+
+        if (bucketConfig.getBuckets() == null && Boolean.TRUE.equals(fromEarliest)) {
+            return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
         }
 
         MetricId<Long> metricId = new MetricId<>(tenantId, COUNTER, id);
@@ -243,9 +249,35 @@ public class CounterHandler {
                     percentiles = new Percentiles(Collections.<Double>emptyList());
                 }
 
-                return metricsService
-                        .findCounterStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
-                                percentiles.getPercentiles())
+                Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
+
+                if (Boolean.TRUE.equals(fromEarliest)) {
+                    metricsService.findMetric(metricId).first().map((metric) -> {
+                        long now = System.currentTimeMillis();
+                        long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+                        return new TimeRange(earliest, now);
+                    });
+                }
+
+                final Percentiles localPercentiles = percentiles;
+                return observableTimeRange
+                        .flatMap((localTimeRange) -> metricsService.findCounterStats(metricId,
+                                localTimeRange.getStart(), localTimeRange.getEnd(), buckets,
+                                localPercentiles.getPercentiles()))
+                        .map((list) -> {
+                            if (Boolean.TRUE.equals(fromEarliest)) {
+                                int index = 0;
+                                for (NumericBucketPoint item : list) {
+                                    if (!item.isEmpty()) {
+                                        break;
+                                    }
+                                    index++;
+                                }
+                                return list.subList(index, list.size());
+                            }
+
+                            return list;
+                        })
                         .map(ApiUtils::collectionToResponse)
                         .toBlocking()
                         .lastOrDefault(null);

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -252,7 +252,7 @@ public class CounterHandler {
                 return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
             }
 
-            observableConfig = metricsService.findMetric(metricId).first().map((metric) -> {
+            observableConfig = metricsService.findMetric(metricId).map((metric) -> {
                 long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
                         ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
                         : metricsService.getDefaultTTL() * 1000L;

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -253,10 +253,7 @@ public class CounterHandler {
             }
 
             observableConfig = metricsService.findMetric(metricId).map((metric) -> {
-                long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
-                        ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
-                        : metricsService.getDefaultTTL() * 1000L;
-
+                long dataRetention = metric.getDataRetention() * 24 * 60 * 60 * 1000L;
                 long now = System.currentTimeMillis();
                 long earliest = now - dataRetention;
 

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -222,6 +222,10 @@ public class CounterHandler {
             @QueryParam("bucketDuration") Duration bucketDuration,
             @QueryParam("percentiles") Percentiles percentiles
     ) {
+        if (Boolean.TRUE.equals(fromEarliest) && (start != null || end != null)) {
+            return badRequest(new ApiError("fromEarliest can only be used without start & end"));
+        }
+
         TimeRange timeRange = new TimeRange(start, end);
         if (!timeRange.isValid()) {
             return badRequest(new ApiError(timeRange.getProblem()));
@@ -252,9 +256,14 @@ public class CounterHandler {
                 Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
 
                 if (Boolean.TRUE.equals(fromEarliest)) {
-                    metricsService.findMetric(metricId).first().map((metric) -> {
+                    observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
+                        long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
+                                ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
+                                : metricsService.getDefaultTTL() * 1000L;
+
                         long now = System.currentTimeMillis();
-                        long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+                        long earliest = now - dataRetention;
+
                         return new TimeRange(earliest, now);
                     });
                 }

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -283,15 +283,15 @@ public class CounterHandler {
             observableConfig = Observable.just(bucketConfig);
         }
 
-        final Percentiles localPercentiles = percentiles != null ? percentiles
+        final Percentiles lPercentiles = percentiles != null ? percentiles
                 : new Percentiles(Collections.<Double> emptyList());
 
         try {
             return observableConfig
-                    .flatMap((localBucketConfig) -> metricsService.findCounterStats(metricId,
-                            localBucketConfig.getTimeRange().getStart(),
-                            localBucketConfig.getTimeRange().getEnd(),
-                            localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+                    .flatMap((config) -> metricsService.findCounterStats(metricId,
+                            config.getTimeRange().getStart(),
+                            config.getTimeRange().getEnd(),
+                            config.getBuckets(), lPercentiles.getPercentiles()))
                     .flatMap(Observable::from)
                     .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
                     .toList()

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -255,10 +255,7 @@ public class GaugeHandler {
             }
 
             observableConfig = metricsService.findMetric(metricId).map((metric) -> {
-                long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
-                        ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
-                        : metricsService.getDefaultTTL() * 1000L;
-
+                long dataRetention = metric.getDataRetention() * 24 * 60 * 60 * 1000L;
                 long now = System.currentTimeMillis();
                 long earliest = now - dataRetention;
 

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -285,15 +285,15 @@ public class GaugeHandler {
             observableConfig = Observable.just(bucketConfig);
         }
 
-        final Percentiles localPercentiles = percentiles != null ? percentiles
+        final Percentiles lPercentiles = percentiles != null ? percentiles
                 : new Percentiles(Collections.<Double> emptyList());
 
         try {
             return observableConfig
-                    .flatMap((localBucketConfig) -> metricsService.findGaugeStats(metricId,
-                            localBucketConfig.getTimeRange().getStart(),
-                            localBucketConfig.getTimeRange().getEnd(),
-                            localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+                    .flatMap((config) -> metricsService.findGaugeStats(metricId,
+                            config.getTimeRange().getStart(),
+                            config.getTimeRange().getEnd(),
+                            config.getBuckets(), lPercentiles.getPercentiles()))
                     .flatMap(Observable::from)
                     .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
                     .toList()

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -254,7 +254,7 @@ public class GaugeHandler {
                 return badRequest(new ApiError("fromEarliest can only be used with bucketed results"));
             }
 
-            observableConfig = metricsService.findMetric(metricId).first().map((metric) -> {
+            observableConfig = metricsService.findMetric(metricId).map((metric) -> {
                 long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
                         ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
                         : metricsService.getDefaultTTL() * 1000L;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -345,14 +345,14 @@ public class CounterHandler {
             observableConfig = Observable.just(bucketConfig);
         }
 
-        final Percentiles localPercentiles = percentiles != null ? percentiles
+        final Percentiles lPercentiles = percentiles != null ? percentiles
                 : new Percentiles(Collections.<Double> emptyList());
 
         observableConfig
-                .flatMap((localBucketConfig) -> metricsService.findCounterStats(metricId,
-                        localBucketConfig.getTimeRange().getStart(),
-                        localBucketConfig.getTimeRange().getEnd(),
-                        localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+                .flatMap((config) -> metricsService.findCounterStats(metricId,
+                        config.getTimeRange().getStart(),
+                        config.getTimeRange().getEnd(),
+                        config.getBuckets(), lPercentiles.getPercentiles()))
                 .flatMap(Observable::from)
                 .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
                 .toList()

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -312,7 +312,7 @@ public class CounterHandler {
                 return;
             }
 
-            observableConfig = metricsService.findMetric(metricId).first().map((metric) -> {
+            observableConfig = metricsService.findMetric(metricId).map((metric) -> {
                 long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
                         ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
                         : metricsService.getDefaultTTL() * 1000L;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -313,10 +313,7 @@ public class CounterHandler {
             }
 
             observableConfig = metricsService.findMetric(metricId).map((metric) -> {
-                long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
-                        ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
-                        : metricsService.getDefaultTTL() * 1000L;
-
+                long dataRetention = metric.getDataRetention() * 24 * 60 * 60 * 1000L;
                 long now = System.currentTimeMillis();
                 long earliest = now - dataRetention;
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -342,14 +342,14 @@ public class GaugeHandler {
             observableConfig = Observable.just(bucketConfig);
         }
 
-        final Percentiles localPercentiles = percentiles != null ? percentiles
+        final Percentiles lPercentiles = percentiles != null ? percentiles
                 : new Percentiles(Collections.<Double> emptyList());
 
         observableConfig
-                .flatMap((localBucketConfig) -> metricsService.findGaugeStats(metricId,
-                        localBucketConfig.getTimeRange().getStart(),
-                        localBucketConfig.getTimeRange().getEnd(),
-                        localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+                .flatMap((config) -> metricsService.findGaugeStats(metricId,
+                        config.getTimeRange().getStart(),
+                        config.getTimeRange().getEnd(),
+                        config.getBuckets(), lPercentiles.getPercentiles()))
                 .flatMap(Observable::from)
                 .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
                 .toList()

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -309,7 +309,7 @@ public class GaugeHandler {
                 return;
             }
 
-            observableConfig = metricsService.findMetric(metricId).first().map((metric) -> {
+            observableConfig = metricsService.findMetric(metricId).map((metric) -> {
                 long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
                         ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
                         : metricsService.getDefaultTTL() * 1000L;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -279,6 +279,12 @@ public class GaugeHandler {
             @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
             @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
             @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles) {
+
+        if (Boolean.TRUE.equals(fromEarliest) && (start != null || end != null)) {
+            asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
+            return;
+        }
+
         TimeRange timeRange = new TimeRange(start, end);
         if (!timeRange.isValid()) {
             asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
@@ -310,9 +316,14 @@ public class GaugeHandler {
             Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
 
             if (Boolean.TRUE.equals(fromEarliest)) {
-                metricsService.findMetric(metricId).first().map((metric) -> {
+                observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
+                    long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
+                            ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
+                            : metricsService.getDefaultTTL() * 1000L;
+
                     long now = System.currentTimeMillis();
-                    long earliest = now - metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+                    long earliest = now - dataRetention;
+
                     return new TimeRange(earliest, now);
                 });
             }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -310,10 +310,7 @@ public class GaugeHandler {
             }
 
             observableConfig = metricsService.findMetric(metricId).map((metric) -> {
-                long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
-                        ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
-                        : metricsService.getDefaultTTL() * 1000L;
-
+                long dataRetention = metric.getDataRetention() * 24 * 60 * 60 * 1000L;
                 long now = System.currentTimeMillis();
                 long earliest = now - dataRetention;
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -54,12 +54,12 @@ import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.service.Functions;
 import org.hawkular.metrics.core.service.MetricsService;
 import org.hawkular.metrics.model.ApiError;
-import org.hawkular.metrics.model.Buckets;
 import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.NumericBucketPoint;
+import org.hawkular.metrics.model.exception.RuntimeApiError;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
 import org.hawkular.metrics.model.param.Percentiles;
@@ -280,75 +280,81 @@ public class GaugeHandler {
             @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
             @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles) {
 
-        if (Boolean.TRUE.equals(fromEarliest) && (start != null || end != null)) {
-            asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
-            return;
-        }
-
-        TimeRange timeRange = new TimeRange(start, end);
-        if (!timeRange.isValid()) {
-            asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
-            return;
-        }
-        BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
-        if (!bucketConfig.isValid()) {
-            asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
-            return;
-        }
-
-        if (bucketConfig.getBuckets() == null && Boolean.TRUE.equals(fromEarliest)) {
-            asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
-            return;
-        }
-
         MetricId<Double> metricId = new MetricId<>(tenantId, GAUGE, id);
-        Buckets buckets = bucketConfig.getBuckets();
-        if (buckets == null) {
+
+        if (bucketsCount == null && bucketDuration == null && !Boolean.TRUE.equals(fromEarliest)) {
+            TimeRange timeRange = new TimeRange(start, end);
+            if (!timeRange.isValid()) {
+                asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
+                return;
+            }
+
             metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd())
                     .toList()
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
-        } else {
-            if(percentiles == null) {
-                percentiles = new Percentiles(Collections.<Double>emptyList());
-            }
-
-            Observable<TimeRange> observableTimeRange = Observable.just(timeRange);
-
-            if (Boolean.TRUE.equals(fromEarliest)) {
-                observableTimeRange = metricsService.findMetric(metricId).first().map((metric) -> {
-                    long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
-                            ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
-                            : metricsService.getDefaultTTL() * 1000L;
-
-                    long now = System.currentTimeMillis();
-                    long earliest = now - dataRetention;
-
-                    return new TimeRange(earliest, now);
-                });
-            }
-
-            final Percentiles localPercentiles = percentiles;
-            observableTimeRange
-                    .flatMap((localTimeRange) -> metricsService.findGaugeStats(metricId, localTimeRange.getStart(),
-                            localTimeRange.getEnd(), buckets, localPercentiles.getPercentiles()))
-                    .map((list) -> {
-                        if (Boolean.TRUE.equals(fromEarliest)) {
-                            int index = 0;
-                            for (NumericBucketPoint item : list) {
-                                if (!item.isEmpty()) {
-                                    break;
-                                }
-                                index++;
-                            }
-                            return list.subList(index, list.size());
-                        }
-
-                        return list;
-                    })
-                    .map(ApiUtils::collectionToResponse)
-                    .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
+            return;
         }
+
+        Observable<BucketConfig> observableConfig = null;
+
+        if (Boolean.TRUE.equals(fromEarliest)) {
+            if (start != null || end != null) {
+                asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
+                return;
+            }
+
+            if (bucketsCount == null && bucketDuration == null) {
+                asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
+                return;
+            }
+
+            observableConfig = metricsService.findMetric(metricId).first().map((metric) -> {
+                long dataRetention = metric.getDataRetention() != null && metric.getDataRetention() != 0
+                        ? metric.getDataRetention() * 24 * 60 * 60 * 1000L
+                        : metricsService.getDefaultTTL() * 1000L;
+
+                long now = System.currentTimeMillis();
+                long earliest = now - dataRetention;
+
+                BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration,
+                        new TimeRange(earliest, now));
+
+                if (!bucketConfig.isValid()) {
+                    throw new RuntimeApiError(bucketConfig.getProblem());
+                }
+
+                return bucketConfig;
+            });
+        } else {
+            TimeRange timeRange = new TimeRange(start, end);
+            if (!timeRange.isValid()) {
+                asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
+                return;
+            }
+
+            BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
+            if (!bucketConfig.isValid()) {
+                asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
+                return;
+            }
+
+            observableConfig = Observable.just(bucketConfig);
+        }
+
+        final Percentiles localPercentiles = percentiles != null ? percentiles
+                : new Percentiles(Collections.<Double> emptyList());
+
+        observableConfig
+                .flatMap((localBucketConfig) -> metricsService.findGaugeStats(metricId,
+                        localBucketConfig.getTimeRange().getStart(),
+                        localBucketConfig.getTimeRange().getEnd(),
+                        localBucketConfig.getBuckets(), localPercentiles.getPercentiles()))
+                .flatMap(Observable::from)
+                .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+                .toList()
+                .map(ApiUtils::collectionToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
     }
 
     @GET
@@ -387,7 +393,7 @@ public class GaugeHandler {
         BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
         if (bucketConfig.isEmpty()) {
             asyncResponse.resume(badRequest(new ApiError(
-                    "Either the buckets or bucketsDuration parameter must be used")));
+                    "Either the buckets or bucketDuration parameter must be used")));
             return;
         }
         if (!bucketConfig.isValid()) {

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -273,10 +273,4 @@ public interface MetricsService {
      * @return a hot {@link Observable} emitting {@link Metric} events after data has been inserted
      */
     Observable<Metric<?>> insertedDataEvents();
-
-    /**
-     * @return default TTL for metric storage
-     */
-    int getDefaultTTL();
-
 }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -273,4 +273,10 @@ public interface MetricsService {
      * @return a hot {@link Observable} emitting {@link Metric} events after data has been inserted
      */
     Observable<Metric<?>> insertedDataEvents();
+
+    /**
+     * @return default TTL for metric storage
+     */
+    int getDefaultTTL();
+
 }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -335,8 +335,7 @@ public class MetricsServiceImpl implements MetricsService, TenantsService {
         this.dateTimeService = dateTimeService;
     }
 
-    @Override
-    public int getDefaultTTL() {
+    private int getDefaultTTL() {
         return defaultTTL;
     }
 
@@ -464,7 +463,7 @@ public class MetricsServiceImpl implements MetricsService, TenantsService {
     public <T> Observable<Metric<T>> findMetric(final MetricId<T> id) {
         return dataAccess.findMetric(id)
                 .flatMap(Observable::from)
-                .map(row -> new Metric<>(id, row.getMap(1, String.class, String.class), row.getInt(2)));
+                .compose(new MetricsIndexRowTransformer<>(id.getTenantId(), id.getType(), defaultTTL));
     }
 
     @Override
@@ -478,11 +477,11 @@ public class MetricsServiceImpl implements MetricsService, TenantsService {
                     })
                     .flatMap(type -> dataAccess.findMetricsInMetricsIndex(tenantId, type)
                             .flatMap(Observable::from)
-                            .compose(new MetricsIndexRowTransformer<>(tenantId, type)));
+                            .compose(new MetricsIndexRowTransformer<>(tenantId, type, defaultTTL)));
         }
         return dataAccess.findMetricsInMetricsIndex(tenantId, metricType)
                 .flatMap(Observable::from)
-                .compose(new MetricsIndexRowTransformer<>(tenantId, metricType));
+                .compose(new MetricsIndexRowTransformer<>(tenantId, metricType, defaultTTL));
     }
 
     @Override

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -335,6 +335,7 @@ public class MetricsServiceImpl implements MetricsService, TenantsService {
         this.dateTimeService = dateTimeService;
     }
 
+    @Override
     public int getDefaultTTL() {
         return defaultTTL;
     }

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/Metric.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,6 +89,10 @@ public class Metric<T> {
         this(id, Collections.emptyMap(), null, Collections.emptyList());
     }
 
+    public Metric(MetricId<T> id, Integer dataRetention) {
+        this(id, Collections.emptyMap(), dataRetention, Collections.emptyList());
+    }
+
     public Metric(MetricId<T> id, Map<String, String> tags, Integer dataRetention) {
         this(id, tags, dataRetention, Collections.emptyList());
     }
@@ -97,20 +101,17 @@ public class Metric<T> {
         this(id, Collections.emptyMap(), null, dataPoints);
     }
 
+    public Metric(MetricId<T> id, List<DataPoint<T>> dataPoints, Integer dataRetention) {
+        this(id, Collections.emptyMap(), dataRetention, dataPoints);
+    }
+
     public Metric(MetricId<T> id, Map<String, String> tags, Integer dataRetention, List<DataPoint<T>> dataPoints) {
         checkArgument(id != null, "id is null");
         checkArgument(tags != null, "tags is null");
         checkArgument(dataPoints != null, "dataPoints is null");
         this.id = id;
         this.tags = unmodifiableMap(tags);
-        // If the data_retention column is not set, the driver returns zero instead of null.
-        // We are (at least for now) using null to indicate that the metric does not have
-        // the data retention set.
-        if (dataRetention == null || dataRetention == 0) {
-            this.dataRetention = null;
-        } else {
-            this.dataRetention = dataRetention;
-        }
+        this.dataRetention = dataRetention;
         this.dataPoints = unmodifiableList(dataPoints);
     }
 

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/exception/RuntimeApiError.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/exception/RuntimeApiError.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.model.exception;
+
+/**
+ * @author John Sanda
+ */
+@SuppressWarnings("serial")
+public class RuntimeApiError extends RuntimeException {
+
+    public RuntimeApiError() {
+        super();
+    }
+
+    public RuntimeApiError(String message) {
+        super(message);
+    }
+
+    public RuntimeApiError(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RuntimeApiError(Throwable cause) {
+        super(cause);
+    }
+
+    protected RuntimeApiError(String message, Throwable cause,
+                               boolean enableSuppression,
+                               boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/param/BucketConfig.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/param/BucketConfig.java
@@ -28,11 +28,14 @@ import org.hawkular.metrics.model.Buckets;
  */
 public class BucketConfig {
     private final Buckets buckets;
+    private final TimeRange timeRange;
     private final boolean valid;
     private final String problem;
 
     public BucketConfig(Integer bucketsCount, Duration bucketDuration, TimeRange timeRange) {
         checkArgument(timeRange != null, "Time range is null");
+        this.timeRange = timeRange;
+
         if (!timeRange.isValid()) {
             throw new IllegalArgumentException("Invalid time range: " + timeRange.getProblem());
         }
@@ -69,6 +72,10 @@ public class BucketConfig {
 
     public Buckets getBuckets() {
         return buckets;
+    }
+
+    public TimeRange getTimeRange() {
+        return timeRange;
     }
 
     public boolean isValid() {

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -138,8 +138,8 @@ class CORSITest extends RESTTest {
     assertEquals(200, response.status)
     assertEquals(
         [
-            [tenantId: tenantId, id: "m11", type: "gauge"],
-            [tenantId: tenantId, id: "m12", type: "gauge"],
+            [dataRetention: 7, tenantId: tenantId, id: "m11", type: "gauge"],
+            [dataRetention: 7, tenantId: tenantId, id: "m12", type: "gauge"],
         ],
         response.data
     )
@@ -179,8 +179,8 @@ class CORSITest extends RESTTest {
     assertEquals(200, response.status)
     assertEquals(
         [
-            [tenantId: tenantId, id: "m11", type: "gauge"],
-            [tenantId: tenantId, id: "m12", type: "gauge"],
+            [dataRetention: 7, tenantId: tenantId, id: "m11", type: "gauge"],
+            [dataRetention: 7, tenantId: tenantId, id: "m12", type: "gauge"],
         ],
         response.data
     )

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -415,8 +415,8 @@ class CassandraBackendITest extends RESTTest {
     assertEquals(200, response.status)
     assertEquals(
         [
-            [tenantId: tenantId, id: 'm11', type: 'gauge'],
-            [tenantId: tenantId, id: 'm12', type: 'gauge'],
+            [dataRetention: 7, tenantId: tenantId, id: 'm11', type: 'gauge'],
+            [dataRetention: 7, tenantId: tenantId, id: 'm12', type: 'gauge'],
             [tenantId: tenantId, id: 'm13', tags: [a1: 'A', B1: 'B'], dataRetention: 32, type: 'gauge']
         ],
         response.data
@@ -455,8 +455,8 @@ class CassandraBackendITest extends RESTTest {
     assertEquals(200, response.status)
     assertEquals(
         [
-            [tenantId: tenantId, id: 'm14', type: 'availability'],
-            [tenantId: tenantId, id: 'm15', type: 'availability'],
+            [dataRetention: 7, tenantId: tenantId, id: 'm14', type: 'availability'],
+            [dataRetention: 7, tenantId: tenantId, id: 'm15', type: 'availability'],
             [tenantId: tenantId, id: 'm16', tags: [a10: '10', a11: '11'], dataRetention: 7, type: 'availability']
         ],
         response.data
@@ -497,6 +497,7 @@ class CassandraBackendITest extends RESTTest {
     response = hawkularMetrics.get(path: "gauges/Empty1", headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals([
+            dataRetention: 7,
             tenantId: tenantId,
             id: 'Empty1',
             type: 'gauge'

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -1267,9 +1267,16 @@ Actual:   ${response.data}
     assertEquals(null, response.data)
 
     badGet(path: "counters/$metric/data",
-      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true"], headers: [(tenantHeaderName): tenantId]) {
+      query: [fromEarliest: "true"], headers: [(tenantHeaderName): tenantId]) {
       exception ->
         // From earliest works only with buckets
+        assertEquals(400, exception.response.status)
+    }
+
+    badGet(path: "counters/$metric/data",
+      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true", buckets: "1h"], headers: [(tenantHeaderName): tenantId]) {
+      exception ->
+        // From earliest works only without start & end
         assertEquals(400, exception.response.status)
     }
   }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -1261,8 +1261,11 @@ Actual:   ${response.data}
     assertEquals(201, response.status)
 
     response = hawkularMetrics.get(path: "counters/$metric/data",
-        query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])
+      query: [start: 1, end: now().millis, bucketDuration: "1000d"], headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
 
+    response = hawkularMetrics.get(path: "counters/$metric/data",
+        query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])
     assertEquals(204, response.status)
     assertEquals(null, response.data)
 
@@ -1274,7 +1277,7 @@ Actual:   ${response.data}
     }
 
     badGet(path: "counters/$metric/data",
-      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true", buckets: "1h"], headers: [(tenantHeaderName): tenantId]) {
+      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId]) {
       exception ->
         // From earliest works only without start & end
         assertEquals(400, exception.response.status)

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -1264,6 +1264,12 @@ Actual:   ${response.data}
       query: [start: 1, end: now().millis, bucketDuration: "1000d"], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
+    badGet(path: "counters/$metric/data",
+        query: [fromEarliest: "true", bucketDuration: "a"], headers: [(tenantHeaderName): tenantId]) {
+        exception ->
+          assertEquals(400, exception.response.status)
+    }
+
     response = hawkularMetrics.get(path: "counters/$metric/data",
         query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])
     assertEquals(204, response.status)

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,7 +95,7 @@ class CountersITest extends RESTTest {
     response = hawkularMetrics.get(path: "counters/$id", headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    def expectedData = [tenantId: tenantId, id: id, type: 'counter']
+    def expectedData = [tenantId: tenantId, id: id, type: 'counter', dataRetention: 7]
     assertEquals(expectedData, response.data)
   }
 
@@ -176,7 +176,8 @@ class CountersITest extends RESTTest {
         [
             tenantId: tenantId,
             id: counter1,
-            type: 'counter'
+            type: 'counter',
+            dataRetention: 7
         ],
         [
             tenantId: tenantId,
@@ -185,7 +186,8 @@ class CountersITest extends RESTTest {
                 tag1: 'one',
                 tag2: 'two'
             ],
-            type: 'counter'
+            type: 'counter',
+            dataRetention: 7
         ]
     ]
     assertEquals(expectedData, response.data)

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
@@ -720,8 +720,11 @@ class GaugeMetricStatisticsITest extends RESTTest {
     assertEquals(201, response.status)
 
     response = hawkularMetrics.get(path: "gauges/$metric/data",
-        query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])
+      query: [start: 1, end: now().millis, bucketDuration: "1000d"], headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
 
+    response = hawkularMetrics.get(path: "gauges/$metric/data",
+        query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])
     assertEquals(204, response.status)
     assertEquals(null, response.data)
 
@@ -733,7 +736,7 @@ class GaugeMetricStatisticsITest extends RESTTest {
     }
 
     badGet(path: "gauges/$metric/data",
-      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true", buckets: "1h"], headers: [(tenantHeaderName): tenantId]) {
+      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId]) {
       exception ->
         // From earliest works only without start & end
         assertEquals(400, exception.response.status)

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
@@ -27,8 +27,10 @@ import org.junit.Test
 import static java.lang.Double.NaN
 import static org.joda.time.DateTime.now
 import static org.joda.time.Seconds.seconds
+import static org.junit.Assert.assertArrayEquals
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertTrue
+
 /**
  * @author Thomas Segismont
  */
@@ -72,6 +74,13 @@ class GaugeMetricStatisticsITest extends RESTTest {
         query: [buckets: 1, bucketDuration: "1d"], headers: [(tenantHeaderName): tenantId]) { exception ->
       // Both buckets and bucketDuration parameters provided
       assertEquals(400, exception.response.status)
+    }
+
+    badGet(path: "gauges/$metric/data",
+        query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true"], headers: [(tenantHeaderName): tenantId]) {
+        exception ->
+          // From earliest works only with buckets
+          assertEquals(400, exception.response.status)
     }
   }
 
@@ -664,6 +673,64 @@ class GaugeMetricStatisticsITest extends RESTTest {
         headers: [(tenantHeaderName): tenantId]
     )
     assertEquals(400, response.status)
+  }
+
+  @Test
+  void fromEarliestWithData() {
+    String tenantId = nextTenantId()
+    String metric = "testStats"
+
+    def response = hawkularMetrics.post(path: 'gauges', body: [
+        id  : '$metric',
+        tags: ['type': 'counter_cpu_usage', 'host': 'server1', 'env': 'stage']
+    ], headers: [(tenantHeaderName): tenantId])
+    assertEquals(201, response.status)
+
+    response = hawkularMetrics.post(path: "gauges/$metric/data", body: [
+        [timestamp: new DateTimeService().currentHour().minusHours(2).millis, value: 2]
+    ], headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+
+    response = hawkularMetrics.post(path: "gauges/$metric/data", body: [
+        [timestamp: new DateTimeService().currentHour().minusHours(3).millis, value: 3]
+    ], headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+
+    response = hawkularMetrics.get(path: "gauges/$metric/data",
+        query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])
+
+    assertEquals(200, response.status)
+    assertEquals(4, response.data.size)
+
+    def expectedArray = [new BigDecimal(3), new BigDecimal(2), 'NaN', 'NaN'].toArray()
+    assertArrayEquals(expectedArray, response.data.min.toArray())
+    assertArrayEquals(expectedArray, response.data.max.toArray())
+    assertArrayEquals(expectedArray, response.data.avg.toArray())
+  }
+
+  @Test
+  void fromEarliestWithoutDataAndBad() {
+    String tenantId = nextTenantId()
+    String metric = "testStats"
+
+    def response = hawkularMetrics.post(path: 'gauges', body: [
+        id  : '$metric',
+        tags: ['type': 'counter_cpu_usage', 'host': 'server1', 'env': 'stage']
+    ], headers: [(tenantHeaderName): tenantId])
+    assertEquals(201, response.status)
+
+    response = hawkularMetrics.get(path: "gauges/$metric/data",
+        query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])
+
+    assertEquals(204, response.status)
+    assertEquals(null, response.data)
+
+    badGet(path: "gauges/$metric/data",
+      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true"], headers: [(tenantHeaderName): tenantId]) {
+      exception ->
+        // From earliest works only with buckets
+        assertEquals(400, exception.response.status)
+    }
   }
 
   private static List<Double> createSample(int sampleSize) {

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
@@ -726,9 +726,16 @@ class GaugeMetricStatisticsITest extends RESTTest {
     assertEquals(null, response.data)
 
     badGet(path: "gauges/$metric/data",
-      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true"], headers: [(tenantHeaderName): tenantId]) {
+      query: [fromEarliest: "true"], headers: [(tenantHeaderName): tenantId]) {
       exception ->
         // From earliest works only with buckets
+        assertEquals(400, exception.response.status)
+    }
+
+    badGet(path: "gauges/$metric/data",
+      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true", buckets: "1h"], headers: [(tenantHeaderName): tenantId]) {
+      exception ->
+        // From earliest works only without start & end
         assertEquals(400, exception.response.status)
     }
   }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
@@ -75,13 +75,6 @@ class GaugeMetricStatisticsITest extends RESTTest {
       // Both buckets and bucketDuration parameters provided
       assertEquals(400, exception.response.status)
     }
-
-    badGet(path: "gauges/$metric/data",
-        query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true"], headers: [(tenantHeaderName): tenantId]) {
-        exception ->
-          // From earliest works only with buckets
-          assertEquals(400, exception.response.status)
-    }
   }
 
   @Test
@@ -722,6 +715,12 @@ class GaugeMetricStatisticsITest extends RESTTest {
     response = hawkularMetrics.get(path: "gauges/$metric/data",
       query: [start: 1, end: now().millis, bucketDuration: "1000d"], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
+
+    badGet(path: "gauges/$metric/data",
+        query: [fromEarliest: "true", bucketDuration: "a"], headers: [(tenantHeaderName): tenantId]) {
+        exception ->
+          assertEquals(400, exception.response.status)
+    }
 
     response = hawkularMetrics.get(path: "gauges/$metric/data",
         query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,6 +88,7 @@ class TagsITest extends RESTTest {
           tenantId: tenantId,
           id  : 'N1',
           tags: ['  a  1   ': '   A', 'bsq   d1': 'B   '],
+          dataRetention: 7,
           type: it.type
       ], response.data)
 
@@ -143,13 +144,15 @@ class TagsITest extends RESTTest {
       // Create metric
       def response = hawkularMetrics.post(path: it.path, body: [
         id  : 'N1',
-        tags: ['a1': 'A', 'd1': 'B']
+        tags: ['a1': 'A', 'd1': 'B'],
+        dataRetention: 7
       ], headers: [(tenantHeaderName): tenantId])
       assertEquals(201, response.status)
 
       response = hawkularMetrics.post(path: it.path, body: [
         id  : 'N2',
-        tags: ['a1': 'A2']
+        tags: ['a1': 'A2'],
+        dataRetention: 7
       ], headers: [(tenantHeaderName): tenantId])
       assertEquals(201, response.status)
 
@@ -167,12 +170,14 @@ class TagsITest extends RESTTest {
         assertTrue(lresponse.data instanceof List)
         assertEquals(2, lresponse.data.size())
         assertTrue((lresponse.data ?: []).contains([
+          dataRetention: 7,
           tenantId: tenantId,
           id      : 'N1',
           tags    : ['a1': 'A', 'd1': 'B'],
           type: it.type
         ]))
         assertTrue((lresponse.data ?: []).contains([
+          dataRetention: 7,
           tenantId: tenantId,
           id      : 'N2',
           tags    : ['a1': 'A2'],
@@ -195,6 +200,7 @@ class TagsITest extends RESTTest {
           tenantId: tenantId,
           id      : 'N1',
           tags    : ['a1': 'A', 'd1': 'B'],
+          dataRetention: 7,
           type: it.type
         ]], lresponse.data)
       }


### PR DESCRIPTION
…earliest date data is available, starting with the first non-empty bucket. In case all buckets are empty, return nothing.