### PR TITLE
[HWKMETRICS-333] Add support for encoded tag queries

### DIFF
--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagsConverter.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagsConverter.java
@@ -20,6 +20,9 @@ import static java.util.stream.Collectors.joining;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,7 +64,12 @@ public class TagsConverter implements StringConverter<Tags> {
             }
             int colonIndex = token.indexOf(Tags.TAG_DELIMITER);
             checkArgument(hasExpectedForm(token, colonIndex), "Invalid tags: %s", value);
-            tags.put(token.substring(0, colonIndex), token.substring(colonIndex + 1));
+            try {
+                String tagValue = URLDecoder.decode(token.substring(colonIndex + 1), StandardCharsets.UTF_8.name());
+                tags.put(token.substring(0, colonIndex), tagValue);
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
             previousToken = token;
         }
         return new Tags(tags);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagsConverter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagsConverter.java
@@ -20,6 +20,9 @@ import static java.util.stream.Collectors.joining;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,7 +63,12 @@ public class TagsConverter implements ParamConverter<Tags> {
             }
             int colonIndex = token.indexOf(Tags.TAG_DELIMITER);
             checkArgument(hasExpectedForm(token, colonIndex), "Invalid tags: %s", value);
-            tags.put(token.substring(0, colonIndex), token.substring(colonIndex + 1));
+            try {
+                String tagValue = URLDecoder.decode(token.substring(colonIndex + 1), StandardCharsets.UTF_8.name());
+                tags.put(token.substring(0, colonIndex), tagValue);
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
             previousToken = token;
         }
         return new Tags(tags);

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/param/Tags.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/param/Tags.java
@@ -53,7 +53,7 @@ public class Tags {
     }
 
     private static boolean isValid(String s) {
-        return s != null && !s.trim().isEmpty() && !s.contains(LIST_DELIMITER) && !s.contains(TAG_DELIMITER);
+        return s != null && !s.trim().isEmpty();
     }
 
     /**


### PR DESCRIPTION
Allows tags with ":" "/" and equal to be queried as long as they're encoded correctly in the URL. @tsegismont You had prevented this in the past in the Tags, any particular reason? I think it would get caught in the TagsConverter already as the splitting would fail / give empty value.