### PR TITLE
HWKMETRICS-352 Add integration tests to metric input from the bus

### DIFF
--- a/integration-tests/hawkular-server-tests/pom.xml
+++ b/integration-tests/hawkular-server-tests/pom.xml
@@ -36,30 +36,27 @@
     <hawkular.port.offset>0</hawkular.port.offset>
     <hawkular.management.port>9990</hawkular.management.port>
     <hawkular.agent.enabled>false</hawkular.agent.enabled>
-    <hawkular.log>DEBUG</hawkular.log>
+    <hawkular.log>ERROR</hawkular.log>
     <hawkular.backend>remote</hawkular.backend>
+    <wildfly.application.username>jmsuser</wildfly.application.username>
+    <wildfly.application.password>password</wildfly.application.password>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>1.1.10.Final</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
-        <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-arquillian-container-managed</artifactId>
-        <version>8.2.1.Final</version>
-        <scope>test</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
+
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-client-all</artifactId>
+      <version>${version.org.wildfly}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>hawkular-metrics-component</artifactId>
@@ -205,6 +202,18 @@
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-maven-plugin</artifactId>
         <configuration>
+          <add-user>
+            <users>
+              <user>
+                <username>${wildfly.application.username}</username>
+                <password>${wildfly.application.password}</password>
+                <applicationUser>true</applicationUser>
+                <groups>
+                  <group>guest</group>
+                </groups>
+              </user>
+            </users>
+          </add-user>
           <jboss-home>${project.build.directory}/${project.artifactId}-${project.version}</jboss-home>
           <skip>${skipTests}</skip>
           <startupTimeout>240</startupTimeout>
@@ -266,6 +275,9 @@
           <systemPropertyVariables>
             <hawkular.bind.address>${hawkular.bind.address}</hawkular.bind.address>
             <hawkular.port.offset>${hawkular.port.offset}</hawkular.port.offset>
+            <wildfly.application.username>${wildfly.application.username}</wildfly.application.username>
+            <wildfly.application.password>${wildfly.application.password}</wildfly.application.password>
+            <hawkular.log>${hawkular.log}</hawkular.log>
 
             <!--output over-the-wire traffic-->
             <!--<org.apache.commons.logging.Log>-->

--- a/integration-tests/hawkular-server-tests/src/main/resources/standalone.xsl
+++ b/integration-tests/hawkular-server-tests/src/main/resources/standalone.xsl
@@ -54,11 +54,17 @@
   <xsl:template match="//*[local-name()='subsystem']/*[local-name()='server' and @name='default']">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
-      <jms-topic name="HawkularAvailData" entries="java:/topic/HawkularAvailData"/>
-      <jms-topic name="HawkularMetricData" entries="java:/topic/HawkularMetricData"/>
-      <jms-queue name="hawkular/metrics/gauges/new" entries="java:/queue/hawkular/metrics/gauges/new"/>
-      <jms-queue name="hawkular/metrics/counters/new" entries="java:/queue/hawkular/metrics/counters/new"/>
-      <jms-queue name="hawkular/metrics/availability/new" entries="java:/queue/hawkular/metrics/availability/new"/>
+      <!-- Topics and queues must be also exposed under jboss/exported to be visible to external clients -->
+      <jms-topic name="HawkularAvailData"
+                 entries="java:/topic/HawkularAvailData java:jboss/exported/topic/HawkularAvailData"/>
+      <jms-topic name="HawkularMetricData"
+                 entries="java:/topic/HawkularMetricData java:jboss/exported/topic/HawkularMetricData"/>
+      <jms-queue name="hawkular/metrics/gauges/new"
+                 entries="java:/queue/hawkular/metrics/gauges/new java:jboss/exported/queue/hawkular/metrics/gauges/new"/>
+      <jms-queue name="hawkular/metrics/counters/new"
+                 entries="java:/queue/hawkular/metrics/counters/new java:jboss/exported/queue/hawkular/metrics/counters/new"/>
+      <jms-queue name="hawkular/metrics/availability/new"
+                 entries="java:/queue/hawkular/metrics/availability/new java:jboss/exported/queue/hawkular/metrics/availability/new"/>
     </xsl:copy>
   </xsl:template>
 

