### PR TITLE
remove wildfly bom from parent pom

### DIFF
--- a/bus/pom.xml
+++ b/bus/pom.xml
@@ -42,6 +42,14 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-javaee7</artifactId>
+        <version>${version.org.wildfly}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.arquillian</groupId>
         <artifactId>arquillian-bom</artifactId>
         <version>1.1.10.Final</version>

--- a/hawkular-component/pom.xml
+++ b/hawkular-component/pom.xml
@@ -41,6 +41,18 @@
     <cassandra.keyspace>hawkular_metrics_component_integration_tests</cassandra.keyspace>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-javaee7</artifactId>
+        <version>${version.org.wildfly}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.hawkular.metrics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -136,14 +136,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.wildfly.bom</groupId>
-        <artifactId>wildfly-javaee7</artifactId>
-        <version>${version.org.wildfly}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
         <version>${version.javax.enterprise.cdi-api}</version>


### PR DESCRIPTION
Based on prior discussions (which I had forgotten about) we agreed to keep the
wildfly bom out of the parent pom. Putting it in the parent pom forces artifact
versions for all sub-modules, including those not meant to run on WildFly. In
the past this has broken the build.