### PR TITLE
Some filters should be pre-matching filters

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/CorsRequestFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/CorsRequestFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,8 @@ package org.hawkular.metrics.api.jaxrs.filter;
 
 import java.io.IOException;
 
+import javax.annotation.Priority;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
@@ -32,6 +34,7 @@ import org.hawkular.metrics.api.jaxrs.util.Headers;
  */
 @Provider
 @PreMatching
+@Priority(0)
 public class CorsRequestFilter implements ContainerRequestFilter {
 
     @Override
@@ -42,7 +45,7 @@ public class CorsRequestFilter implements ContainerRequestFilter {
         }
 
         //It is a CORS pre-flight request, there is no route for it, just return 200
-        if (requestContext.getRequest().getMethod().equalsIgnoreCase("OPTIONS")) {
+        if (requestContext.getMethod().equalsIgnoreCase(HttpMethod.OPTIONS)) {
             requestContext.abortWith(Response.status(Response.Status.OK).build());
         }
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/MetricsServiceStateFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/MetricsServiceStateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ import java.io.IOException;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
@@ -37,6 +38,7 @@ import org.hawkular.metrics.model.ApiError;
  * @author Matt Wringe
  */
 @Provider
+@PreMatching
 public class MetricsServiceStateFilter implements ContainerRequestFilter {
 
     private static final String STARTING = "Service unavailable while initializing.";

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/TenantFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/TenantFilter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
@@ -35,6 +36,7 @@ import org.hawkular.metrics.model.ApiError;
  * @author Stefan Negrea
  */
 @Provider
+@PreMatching
 public class TenantFilter implements ContainerRequestFilter {
     public static final String TENANT_HEADER_NAME = "Hawkular-Tenant";
 

--- a/hawkular-component/src/main/java/org/hawkular/metrics/security/PersonaFilter.java
+++ b/hawkular-component/src/main/java/org/hawkular/metrics/security/PersonaFilter.java
@@ -25,6 +25,7 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
@@ -42,6 +43,7 @@ import org.jboss.logging.Logger;
  * @author jsanda
  */
 @Provider
+@PreMatching
 public class PersonaFilter implements ContainerRequestFilter {
 
     private final Logger log = Logger.getLogger(PersonaFilter.class);


### PR DESCRIPTION
Some filters should be pre-matching filters: they should be applied very early in the request processing pipeline