### PR TITLE
[HWKMETRICS-332] Fix the path for multi-counter rate queries

### DIFF
--- a/api/diff.txt
+++ b/api/diff.txt
@@ -2204,15 +2204,15 @@ diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/o
 ---
 >     @Override public String toString(Percentiles percentiles) {
 diff -r '--exclude-from=api/diff-excludes' api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagsConverter.java api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagsConverter.java
-28c28
+31c31
 < import javax.ws.rs.ext.ParamConverter;
 ---
 > import javax.ws.rs.ext.Provider;
-31c31
+34c34
 < 
 ---
 > import org.jboss.resteasy.spi.StringConverter;
-39c39,40
+42c42,43
 < public class TagsConverter implements ParamConverter<Tags> {
 ---
 > @Provider

--- a/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs-1.1/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -400,7 +400,7 @@ public class CounterHandler {
     }
 
     @GET
-    @Path("/data/rate")
+    @Path("/rate")
     public Response findCounterRateDataStats(
             @QueryParam("start") final Long start,
             @QueryParam("end") final Long end,

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -480,7 +480,7 @@ public class CounterHandler {
     }
 
     @GET
-    @Path("/data/rate")
+    @Path("/rate")
     @ApiOperation(value = "Fetches data points from one or more metrics that are determined using either a tags " +
             "filter or a list of metric names. The time range between start and end is divided into buckets of " +
             "equal size (i.e., duration) using either the buckets or bucketDuration parameter. Functions are " +

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -1018,7 +1018,7 @@ Actual:   ${response.data}
 
     //Tests start here
     response = hawkularMetrics.get(
-        path: 'counters/data/rate',
+        path: 'counters/rate',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1043,7 +1043,7 @@ Actual:   ${response.data}
     assertTrue("Expected the [median] property to be set", actualCounterRateBucketByTag.median != null)
 
     response = hawkularMetrics.get(
-        path: 'counters/data/rate',
+        path: 'counters/rate',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1167,7 +1167,7 @@ Actual:   ${response.data}
 
     //Tests start here
     response = hawkularMetrics.get(
-        path: 'counters/data/rate',
+        path: 'counters/rate',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1192,7 +1192,7 @@ Actual:   ${response.data}
     assertTrue("Expected the [median] property to be set", actualCounterRateBucketByTag.median != null)
 
     response = hawkularMetrics.get(
-        path: 'counters/data/rate',
+        path: 'counters/rate',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,


### PR DESCRIPTION
/counters/rate path is now aligned with the path for rate queries with specified metric id.