--- a/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/AuthenticationITest.groovy
+++ b/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/AuthenticationITest.groovy
@@ -19,53 +19,15 @@
 package org.hawkular.metrics
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
 
-import org.junit.BeforeClass
 import org.junit.Test
-
-import groovy.json.internal.Charsets
-import groovyx.net.http.ContentType
-import groovyx.net.http.RESTClient
 
 /**
  * @author jsanda
  */
-class AuthenticationITest {
-
-  static String testUser = 'jdoe'
-  static String testPasword = 'password'
-  static String baseURI
-  static Closure defaultFailureHandler
-  static String protectedEndpoint
-
-  @BeforeClass
-  static void initClient() {
-    defaultFailureHandler = { resp ->
-      def msg = "Got error response: ${resp.statusLine}"
-      if (resp.entity != null && resp.entity.contentLength != 0) {
-        def baos = new ByteArrayOutputStream()
-        resp.entity.writeTo(baos)
-        def entity = new String(baos.toByteArray(), Charsets.UTF_8)
-        msg = """${msg}
-=== Response body
-${entity}
-===
-"""
-      }
-      System.err.println(msg)
-      return resp
-    }
-
-    String host = System.getProperty('hawkular.bind.address') ?: 'localhost'
-    if ("0.0.0.0".equals(host)) {
-      host = "localhost"
-    }
-    int portOffset = Integer.parseInt(System.getProperty('hawkular.port.offset') ?: '0')
-    int httpPort = portOffset + 8080
-    baseURI = "http://${host}:${httpPort}/hawkular/metrics/"
-
-    protectedEndpoint = 'gauges'
-  }
+class AuthenticationITest extends BaseITest {
+  static String protectedEndpoint = 'gauges'
 
   @Test
   void noCredentialsShouldFail() {
@@ -91,7 +53,8 @@ ${entity}
 
     def response = client.get(path: protectedEndpoint)
 
-    assertEquals(204, response.status)
+    // Status can be 200 if another test ran before and inserted some gauge data points
+    assertTrue([200, 204].contains(response.status))
   }
 
   @Test
@@ -139,39 +102,9 @@ ${entity}
 
   @Test
   void influxShouldAuthenticateUserWithRequestParams() {
-    def client = createClient('jdoe', 'password')
-    def response = client.get(path: 'http://localhost:8080/hawkular/accounts/personas/current')
-    assertEquals(200, response.status)
-
     def unauthenticatedClient = createClientWithoutCredentials()
-    def tenantId = response.data.id
-    response = unauthenticatedClient.get(path: "db/${tenantId}/series", query: [q: 'list series', u: 'jdoe', p: 'password'])
+    def response = unauthenticatedClient.get(path: "db/${getTenantId()}/series", query: [q: 'list series', u: 'jdoe', p: 'password'])
     assertEquals(200, response.status)
-  }
-
-  static RESTClient createClient(String username, String password) {
-    /* http://en.wikipedia.org/wiki/Basic_access_authentication#Client_side :
-     * The Authorization header is constructed as follows:
-     *  * Username and password are combined into a string "username:password"
-     *  * The resulting string is then encoded using the RFC2045-MIME variant of Base64,
-     *    except not limited to 76 char/line[9]
-     *  * The authorization method and a space i.e. "Basic " is then put before the encoded string.
-     */
-    String encodedCredentials = Base64.getMimeEncoder().encodeToString("$username:$password".getBytes("utf-8"))
-    RESTClient client = new RESTClient(baseURI, ContentType.JSON)
-    client.defaultRequestHeaders.Authorization = "Basic " + encodedCredentials
-    client.defaultRequestHeaders.Accept = ContentType.JSON
-    client.handler.failure = defaultFailureHandler
-
-    return client
-  }
-
-  static RESTClient createClientWithoutCredentials() {
-    RESTClient client = new RESTClient(baseURI, ContentType.JSON)
-    client.defaultRequestHeaders.Accept = ContentType.JSON
-    client.handler.failure = defaultFailureHandler
-
-    return client
   }
 
 }

--- a/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/BaseITest.groovy
+++ b/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/BaseITest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics
+
+import static org.junit.Assert.assertEquals
+
+import org.junit.BeforeClass
+
+import groovy.json.internal.Charsets
+import groovyx.net.http.ContentType
+import groovyx.net.http.RESTClient
+
+/**
+ * @author Thomas Segismont
+ */
+class BaseITest {
+  static String testUser = 'jdoe'
+  static String testPasword = 'password'
+  static String host
+  static int httpPort
+  static String baseURI
+  static Closure defaultFailureHandler
+
+  @BeforeClass
+  static void initClient() {
+    defaultFailureHandler = { resp ->
+      def msg = "Got error response: ${resp.statusLine}"
+      if (resp.entity != null && resp.entity.contentLength != 0) {
+        def baos = new ByteArrayOutputStream()
+        resp.entity.writeTo(baos)
+        def entity = new String(baos.toByteArray(), Charsets.UTF_8)
+        msg = """${msg}
+=== Response body
+${entity}
+===
+"""
+      }
+      System.err.println(msg)
+      return resp
+    }
+
+    host = System.getProperty('hawkular.bind.address') ?: 'localhost'
+    if ("0.0.0.0".equals(host)) {
+      host = "localhost"
+    }
+    int portOffset = Integer.parseInt(System.getProperty('hawkular.port.offset') ?: '0')
+    httpPort = portOffset + 8080
+    baseURI = "http://${host}:${httpPort}/hawkular/metrics/"
+  }
+
+  static String getTenantId() {
+    def client = createClient('jdoe', 'password')
+    def response = client.get(path: 'http://localhost:8080/hawkular/accounts/personas/current')
+    assertEquals(200, response.status)
+    return response.data.id
+  }
+
+  static RESTClient createClient(String username, String password) {
+    /* http://en.wikipedia.org/wiki/Basic_access_authentication#Client_side :
+     * The Authorization header is constructed as follows:
+     *  * Username and password are combined into a string "username:password"
+     *  * The resulting string is then encoded using the RFC2045-MIME variant of Base64,
+     *    except not limited to 76 char/line[9]
+     *  * The authorization method and a space i.e. "Basic " is then put before the encoded string.
+     */
+    String encodedCredentials = Base64.getMimeEncoder().encodeToString("$username:$password".getBytes("utf-8"))
+    RESTClient client = new RESTClient(baseURI, ContentType.JSON)
+    client.defaultRequestHeaders.Authorization = "Basic " + encodedCredentials
+    client.defaultRequestHeaders.Accept = ContentType.JSON
+    client.handler.failure = defaultFailureHandler
+
+    return client
+  }
+
+  static RESTClient createClientWithoutCredentials() {
+    RESTClient client = new RESTClient(baseURI, ContentType.JSON)
+    client.defaultRequestHeaders.Accept = ContentType.JSON
+    client.handler.failure = defaultFailureHandler
+
+    return client
+  }
+}

--- a/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/NewDataListenerITest.groovy
+++ b/integration-tests/hawkular-server-tests/src/test/groovy/org/hawkular/metrics/NewDataListenerITest.groovy
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics
+
+import static java.util.UUID.randomUUID
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static java.util.concurrent.TimeUnit.MINUTES
+import static org.hawkular.metrics.BaseITest.host
+import static org.hawkular.metrics.BaseITest.httpPort
+import static org.junit.Assert.assertEquals
+
+import java.util.concurrent.CountDownLatch
+
+import javax.jms.ConnectionFactory
+import javax.jms.JMSConsumer
+import javax.jms.JMSContext
+import javax.jms.JMSProducer
+import javax.jms.Queue
+import javax.jms.TextMessage
+import javax.jms.Topic
+import javax.naming.Context
+import javax.naming.InitialContext
+
+import org.junit.After
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+
+/**
+ * @author Thomas Segismont
+ */
+class NewDataListenerITest extends BaseITest {
+  static String tenantId
+
+  static Context jndiContext
+  static ConnectionFactory connectionFactory
+
+  static Queue gaugesQueue
+  static Queue countersQueue
+  static Queue availabilityQueue
+
+  static Topic metricDataTopic
+  static Topic availabilityDataTopic
+
+  static JMSContext jmsProducerContext
+  static JMSProducer producer
+  static JMSContext jmsConsumerContext
+  static JMSConsumer metricDataTopicConsumer
+  static JMSConsumer availabilityDataTopicConsumer
+
+  long now = System.currentTimeMillis()
+
+  @BeforeClass
+  static void setup() {
+    tenantId = BaseITest.getTenantId()
+
+    Properties env = new Properties()
+    env.put(Context.INITIAL_CONTEXT_FACTORY, 'org.jboss.naming.remote.client.InitialContextFactory')
+    env.put(Context.PROVIDER_URL, System.getProperty(Context.PROVIDER_URL, "http-remoting://${host}:${httpPort}"))
+
+    jndiContext = new InitialContext(env)
+
+    connectionFactory = (ConnectionFactory) jndiContext.lookup('jms/RemoteConnectionFactory')
+    gaugesQueue = (Queue) jndiContext.lookup('queue/hawkular/metrics/gauges/new')
+    countersQueue = (Queue) jndiContext.lookup('queue/hawkular/metrics/counters/new')
+    availabilityQueue = (Queue) jndiContext.lookup('queue/hawkular/metrics/availability/new')
+
+    metricDataTopic = (Topic) jndiContext.lookup('topic/HawkularMetricData')
+    availabilityDataTopic = (Topic) jndiContext.lookup('topic/HawkularAvailData')
+
+    def userName = 'jmsuser'
+    def password = 'password'
+    jmsProducerContext = connectionFactory.createContext(userName, password)
+    producer = jmsProducerContext.createProducer()
+    jmsConsumerContext = connectionFactory.createContext(userName, password)
+    metricDataTopicConsumer = jmsConsumerContext.createConsumer(metricDataTopic)
+    availabilityDataTopicConsumer = jmsConsumerContext.createConsumer(availabilityDataTopic)
+  }
+
+  @Before
+  @After
+  void beforeAndAfterTest() {
+    metricDataTopicConsumer.setMessageListener(null);
+  }
+
+  @Test
+  void testAddGaugeData() {
+    testAddNumericData(gaugesQueue, 3.45, BigDecimal.class)
+  }
+
+  @Test
+  void testAddCounterData() {
+    testAddNumericData(countersQueue, 29, Integer.class)
+  }
+
+  void testAddNumericData(Queue inputQueue, Number initValue, Class<? extends Number> comparisonClass) {
+    def expectedMetrics = []
+    def inputMessages = []
+    10.times { i ->
+      def source = randomUUID().toString()
+      expectedMetrics.push(source)
+      10.times { j ->
+        def timestamp = now - MILLISECONDS.convert(j + 1, MINUTES)
+        inputMessages.push(metricDataMessage(source, timestamp, initValue + j))
+      }
+    }
+
+    def latch = new CountDownLatch(100)
+    def data = []
+    metricDataTopicConsumer.setMessageListener({ message ->
+      def insertedData = new JsonSlurper().parseText(((TextMessage) message).text)
+      if (insertedData.metricData.tenantId.equals(tenantId)
+          && insertedData.metricData.data.size() == 1
+          && expectedMetrics.contains(insertedData.metricData.data[0].source)) {
+        data.push(insertedData.metricData.data[0])
+        latch.countDown()
+      }
+    })
+
+    inputMessages.each { it ->
+      def json = new JsonBuilder(it).toString()
+      producer.send(inputQueue, json)
+    }
+
+    latch.await(1, MINUTES)
+
+    assertEquals(expectedMetrics as Set, data.groupBy { it -> it.source }.keySet())
+
+    data.groupBy { it -> it.source }.each { Map.Entry entry ->
+      def expected = []
+      10.times { i ->
+        def point = [source: entry.key, timestamp: now - MILLISECONDS.convert(i + 1, MINUTES), value: (initValue + i).asType(comparisonClass)]
+        expected.push(point)
+      }
+      def actual = (entry.value as List).sort({ p1, p2 -> Long.compare(p2.timestamp, p1.timestamp) }).collect { point ->
+        point.value = point.value.asType(comparisonClass)
+        point
+      }
+      assertEquals(expected, actual)
+    }
+  }
+
+  private static Map metricDataMessage(String source, long timestamp, Number value) {
+    [
+        metricData: [
+            tenantId: tenantId,
+            data    : [
+                [source: source, timestamp: timestamp, value: value]
+            ]
+        ]
+    ]
+  }
+
+  @Test
+  void testAddAvailabilityData() {
+    def expectedMetrics = []
+    def inputMessages = []
+    10.times { i ->
+      def id = randomUUID().toString()
+      expectedMetrics.push(id)
+      10.times { j ->
+        def timestamp = now - MILLISECONDS.convert(j + 1, MINUTES)
+        inputMessages.push(availDataMessage(id, timestamp, j % 2 == 0 ? 'up' : 'down'))
+      }
+    }
+
+    def latch = new CountDownLatch(100)
+    def data = []
+    availabilityDataTopicConsumer.setMessageListener({ message ->
+      def insertedData = new JsonSlurper().parseText(((TextMessage) message).text)
+      if (insertedData.availData.data.size() == 1
+          && insertedData.availData.data[0].tenantId.equals(tenantId)
+          && expectedMetrics.contains(insertedData.availData.data[0].id)) {
+        data.push(insertedData.availData.data[0])
+        latch.countDown()
+      }
+    })
+
+    inputMessages.each { it ->
+      def json = new JsonBuilder(it).toString()
+      producer.send(availabilityQueue, json)
+    }
+
+    latch.await(1, MINUTES)
+
+    assertEquals(expectedMetrics as Set, data.groupBy { it -> it.id }.keySet())
+
+    data.groupBy { it -> it.id }.each { Map.Entry entry ->
+      def expected = []
+      10.times { i ->
+        def point = [tenantId: tenantId, id: entry.key, timestamp: now - MILLISECONDS.convert(i + 1, MINUTES), avail: i % 2 == 0 ? 'up' : 'down']
+        expected.push(point)
+      }
+      def actual = (entry.value as List).sort({ p1, p2 -> Long.compare(p2.timestamp, p1.timestamp) }).collect({ point ->
+        point.avail = (point.avail as String).toLowerCase()
+        point
+      })
+      assertEquals(expected, actual)
+    }
+  }
+
+  private static Map availDataMessage(String id, long timestamp, String value) {
+    [
+        availData: [
+            data: [
+                [tenantId: tenantId, id: id, timestamp: timestamp, avail: value]
+            ]
+        ]
+    ]
+  }
+
+  @AfterClass
+  static void tearDown() {
+    try {
+      jmsProducerContext?.close()
+    } catch (Exception ignored) {
+    }
+    try {
+      jmsConsumerContext?.close()
+    } catch (Exception ignored) {
+    }
+    try {
+      jndiContext?.close()
+    } catch (Exception ignored) {
+    }
+  }
+
+}

--- a/integration-tests/hawkular-server-tests/src/test/resources/logback-test.xml
+++ b/integration-tests/hawkular-server-tests/src/test/resources/logback-test.xml
@@ -1,0 +1,46 @@
+<!--
+
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+  <property name="pattern" value="%-5level %date{ISO8601} [%thread] %class:%M:%L - %message%n"/>
+
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>${hawkular.log:-ERROR}</level>
+    </filter>
+    <encoder>
+      <pattern>${pattern}</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="file" class="ch.qos.logback.core.FileAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>${hawkular.log:-ERROR}</level>
+    </filter>
+    <file>target/test.log</file>
+    <append>false</append>
+    <encoder>
+      <pattern>${pattern}</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="stdout"/>
+    <appender-ref ref="file"/>
+  </root>
+</configuration>


### PR DESCRIPTION
HWKMETRICS-352 Add integration tests to metric input from the bus

Configured the input queues and inserted data topics to be accessible to remote clients

The integration test connects as a remote client, sends input data and listens to inserted data.
 Inserted data events must match input data.