### PR TITLE
HWKMETRICS-343 Grafana should be able to connect to a Metrics server …

### DIFF
--- a/hawkular-component/pom.xml
+++ b/hawkular-component/pom.xml
@@ -68,14 +68,6 @@
       <artifactId>hawkular-accounts-api</artifactId>
       <version>${version.org.hawkular.accounts}</version>
     </dependency>
-    <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-processor</artifactId>
-    </dependency>
     <!-- Overlay -->
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -84,6 +76,7 @@
       <type>war</type>
       <scope>provided</scope>
     </dependency>
+    <!-- Provided by container -->
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
@@ -94,7 +87,12 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>io.undertow</groupId>
+      <artifactId>undertow-servlet</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Test dependencies -->
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
@@ -121,6 +119,9 @@
               <artifactId>hawkular-metrics-api-jaxrs</artifactId>
               <excludes>
                 <exclude>**/TenantFilter.class</exclude>
+                <exclude>**/CorsRequestFilter.class</exclude>
+                <exclude>**/CorsResponseFilter.class</exclude>
+                <exclude>**/OriginValidation.class</exclude>
               </excludes>
             </overlay>
           </overlays>

--- a/hawkular-component/src/main/java/org/hawkular/metrics/security/InfluxAuthHttpHandler.java
+++ b/hawkular-component/src/main/java/org/hawkular/metrics/security/InfluxAuthHttpHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.security;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.Base64;
+import java.util.Deque;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
+
+/**
+ * An Undertow handler to help with Influx authentication on Hawkular servers.
+ *
+ * Code was initially created in a generic way by Juca and is here adapted to fit the very specifix Influx endpoint
+ * needs.
+ *
+ * @author Juraci Paixão Kröhling
+ * @author Thomas Segismont
+ */
+public class InfluxAuthHttpHandler implements HttpHandler {
+    private static final Pattern INFLUX_URI_PATTERN = Pattern.compile("^/hawkular/metrics/db/(.+)/series$");
+    private static final HttpString PERSONA_HEADER = HttpString.tryFromString("Hawkular-Persona");
+    private static final String USERNAME_PARAM_NAME = "u";
+    private static final String PASSWORD_PARAM_NAME = "p";
+
+    private HttpHandler next;
+
+    public InfluxAuthHttpHandler(HttpHandler next) {
+        this.next = next;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange httpServerExchange) throws Exception {
+        if (httpServerExchange.isInIoThread()) {
+            httpServerExchange.dispatch(this);
+            return;
+        }
+
+        Matcher matcher = INFLUX_URI_PATTERN.matcher(httpServerExchange.getRequestURI());
+        if (!matcher.matches()) {
+            next.handleRequest(httpServerExchange);
+            return;
+        }
+
+        HeaderMap requestHeaders = httpServerExchange.getRequestHeaders();
+
+        String databaseName = matcher.group(1);
+        try {
+            UUID.fromString(databaseName);
+        } catch (IllegalArgumentException e) {
+            httpServerExchange.setStatusCode(400);
+            httpServerExchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
+            httpServerExchange.getResponseSender().send("Database name is not a valid identifier.", UTF_8);
+            return;
+        }
+        requestHeaders.put(PERSONA_HEADER, databaseName);
+
+        Map<String, Deque<String>> requestParameters = httpServerExchange.getQueryParameters();
+        Deque<String> usernameParamValues = requestParameters.get(USERNAME_PARAM_NAME);
+        Deque<String> passwordParamValues = requestParameters.get(PASSWORD_PARAM_NAME);
+
+        if (usernameParamValues != null && passwordParamValues != null) {
+            String concat = usernameParamValues.getFirst() + ":" + passwordParamValues.getFirst();
+            String encoded = Base64.getEncoder().encodeToString(concat.getBytes(UTF_8));
+            String authHeader = "Basic " + encoded;
+            requestHeaders.put(Headers.AUTHORIZATION, authHeader);
+            httpServerExchange.getQueryParameters().remove(USERNAME_PARAM_NAME);
+            httpServerExchange.getQueryParameters().remove(PASSWORD_PARAM_NAME);
+        }
+
+        next.handleRequest(httpServerExchange);
+    }
+}

--- a/hawkular-component/src/main/java/org/hawkular/metrics/security/InfluxAuthServletExtension.java
+++ b/hawkular-component/src/main/java/org/hawkular/metrics/security/InfluxAuthServletExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.security;
+
+import javax.servlet.ServletContext;
+
+import io.undertow.servlet.ServletExtension;
+import io.undertow.servlet.api.DeploymentInfo;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+public class InfluxAuthServletExtension implements ServletExtension {
+
+    @Override
+    public void handleDeployment(DeploymentInfo deploymentInfo, ServletContext servletContext) {
+        deploymentInfo.addOuterHandlerChainWrapper(InfluxAuthHttpHandler::new);
+    }
+}

--- a/hawkular-component/src/main/resources/META-INF/services/io.undertow.servlet.ServletExtension
+++ b/hawkular-component/src/main/resources/META-INF/services/io.undertow.servlet.ServletExtension
@@ -1,0 +1,18 @@
+#
+# Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.hawkular.metrics.security.InfluxAuthServletExtension

--- a/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/AuthenticationITest.groovy
+++ b/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/AuthenticationITest.groovy
@@ -121,6 +121,34 @@ ${entity}
     assertEquals(200, response.status)
   }
 
+  @Test
+  void influxShouldRejectInvalidDatabaseIdentifier() {
+    def client = createClientWithoutCredentials()
+
+    def response = client.get(path: 'db/invalid_tenant/series', query: [q: 'list series'])
+
+    assertEquals(400, response.status)
+  }
+
+  @Test
+  void influxShouldRejectInvalidDatabaseFormat() {
+    def client = createClientWithoutCredentials()
+    def response = client.get(path: 'db/invalid_tenant/series', query: [q: 'list series'])
+    assertEquals(400, response.status)
+  }
+
+  @Test
+  void influxShouldAuthenticateUserWithRequestParams() {
+    def client = createClient('jdoe', 'password')
+    def response = client.get(path: 'http://localhost:8080/hawkular/accounts/personas/current')
+    assertEquals(200, response.status)
+
+    def unauthenticatedClient = createClientWithoutCredentials()
+    def tenantId = response.data.id
+    response = unauthenticatedClient.get(path: "db/${tenantId}/series", query: [q: 'list series', u: 'jdoe', p: 'password'])
+    assertEquals(200, response.status)
+  }
+
   static RESTClient createClient(String username, String password) {
     /* http://en.wikipedia.org/wiki/Basic_access_authentication#Client_side :
      * The Authorization header is constructed as follows:


### PR DESCRIPTION
…protected by Accounts

The server now supports InfluxDB request parameter based authentication
(with an Undertow extension).

The database name is used to create the Hawkular-Persona header. This
allows to select the authenticated user tenant or an organization tenant.

Also, CORS filters are now removed from the component. CORS is managed
by Keycloack within Hawkular.