### PR TITLE
do not hard code dependency versions in arquillian tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 install:
 - mvn -version -B
 script:
-- mvn verify -Dtest.logging.console.level=INFO -Dwildfly.logging.console.level=INFO -Djboss-as.logging.console.level=INFO -Dterminal-event.timeout=25 -B
+- mvn verify -Dtest.logging.console.level=INFO -Dwildfly.logging.console.level=INFO -Djboss-as.logging.console.level=INFO -Dterminal-event.timeout=25 -Dtravis -B
 after_failure: bash .travis.diagnose.sh
 after_success:
 - PROJECT_VERSION=`mvn --batch-mode org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version | grep -v '\['`

--- a/bus/pom.xml
+++ b/bus/pom.xml
@@ -71,16 +71,6 @@
       <artifactId>hawkular-bus-common</artifactId>
       <version>${version.org.hawkular.bus}</version>
       <scope>provided</scope>
-      <!--<exclusions>-->
-        <!--&lt;!&ndash;-->
-          <!--jboss-logging is getting pulled in transitively by commons bus which does not declare it with provided-->
-          <!--scope.-->
-        <!--&ndash;&gt;-->
-        <!--<exclusion>-->
-          <!--<groupId>org.jboss.logging</groupId>-->
-          <!--<artifactId>jboss-logging</artifactId>-->
-        <!--</exclusion>-->
-      <!--</exclusions>-->
     </dependency>
 
     <dependency>
@@ -194,10 +184,43 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <org.apache.maven.user-settings>nonExistentSetting.xml</org.apache.maven.user-settings>
+            <hawkular.metrics.version>${project.version}</hawkular.metrics.version>
+            <hawkular.bus.version>${version.org.hawkular.bus}</hawkular.bus.version>
+            <rxjava.version>${version.io.reactivex.rxjava}</rxjava.version>
           </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>travis-build</id>
+      <activation>
+        <property>
+          <name>travis</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <!--
+                  This needs to be set for travis builds otherwise Shrinkwrap, which is used in Arquillian tests, is
+                  not able to resolve Maven dependencies. See http://goo.gl/cVf6uI for details.
+                -->
+                <org.apache.maven.user-settings>nonExistentSetting.xml</org.apache.maven.user-settings>
+                <hawkular.metrics.version>${project.version}</hawkular.metrics.version>
+                <hawkular.bus.version>${version.org.hawkular.bus}</hawkular.bus.version>
+                <rxjava.version>${version.io.reactivex.rxjava}</rxjava.version>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/bus/pom.xml
+++ b/bus/pom.xml
@@ -213,9 +213,9 @@
                   not able to resolve Maven dependencies. See http://goo.gl/cVf6uI for details.
                 -->
                 <org.apache.maven.user-settings>nonExistentSetting.xml</org.apache.maven.user-settings>
-                <hawkular.metrics.version>${project.version}</hawkular.metrics.version>
-                <hawkular.bus.version>${version.org.hawkular.bus}</hawkular.bus.version>
-                <rxjava.version>${version.io.reactivex.rxjava}</rxjava.version>
+                <version.org.hawkular.metrics>${project.version}</version.org.hawkular.metrics>
+                <version.org.hawkular.bus>${version.org.hawkular.bus}</version.org.hawkular.bus>
+                <version.io.reactivex.rxjava>${version.io.reactivex.rxjava}</version.io.reactivex.rxjava>
               </systemPropertyVariables>
             </configuration>
           </plugin>

--- a/bus/src/test/java/org/hawkular/bus/PublishDataPointsTest.java
+++ b/bus/src/test/java/org/hawkular/bus/PublishDataPointsTest.java
@@ -78,10 +78,10 @@ public class PublishDataPointsTest {
     public static WebArchive createDeployment() {
         MavenResolverSystem mavenResolver = Resolvers.use(MavenResolverSystem.class);
         List<String> deps = asList(
-                "org.hawkular.metrics:hawkular-metrics-model:" + System.getProperty("hawkular.metrics.version"),
-                "org.hawkular.metrics:hawkular-metrics-api-util:" + System.getProperty("hawkular.metrics.version"),
-                "org.hawkular.commons:hawkular-bus-common:" + System.getProperty("hawkular.bus.version"),
-                "io.reactivex:rxjava:" + System.getProperty("rxjava.version")
+                "org.hawkular.metrics:hawkular-metrics-model:" + System.getProperty("version.org.hawkular.metrics"),
+                "org.hawkular.metrics:hawkular-metrics-api-util:" + System.getProperty("version.org.hawkular.metrics"),
+                "org.hawkular.commons:hawkular-bus-common:" + System.getProperty("version.org.hawkular.bus"),
+                "io.reactivex:rxjava:" + System.getProperty("version.io.reactivex.rxjava")
         );
 
         Collection<JavaArchive> dependencies = new HashSet<JavaArchive>();
@@ -93,8 +93,6 @@ public class PublishDataPointsTest {
                 .addAsLibraries(dependencies)
                 .setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: com.google.guava\n"));
 
-//        ZipExporter exporter = new ZipExporterImpl(archive);
-//        exporter.exportTo(new File("target", "test-archive.war"));
         return archive;
     }
 

--- a/bus/src/test/java/org/hawkular/bus/PublishDataPointsTest.java
+++ b/bus/src/test/java/org/hawkular/bus/PublishDataPointsTest.java
@@ -76,13 +76,12 @@ public class PublishDataPointsTest {
 
     @Deployment
     public static WebArchive createDeployment() {
-        String projectVersion = "0.12.0-SNAPSHOT";
         MavenResolverSystem mavenResolver = Resolvers.use(MavenResolverSystem.class);
         List<String> deps = asList(
-                "org.hawkular.metrics:hawkular-metrics-model:" + projectVersion,
-                "org.hawkular.metrics:hawkular-metrics-api-util:" + projectVersion,
-                "org.hawkular.commons:hawkular-bus-common:0.3.2.Final",
-                "io.reactivex:rxjava:1.0.13"
+                "org.hawkular.metrics:hawkular-metrics-model:" + System.getProperty("hawkular.metrics.version"),
+                "org.hawkular.metrics:hawkular-metrics-api-util:" + System.getProperty("hawkular.metrics.version"),
+                "org.hawkular.commons:hawkular-bus-common:" + System.getProperty("hawkular.bus.version"),
+                "io.reactivex:rxjava:" + System.getProperty("rxjava.version")
         );
 
         Collection<JavaArchive> dependencies = new HashSet<JavaArchive>();


### PR DESCRIPTION
This commit also modifies the travis configuration slightly by setting the
travis system property in order to activate a profile for travis builds.
See http://goo.gl/cVf6uI for details.