### PR TITLE
Don't build the rest-tests tests JAR

### DIFF
--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -84,17 +84,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skipTests>true</skipTests>


### PR DESCRIPTION
It's no longer needed to build the rest-tests tests JAR (it used to be useful to run the suite against a JAX-RS 1.1 server)