### PR TITLE
HWKMETRICS-346 Fix bogus Hawkular Component security rules

### DIFF
--- a/hawkular-component/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-component/src/main/webapp/WEB-INF/web.xml
@@ -16,44 +16,33 @@
     limitations under the License.
 
 -->
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-         version="3.0">
-
-  <security-constraint>
-    <web-resource-collection>
-      <web-resource-name>Unprotected endpoint</web-resource-name>
-      <url-pattern>/status</url-pattern>
-      <url-pattern>/</url-pattern>
-    </web-resource-collection>
-  </security-constraint>
-
-  <security-constraint>
-    <web-resource-collection>
-      <web-resource-name>REST endpoints</web-resource-name>
-      <url-pattern>/*</url-pattern>
-    </web-resource-collection>
-    <auth-constraint>
-      <role-name>*</role-name>
-    </auth-constraint>
-  </security-constraint>
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
 
   <context-param>
     <param-name>org.keycloak.secretstore.enabled</param-name>
     <param-value>true</param-value>
   </context-param>
 
-  <login-config>
-    <auth-method>KEYCLOAK</auth-method>
-    <realm-name>hawkular</realm-name>
-  </login-config>
+  <context-param>
+    <param-name>resteasy.providers</param-name>
+    <param-value>org.hawkular.metrics.api.jaxrs.util.JacksonConfig</param-value>
+  </context-param>
 
-  <security-role>
-    <role-name>user</role-name>
-  </security-role>
-  <security-role>
-    <role-name>admin</role-name>
-  </security-role>
+  <servlet>
+    <servlet-name>staticContent</servlet-name>
+    <servlet-class>io.undertow.servlet.handlers.DefaultServlet</servlet-class>
+    <init-param>
+      <param-name>resolve-against-context-root</param-name>
+      <param-value>true</param-value>
+    </init-param>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>staticContent</servlet-name>
+    <url-pattern>/static/*</url-pattern>
+  </servlet-mapping>
 
 </web-app>

--- a/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/AuthenticationITest.groovy
+++ b/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/AuthenticationITest.groovy
@@ -73,7 +73,7 @@ ${entity}
 
     def response = client.get(path: protectedEndpoint)
 
-    assertEquals(500, response.status)
+    assertEquals(401, response.status)
   }
 
   @Test


### PR DESCRIPTION
HWKMETRICS-346 Fix bogus Hawkular Component security rules

Do not use declarative security in web.xml.

Note that the REST endpoints are still all secured by default, only a couple are white-listed for free access.