### PR TITLE
[HWKMETRICS-24] 

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -241,7 +241,7 @@ public class AvailabilityHandler {
     @Deprecated
     @POST
     @Path("/{id}/data")
-    @ApiOperation(value = "Deprecated. Please use /raw endpoit.")
+    @ApiOperation(value = "Deprecated. Please use /raw endpoint.")
     public void deprecatedAddAvailabilityForMetric(
             @Suspended final AsyncResponse asyncResponse, @PathParam("id") String id,
             @ApiParam(value = "List of availability datapoints", required = true)

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -543,7 +543,7 @@ public class CounterHandler {
 
     @Deprecated
     @GET
-    @Path("/{id}/ratel")
+    @Path("/{id}/rate")
     @ApiOperation(value = "Deprecated. Please use rate/raw or rate/stats endpoints.",
                     response = DataPoint.class, responseContainer = "List")
     public void findRate(
@@ -827,7 +827,7 @@ public class CounterHandler {
 
     @Deprecated
     @GET
-    @Path("/ratel")
+    @Path("/rate")
     @ApiOperation(value = "Deprecated. Please use /rate/stats endpoint.",
                     response = NumericBucketPoint.class, responseContainer = "List")
     public void deprecatedFindCounterRateDataStats(

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -220,7 +220,7 @@ public class GaugeHandler {
     }
 
     @POST
-    @Path("/{id}/data")
+    @Path("/{id}/raw")
     @ApiOperation(value = "Add data for a single gauge metric.")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Adding data succeeded."),
@@ -239,29 +239,52 @@ public class GaugeHandler {
         observable.subscribe(new ResultSetObserver(asyncResponse));
     }
 
+    @Deprecated
     @POST
-    @Path("/data")
+    @Path("/{id}/data")
+    @ApiOperation(value = "Deprecated. Please use /raw endpoint.")
+    public void deprecatedAddDataForMetric(
+            @Suspended final AsyncResponse asyncResponse,
+            @PathParam("id") String id,
+            @ApiParam(value = "List of datapoints containing timestamp and value", required = true)
+            List<DataPoint<Double>> data
+    ) {
+        addDataForMetric(asyncResponse, id, data);
+    }
+
+    @POST
+    @Path("/raw")
     @ApiOperation(value = "Add data for multiple gauge metrics in a single call.")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Adding data succeeded."),
             @ApiResponse(code = 400, message = "Missing or invalid payload", response = ApiError.class),
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data",
-                    response = ApiError.class)
+                response = ApiError.class)
     })
     public void addGaugeData(
             @Suspended final AsyncResponse asyncResponse,
-            @ApiParam(value = "List of metrics", required = true) List<Metric<Double>> gauges
-    ) {
+            @ApiParam(value = "List of metrics", required = true) List<Metric<Double>> gauges) {
         Observable<Metric<Double>> metrics = Functions.metricToObservable(tenantId, gauges, GAUGE);
         Observable<Void> observable = metricsService.addDataPoints(GAUGE, metrics);
         observable.subscribe(new ResultSetObserver(asyncResponse));
     }
 
+    @Deprecated
+    @POST
+    @Path("/data")
+    @ApiOperation(value = "Deprecated. Please use /raw endpoint.")
+    public void deprecatedAddGaugeData(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "List of metrics", required = true) List<Metric<Double>> gauges
+    ) {
+        addGaugeData(asyncResponse, gauges);
+    }
+
+    @Deprecated
     @GET
     @Path("/{id}/data")
-    @ApiOperation(value = "Retrieve gauge data.", notes = "When buckets or bucketDuration query parameter is used, " +
-            "the time range between start and end will be divided in buckets of equal duration, and metric statistics" +
-            " will be computed for each bucket.", response = DataPoint.class, responseContainer = "List")
+    @ApiOperation(value = "Deprecated. Please use /raw or /stats endpoints.",
+                    response = DataPoint.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched metric data."),
             @ApiResponse(code = 204, message = "No metric data was found."),
@@ -384,7 +407,146 @@ public class GaugeHandler {
     }
 
     @GET
-    @Path("/data")
+    @Path("/{id}/raw")
+    @ApiOperation(value = "Retrieve raw gauge data.", response = DataPoint.class, responseContainer = "List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully fetched metric data."),
+            @ApiResponse(code = 204, message = "No metric data was found."),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
+                    response = ApiError.class)
+    })
+    public void findRawData(
+            @Suspended AsyncResponse asyncResponse,
+            @PathParam("id") String id,
+            @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
+            @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
+            @ApiParam(value = "Use data from earliest received, subject to retention period")
+                @QueryParam("fromEarliest") Boolean fromEarliest,
+            @ApiParam(value = "Limit the number of data points returned") @QueryParam("limit") Integer limit,
+            @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
+            ) {
+
+        MetricId<Double> metricId = new MetricId<>(tenantId, GAUGE, id);
+
+        TimeRange timeRange = new TimeRange(start, end);
+        if (!timeRange.isValid()) {
+            asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
+            return;
+        }
+
+        if (limit != null) {
+            if (order == null) {
+                if (start == null && end != null) {
+                    order = Order.DESC;
+                } else if (start != null && end == null) {
+                    order = Order.ASC;
+                } else {
+                    order = Order.DESC;
+                }
+            }
+        } else {
+            limit = 0;
+        }
+
+        if (order == null) {
+            order = Order.DESC;
+        }
+
+        metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd(), limit, order)
+                .toList()
+                .map(ApiUtils::collectionToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
+
+    }
+
+    @GET
+    @Path("/{id}/stats")
+    @ApiOperation(value = "Retrieve gauge data.", notes = "The time range between start and end will be divided "
+            + "in buckets of equal duration, and metric statistics will be computed for each bucket.",
+                    response = DataPoint.class, responseContainer = "List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully fetched metric data."),
+            @ApiResponse(code = 204, message = "No metric data was found."),
+            @ApiResponse(code = 400, message = "buckets or bucketDuration parameter is invalid, or both are used.",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
+                    response = ApiError.class)
+    })
+    public void findStatsData(
+            @Suspended AsyncResponse asyncResponse,
+            @PathParam("id") String id,
+            @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
+            @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
+            @ApiParam(value = "Use data from earliest received, subject to retention period")
+                                                @QueryParam("fromEarliest") Boolean fromEarliest,
+            @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
+            @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
+            @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles) {
+
+        MetricId<Double> metricId = new MetricId<>(tenantId, GAUGE, id);
+
+        if (bucketsCount == null && bucketDuration == null) {
+            asyncResponse
+                    .resume(badRequest(new ApiError("Either the buckets or bucketDuration parameter must be used")));
+            return;
+        }
+
+        Observable<BucketConfig> observableConfig = null;
+
+        if (Boolean.TRUE.equals(fromEarliest)) {
+            if (start != null || end != null) {
+                asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
+                return;
+            }
+
+
+            observableConfig = metricsService.findMetric(metricId).map((metric) -> {
+                long dataRetention = metric.getDataRetention() * 24 * 60 * 60 * 1000L;
+                long now = System.currentTimeMillis();
+                long earliest = now - dataRetention;
+
+                BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration,
+                        new TimeRange(earliest, now));
+
+                if (!bucketConfig.isValid()) {
+                    throw new RuntimeApiError(bucketConfig.getProblem());
+                }
+
+                return bucketConfig;
+            });
+        } else {
+            TimeRange timeRange = new TimeRange(start, end);
+            if (!timeRange.isValid()) {
+                asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
+                return;
+            }
+
+            BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
+            if (!bucketConfig.isValid()) {
+                asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
+                return;
+            }
+
+            observableConfig = Observable.just(bucketConfig);
+        }
+
+        final Percentiles lPercentiles = percentiles != null ? percentiles
+                : new Percentiles(Collections.<Double> emptyList());
+
+        observableConfig
+                .flatMap((config) -> metricsService.findGaugeStats(metricId,
+                        config.getTimeRange().getStart(),
+                        config.getTimeRange().getEnd(),
+                        config.getBuckets(), lPercentiles.getPercentiles()))
+                .flatMap(Observable::from)
+                .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+                .toList()
+                .map(ApiUtils::collectionToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
+    }
+
+    @GET
+    @Path("/stats")
     @ApiOperation(value = "Find stats for multiple metrics.", notes = "Fetches data points from one or more metrics"
             + " that are determined using either a tags filter or a list of metric names. The time range between " +
             "start and end is divided into buckets of equal size (i.e., duration) using either the buckets or " +
@@ -399,7 +561,7 @@ public class GaugeHandler {
                     response = ApiError.class),
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class) })
-    public void findGaugeData(
+    public void findStats(
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") final Long start,
             @ApiParam(value = "Defaults to now") @QueryParam("end") final Long end,
@@ -450,6 +612,26 @@ public class GaugeHandler {
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
         }
+    }
+
+    @Deprecated
+    @GET
+    @Path("/data")
+    @ApiOperation(value = "Deprecated. Please use /stast endpoint.",
+            response = NumericBucketPoint.class, responseContainer = "List")
+    public void findData(
+            @Suspended AsyncResponse asyncResponse,
+            @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") final Long start,
+            @ApiParam(value = "Defaults to now") @QueryParam("end") final Long end,
+            @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
+            @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
+            @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles,
+            @ApiParam(value = "List of tags filters", required = false) @QueryParam("tags") Tags tags,
+            @ApiParam(value = "List of metric names", required = false) @QueryParam("metrics") List<String> metricNames,
+            @ApiParam(value = "Downsample method (if true then sum of stacked individual stats; defaults to false)",
+                    required = false) @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
+
+        findStats(asyncResponse, start, end, bucketsCount, bucketDuration, percentiles, tags, metricNames, stacked);
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -115,7 +115,7 @@ public class MetricHandler {
     @GET
     @Path("/")
     @ApiOperation(value = "Find tenant's metric definitions.", notes = "Does not include any metric values. ",
- response = Metric.class, responseContainer = "List")
+                    response = Metric.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully retrieved at least one metric definition."),
             @ApiResponse(code = 204, message = "No metrics found."),
@@ -162,9 +162,9 @@ public class MetricHandler {
 
     @POST
     @Path("/data")
-    @ApiOperation(value = "Add data for multiple metrics in a single call.")
+    @ApiOperation(value = "Add data points for multiple metrics in a single call.")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Adding data succeeded."),
+            @ApiResponse(code = 200, message = "Adding data points succeeded."),
             @ApiResponse(code = 400, message = "Missing or invalid payload.", response = ApiError.class),
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data",
                     response = ApiError.class)

--- a/clients/ptranslator/ptrans.conf
+++ b/clients/ptranslator/ptrans.conf
@@ -46,7 +46,7 @@ graphite.port=2003
 # REST endpoint
 # Supported server types: metrics,hawkular
 server.type=metrics
-rest.url=http://localhost:8080/hawkular/metrics/gauges/data
+rest.url=http://localhost:8080/hawkular/metrics/gauges/raw
 #http.proxy=http://proxyhost:8000
 # Tenant selection on standalone Metrics servers
 tenant=default

--- a/clients/ptranslator/src/assembly/dist/assets/ptrans.conf
+++ b/clients/ptranslator/src/assembly/dist/assets/ptrans.conf
@@ -46,7 +46,7 @@ graphite.port=2003
 # REST endpoint
 # Supported server types: metrics,hawkular
 server.type=metrics
-rest.url=http://localhost:8080/hawkular/metrics/gauges/data
+rest.url=http://localhost:8080/hawkular/metrics/gauges/raw
 #http.proxy=http://proxyhost:8000
 # Tenant selection on standalone Metrics servers
 tenant=default

--- a/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/Configuration.java
+++ b/clients/ptranslator/src/main/java/org/hawkular/metrics/clients/ptrans/Configuration.java
@@ -132,7 +132,7 @@ public class Configuration {
         int graphitePort = getIntProperty(properties, GRAPHITE_PORT, 2003);
         ServerType serverType = getServerType(properties, validationMessages);
         URI restUrl = URI.create(properties.getProperty(REST_URL.toString(),
-                "http://localhost:8080/hawkular/metrics/gauges/data"));
+                "http://localhost:8080/hawkular/metrics/gauges/raw"));
         String proxyString = properties.getProperty(HTTP_PROXY.toString());
         URI httpProxy = null;
         if (proxyString != null && !proxyString.trim().isEmpty()) {

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/backend/MetricsSenderITest.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/backend/MetricsSenderITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,7 +60,7 @@ public class MetricsSenderITest {
     public void setUp() throws Exception {
         tenant = getRandomTenantId();
         idGenerator = new AtomicLong(0);
-        String addGaugeDataUrl = "http://" + BASE_URI + "/gauges/data";
+        String addGaugeDataUrl = "http://" + BASE_URI + "/gauges/raw";
 
         Properties properties = new Properties();
         properties.setProperty(ConfigurationKey.REST_URL.toString(), addGaugeDataUrl);

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/data/ServerDataHelper.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/data/ServerDataHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,6 +101,6 @@ public class ServerDataHelper {
     }
 
     private String findGaugeDataUrl(String metricName) {
-        return "http://" + BASE_URI + "/gauges/" + metricName + "/data?start=0";
+        return "http://" + BASE_URI + "/gauges/" + metricName + "/raw?start=0";
     }
 }

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/fullstack/FullStackITest.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/fullstack/FullStackITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,7 +62,7 @@ abstract class FullStackITest extends ExecutableITestBase {
         try (InputStream in = new FileInputStream(ptransConfFile)) {
             properties.load(in);
         }
-        String restUrl = "http://" + BASE_URI + "/gauges/data";
+        String restUrl = "http://" + BASE_URI + "/gauges/raw";
         properties.setProperty(ConfigurationKey.REST_URL.toString(), restUrl);
         properties.setProperty(ConfigurationKey.TENANT.toString(), tenant);
         changePTransConfig(properties);

--- a/clients/ptranslator/src/test/resources/ptrans.conf
+++ b/clients/ptranslator/src/test/resources/ptrans.conf
@@ -46,7 +46,7 @@ graphite.port=2003
 # REST endpoint
 # Supported server types: metrics,hawkular
 server.type=metrics
-rest.url=http://localhost:8080/hawkular/metrics/gauges/data
+rest.url=http://localhost:8080/hawkular/metrics/gauges/raw
 #http.proxy=http://proxyhost:8000
 # Tenant selection on standalone Metrics servers
 tenant=default

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
@@ -31,7 +31,7 @@ class AvailabilityITest extends RESTTest {
 
   @Test
   void shouldNotAcceptInvalidTimeRange() {
-    badGet(path: "availability/test/data", headers: [(tenantHeaderName): tenantId],
+    badGet(path: "availability/test/raw", headers: [(tenantHeaderName): tenantId],
         query: [start: 1000, end: 500]) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -39,7 +39,7 @@ class AvailabilityITest extends RESTTest {
 
   @Test
   void shouldNotAcceptInvalidBucketConfig() {
-    badGet(path: "availability/test/data", headers: [(tenantHeaderName): tenantId],
+    badGet(path: "availability/test/stats", headers: [(tenantHeaderName): tenantId],
         query: [start: 500, end: 100, buckets: '10', bucketDuration: '10ms']) { exception ->
       assertEquals("Should fail when both bucket params are specified", 400, exception.response.status)
     }
@@ -54,12 +54,12 @@ class AvailabilityITest extends RESTTest {
 
   @Test
   void shouldNotAddAvailabilityForMetricWithEmptyPayload() {
-    badPost(path: "availability/pimpo/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "availability/pimpo/raw", headers: [(tenantHeaderName): tenantId],
         body: "" /* Empty Body */) { exception ->
       assertEquals(400, exception.response.status)
     }
 
-    badPost(path: "availability/pimpo/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "availability/pimpo/raw", headers: [(tenantHeaderName): tenantId],
         body: [] /* Empty List */) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -67,12 +67,12 @@ class AvailabilityITest extends RESTTest {
 
   @Test
   void shouldNotAddAvailabilityDataWithEmptyPayload() {
-    badPost(path: "availability/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "availability/raw", headers: [(tenantHeaderName): tenantId],
         body: "" /* Empty Body */) { exception ->
       assertEquals(400, exception.response.status)
     }
 
-    badPost(path: "availability/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "availability/raw", headers: [(tenantHeaderName): tenantId],
         body: [] /* Empty List */) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -91,7 +91,7 @@ class AvailabilityITest extends RESTTest {
     DateTime start = now().minusMinutes(20)
     String metric = 'A1'
 
-    def response = hawkularMetrics.post(path: "availability/$metric/data", body: [
+    def response = hawkularMetrics.post(path: "availability/$metric/raw", body: [
         [timestamp: start.millis, value: "up"]], headers: [(tenantHeaderName): tenantId])
 
     assertEquals(200, response.status)
@@ -139,7 +139,7 @@ class AvailabilityITest extends RESTTest {
     String id = 'A1'
 
     def response = hawkularMetrics.post(
-        path: "availability/$id/data",
+        path: "availability/$id/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [
@@ -160,7 +160,7 @@ class AvailabilityITest extends RESTTest {
         ]
     )
     assertEquals(200, response.status)
-    response = hawkularMetrics.get(path: "availability/$id/data", headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$id/raw", headers: [(tenantHeaderName): tenantId])
     def expectedData = [
         [
             timestamp: start.plusMinutes(3).millis,

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/BaseITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/BaseITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,10 +29,10 @@ class BaseITest extends RESTTest {
         def start = end - 100
         def tenantId = 'test-tenant'
         def metric = 'foo'
-        def response = hawkularMetrics.post(path: "gauges/$metric/data", body: [[timestamp: start + 10, value: 42]], headers: [(tenantHeaderName): tenantId])
+        def response = hawkularMetrics.post(path: "gauges/$metric/raw", body: [[timestamp: start + 10, value: 42]], headers: [(tenantHeaderName): tenantId])
         assertEquals(200, response.status)
 
-        response = hawkularMetrics.get(path: "gauges/$metric/data", query: [start: start, end: end], headers: [(tenantHeaderName): tenantId])
+        response = hawkularMetrics.get(path: "gauges/$metric/raw", query: [start: start, end: end], headers: [(tenantHeaderName): tenantId])
         assertEquals(200, response.status)
 
         assertEquals(start + 10, response.data[0].timestamp)

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
@@ -114,7 +114,7 @@ class CORSITest extends RESTTest {
     def tenantId = nextTenantId()
 
     // First create a couple gauge metrics by only inserting data
-    def response = hawkularMetrics.post(path: "gauges/data", body: [
+    def response = hawkularMetrics.post(path: "gauges/raw", body: [
         [
             id: "m11",
             data: [

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -51,16 +51,16 @@ class CassandraBackendITest extends RESTTest {
     def tenantId = nextTenantId()
     def metric = "N1"
 
-    def response = hawkularMetrics.get(path: "gauges/missing/data", headers: [(tenantHeaderName): tenantId])
+    def response = hawkularMetrics.get(path: "gauges/missing/raw", headers: [(tenantHeaderName): tenantId])
     assertEquals("Expected a 204 response when the gauge metric does not exist", 204, response.status)
 
-    response = hawkularMetrics.post(path: "gauges/$metric/data", body: [
+    response = hawkularMetrics.post(path: "gauges/$metric/raw", body: [
         [timestamp: now().minusHours(2).millis, value: 1.23],
         [timestamp: now().minusHours(1).millis, value: 3.21]
     ], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: "gauges/$metric/data", query: [
+    response = hawkularMetrics.get(path: "gauges/$metric/raw", query: [
         start: now().minusDays(3).millis, end: now().minusDays(2).millis], headers: [(tenantHeaderName): tenantId])
     assertEquals("Expected a 204 response when there is no data for the specified date range", 204, response.status)
   }
@@ -70,16 +70,16 @@ class CassandraBackendITest extends RESTTest {
     def tenantId = nextTenantId()
     def metric = 'A1'
 
-    def response = hawkularMetrics.get(path: "availability/missing/data", headers: [(tenantHeaderName): tenantId])
+    def response = hawkularMetrics.get(path: "availability/missing/raw", headers: [(tenantHeaderName): tenantId])
     assertEquals("Expected a 204 response when the availability metric does not exist", 204, response.status)
 
-    response = hawkularMetrics.post(path: "availability/$metric/data", body: [
+    response = hawkularMetrics.post(path: "availability/$metric/raw", body: [
         [timestamp: now().minusHours(2).millis, value: 'up'],
         [timestamp: now().minusHours(1).millis, value: 'up']
     ], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: "availability/$metric/data", query: [
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [
         start: now().minusDays(3).millis, end: now().minusDays(2).millis], headers: [(tenantHeaderName): tenantId])
     assertEquals("Expected a 204 response when there is no data for the specified date range", 204, response.status)
   }
@@ -97,7 +97,7 @@ class CassandraBackendITest extends RESTTest {
     def buckets = []
     numBuckets.times { buckets.add(start.millis + (it * bucketSize)) }
 
-    def response = hawkularMetrics.post(path: "gauges/data", body: [
+    def response = hawkularMetrics.post(path: "gauges/raw", body: [
         [id: 'test',
          data: [
             [timestamp: buckets[0], value: 12.22],
@@ -109,7 +109,7 @@ class CassandraBackendITest extends RESTTest {
         ]]], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: "gauges/$metric/data",
+    response = hawkularMetrics.get(path: "gauges/$metric/raw",
         query: [start: start.minusHours(12).millis, end: end.minusHours(11).millis], headers: [(tenantHeaderName): tenantId])
     assertEquals("Expected a 204 status code when there is no gauge data", 204, response.status)
   }
@@ -121,7 +121,7 @@ class CassandraBackendITest extends RESTTest {
     String tenantId = nextTenantId()
     String metric = "n1"
 
-    def response = hawkularMetrics.post(path: "gauges/$metric/data", body: [
+    def response = hawkularMetrics.post(path: "gauges/$metric/raw", body: [
         [timestamp: start.millis, value: 22.3],
         [timestamp: start.plusMinutes(1).millis, value: 17.4],
         [timestamp: start.plusMinutes(2).millis, value: 16.6],
@@ -219,7 +219,7 @@ class CassandraBackendITest extends RESTTest {
     assertEquals(201, response.status)
     assertEquals("http://$baseURI/gauges/m2".toString(), response.getFirstHeader('location').value)
 
-    response = hawkularMetrics.post(path: "gauges/data", body: [
+    response = hawkularMetrics.post(path: "gauges/raw", body: [
         [
             id: 'm1',
             data: [
@@ -244,7 +244,7 @@ class CassandraBackendITest extends RESTTest {
     ], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: "gauges/m2/data", headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "gauges/m2/raw", headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -277,7 +277,7 @@ class CassandraBackendITest extends RESTTest {
         response.getFirstHeader('location').value
     )
 
-    response = hawkularMetrics.post(path: "availability/data", body: [
+    response = hawkularMetrics.post(path: "availability/raw", body: [
         [
             id: 'm1',
             data: [
@@ -302,7 +302,7 @@ class CassandraBackendITest extends RESTTest {
     ], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: "availability/m2/data", headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/m2/raw", headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -319,7 +319,7 @@ class CassandraBackendITest extends RESTTest {
     String tenantId = nextTenantId()
     String metric = 'A1'
 
-    def response = hawkularMetrics.post(path: "availability/$metric/data", body: [
+    def response = hawkularMetrics.post(path: "availability/$metric/raw", body: [
         [timestamp: start.millis, value: "up"],
         [timestamp: start.plusMinutes(1).millis, value: "up"],
         [timestamp: start.plusMinutes(2).millis, value: "down"],
@@ -336,7 +336,7 @@ class CassandraBackendITest extends RESTTest {
     ], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: "availability/$metric/data", query: [distinct: "true"], headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [distinct: "true"], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -351,7 +351,7 @@ class CassandraBackendITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: "availability/$metric/data", query: [distinct: "true", order: "ASC"], headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [distinct: "true", order: "ASC"], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -366,7 +366,7 @@ class CassandraBackendITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: "availability/$metric/data", query: [distinct: "true", limit: 2], headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [distinct: "true", limit: 2], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -376,7 +376,7 @@ class CassandraBackendITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: "availability/$metric/data", query: [limit: 3], headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [limit: 3], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -387,7 +387,7 @@ class CassandraBackendITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: "availability/$metric/data", query: [limit: 3, end: start.plusMinutes(14).millis], headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [limit: 3, end: start.plusMinutes(14).millis], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -398,7 +398,7 @@ class CassandraBackendITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: "availability/$metric/data",
+    response = hawkularMetrics.get(path: "availability/$metric/raw",
       query: [limit: 3, start: start.plusMinutes(4).millis, order: "DESC"],
       headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
@@ -411,7 +411,7 @@ class CassandraBackendITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: "availability/$metric/data", query: [limit: 4, order: "ASC"], headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [limit: 4, order: "ASC"], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -423,7 +423,7 @@ class CassandraBackendITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: "availability/$metric/data", query: [limit: 4, start: (start.millis - 1)], headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [limit: 4, start: (start.millis - 1)], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -467,7 +467,7 @@ class CassandraBackendITest extends RESTTest {
     def tenantId = nextTenantId()
 
     // First create a couple gauge metrics by only inserting data
-    def response = hawkularMetrics.post(path: "gauges/data", body: [
+    def response = hawkularMetrics.post(path: "gauges/raw", body: [
         [
             id: 'm11',
             data: [
@@ -507,7 +507,7 @@ class CassandraBackendITest extends RESTTest {
     )
 
     // Create a couple availability metrics by only inserting data
-    response = hawkularMetrics.post(path: "availability/data", body: [
+    response = hawkularMetrics.post(path: "availability/raw", body: [
         [
             id: 'm14',
             data: [

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -547,7 +547,7 @@ class CountersITest extends RESTTest {
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/rate/raw",
+        path: "counters/$counter/rate",
         headers: [(tenantHeaderName): tenantId],
         query: [start: 0]
     )
@@ -602,7 +602,7 @@ Actual:   ${response.data}
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/rate/raw",
+        path: "counters/$counter/rate",
         headers: [(tenantHeaderName): tenantId],
         query: [start: 0]
     )

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -547,7 +547,7 @@ class CountersITest extends RESTTest {
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/rate",
+        path: "counters/$counter/rate/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [start: 0]
     )
@@ -602,7 +602,7 @@ Actual:   ${response.data}
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/rate",
+        path: "counters/$counter/rate/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [start: 0]
     )
@@ -655,7 +655,7 @@ Actual:   ${response.data}
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/rate",
+        path: "counters/$counter/rate/stats",
         headers: [(tenantHeaderName): tenantId],
         query: [start: 60_000, end: 60_000 * 8, bucketDuration: '1mn']
     )
@@ -846,7 +846,7 @@ Actual:   ${response.data}
 
     //Get counter rates
     response = hawkularMetrics.get(
-        path: 'counters/C1/rate',
+        path: 'counters/C1/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -857,7 +857,7 @@ Actual:   ${response.data}
     def c1Rates = response.data[0];
 
     response = hawkularMetrics.get(
-        path: 'counters/C2/rate',
+        path: 'counters/C2/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -987,7 +987,7 @@ Actual:   ${response.data}
 
     //Get counter rates
     response = hawkularMetrics.get(
-        path: 'counters/C1/rate',
+        path: 'counters/C1/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -998,7 +998,7 @@ Actual:   ${response.data}
     def c1Rates = response.data[0];
 
     response = hawkularMetrics.get(
-        path: 'counters/C2/rate',
+        path: 'counters/C2/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1132,7 +1132,7 @@ Actual:   ${response.data}
 
     //Get counter rates
     response = hawkularMetrics.get(
-        path: 'counters/C1/rate',
+        path: 'counters/C1/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1143,7 +1143,7 @@ Actual:   ${response.data}
     def c1Rates = response.data[0];
 
     response = hawkularMetrics.get(
-        path: 'counters/C2/rate',
+        path: 'counters/C2/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1155,7 +1155,7 @@ Actual:   ${response.data}
 
     //Tests start here
     response = hawkularMetrics.get(
-        path: 'counters/rate',
+        path: 'counters/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1180,7 +1180,7 @@ Actual:   ${response.data}
     assertTrue("Expected the [median] property to be set", actualCounterRateBucketByTag.median != null)
 
     response = hawkularMetrics.get(
-        path: 'counters/rate',
+        path: 'counters/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1281,7 +1281,7 @@ Actual:   ${response.data}
 
     //Get counter rates
     response = hawkularMetrics.get(
-        path: 'counters/C1/rate',
+        path: 'counters/C1/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1292,7 +1292,7 @@ Actual:   ${response.data}
     def c1Rates = response.data[0];
 
     response = hawkularMetrics.get(
-        path: 'counters/C2/rate',
+        path: 'counters/C2/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1304,7 +1304,7 @@ Actual:   ${response.data}
 
     //Tests start here
     response = hawkularMetrics.get(
-        path: 'counters/rate',
+        path: 'counters/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1329,7 +1329,7 @@ Actual:   ${response.data}
     assertTrue("Expected the [median] property to be set", actualCounterRateBucketByTag.median != null)
 
     response = hawkularMetrics.get(
-        path: 'counters/rate',
+        path: 'counters/rate/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -34,7 +34,7 @@ class CountersITest extends RESTTest {
 
   @Test
   void shouldNotAcceptInvalidTimeRange() {
-    badGet(path: "counters/test/data", headers: [(tenantHeaderName): tenantId],
+    badGet(path: "counters/test/raw", headers: [(tenantHeaderName): tenantId],
         query: [start: 1000, end: 500]) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -42,7 +42,7 @@ class CountersITest extends RESTTest {
 
   @Test
   void shouldNotAcceptInvalidBucketConfig() {
-    badGet(path: "counters/test/data", headers: [(tenantHeaderName): tenantId],
+    badGet(path: "counters/test/raw", headers: [(tenantHeaderName): tenantId],
         query: [start: 500, end: 100, buckets: '10', bucketDuration: '10ms']) { exception ->
       assertEquals("Should fail when both bucket params are specified", 400, exception.response.status)
     }
@@ -57,12 +57,12 @@ class CountersITest extends RESTTest {
 
   @Test
   void shouldNotAddDataForCounterWithEmptyPayload() {
-    badPost(path: "counters/pimpo/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "counters/pimpo/raw", headers: [(tenantHeaderName): tenantId],
         body: "" /* Empty Body */) { exception ->
       assertEquals(400, exception.response.status)
     }
 
-    badPost(path: "counters/pimpo/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "counters/pimpo/raw", headers: [(tenantHeaderName): tenantId],
         body: [] /* Empty List */) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -70,12 +70,12 @@ class CountersITest extends RESTTest {
 
   @Test
   void shouldNotAddDataWithEmptyPayload() {
-    badPost(path: "counters/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "counters/raw", headers: [(tenantHeaderName): tenantId],
         body: "" /* Empty Body */) { exception ->
       assertEquals(400, exception.response.status)
     }
 
-    badPost(path: "counters/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "counters/raw", headers: [(tenantHeaderName): tenantId],
         body: [] /* Empty List */) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -201,7 +201,7 @@ class CountersITest extends RESTTest {
     DateTime start = now().minusMinutes(5)
 
     def response = hawkularMetrics.post(
-        path: "counters/data",
+        path: "counters/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [
@@ -224,7 +224,7 @@ class CountersITest extends RESTTest {
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter1/data",
+        path: "counters/$counter1/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [start: start.millis, end: start.plusMinutes(1).millis]
     )
@@ -236,7 +236,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter2/data",
+        path: "counters/$counter2/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [start: start.millis, end: start.plusMinutes(2).millis]
     )
@@ -255,7 +255,7 @@ class CountersITest extends RESTTest {
     DateTime start = now().minusHours(8)
 
     def response = hawkularMetrics.post(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: start.millis, value: 100],
@@ -267,7 +267,7 @@ class CountersITest extends RESTTest {
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
     )
     assertEquals(200, response.status)
@@ -285,7 +285,7 @@ class CountersITest extends RESTTest {
     DateTime start = now().minusHours(1)
 
     def response = hawkularMetrics.post(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: start.millis, value: 100],
@@ -300,7 +300,7 @@ class CountersITest extends RESTTest {
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 2]
     )
@@ -313,7 +313,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 2, order: "DESC"]
     )
@@ -326,7 +326,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 3, order: "ASC"]
     )
@@ -340,7 +340,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 3, start: start.plusMinutes(1).millis]
     )
@@ -354,7 +354,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 3, end: (start.plusMinutes(5).millis + 1)]
     )
@@ -368,7 +368,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 3, start: (start.plusMinutes(1).millis - 1), order: "DESC"]
     )
@@ -382,7 +382,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: -1, order: "DESC"]
     )
@@ -399,7 +399,7 @@ class CountersITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: -100, order: "ASC"]
     )
@@ -423,7 +423,7 @@ class CountersITest extends RESTTest {
     DateTime start = now().minusHours(3)
 
     def response = hawkularMetrics.post(
-        path: "counters/data",
+        path: "counters/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [
@@ -440,7 +440,7 @@ class CountersITest extends RESTTest {
     // First query a counter that has data but outside of the date range for which data
     // points are available
     response = hawkularMetrics.get(
-        path: "counters/$counter1/data",
+        path: "counters/$counter1/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [start: start.minusHours(5).millis, end: start.minusHours(4).millis]
     )
@@ -448,7 +448,7 @@ class CountersITest extends RESTTest {
 
     // Now query a counter that has no dat at all
     response = hawkularMetrics.get(
-        path: "counters/$counter2/data",
+        path: "counters/$counter2/raw",
         headers: [(tenantHeaderName): tenantId]
     )
     assertEquals(204, response.status)
@@ -466,7 +466,7 @@ class CountersITest extends RESTTest {
     assertEquals(201, response.status)
 
     response = hawkularMetrics.post(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: 60_000 * 1.0, value: 0],
@@ -480,7 +480,7 @@ class CountersITest extends RESTTest {
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "counters/$counter/data",
+        path: "counters/$counter/stats",
         headers: [(tenantHeaderName): tenantId],
         query: [start: 60_000, end: 60_000 * 8, bucketDuration: '1mn']
     )
@@ -533,7 +533,7 @@ class CountersITest extends RESTTest {
     assertEquals(201, response.status)
 
     response = hawkularMetrics.post(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: 60_000 * 1.0, value: 0],
@@ -585,7 +585,7 @@ Actual:   ${response.data}
     assertEquals(201, response.status)
 
     response = hawkularMetrics.post(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: 60_000 * 1.0, value: 1],
@@ -641,7 +641,7 @@ Actual:   ${response.data}
     assertEquals(201, response.status)
 
     response = hawkularMetrics.post(
-        path: "counters/$counter/data",
+        path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: 60_000 * 1.0, value: 0],
@@ -744,7 +744,7 @@ Actual:   ${response.data}
       assertEquals(201, response.status)
 
       response = hawkularMetrics.post(
-          path: "counters/$counter/data",
+          path: "counters/$counter/raw",
           headers: [(tenantHeaderName): tenantId],
           body: [
               [timestamp: 60_000 * 1.0, value: 0],
@@ -758,7 +758,7 @@ Actual:   ${response.data}
       assertEquals(200, response.status)
 
       response = hawkularMetrics.get(
-          path: "counters/$counter/data",
+          path: "counters/$counter/stats",
           headers: [(tenantHeaderName): tenantId],
           query: [start: 60_000, end: 60_000 * 8, buckets: '1', percentiles: '50.0,90.0,99.9']
       )
@@ -818,7 +818,7 @@ Actual:   ${response.data}
     ]
 
     // insert data points
-    response = hawkularMetrics.post(path: "counters/data", body: [
+    response = hawkularMetrics.post(path: "counters/raw", body: [
         [
             id: 'C1',
             data: c1
@@ -869,7 +869,7 @@ Actual:   ${response.data}
 
     //Tests start here
     response = hawkularMetrics.get(
-        path: 'counters/data',
+        path: 'counters/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -894,7 +894,7 @@ Actual:   ${response.data}
     assertTrue("Expected the [median] property to be set", actualCounterBucketByTag.median != null)
 
     response = hawkularMetrics.get(
-        path: 'counters/data',
+        path: 'counters/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -959,7 +959,7 @@ Actual:   ${response.data}
     ]
 
     // insert data points
-    response = hawkularMetrics.post(path: "counters/data", body: [
+    response = hawkularMetrics.post(path: "counters/raw", body: [
         [
             id: 'C1',
             data: c1
@@ -1010,7 +1010,7 @@ Actual:   ${response.data}
 
     //Tests start here
     response = hawkularMetrics.get(
-        path: 'counters/data',
+        path: 'counters/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1034,7 +1034,7 @@ Actual:   ${response.data}
     assertTrue("Expected the [median] property to be set", expectedSimpleCounterBucketByTag.median != null)
 
     response = hawkularMetrics.get(
-        path: 'counters/data',
+        path: 'counters/stats',
         query: [
             start: start.millis,
             end: start.plusMinutes(4).millis,
@@ -1104,7 +1104,7 @@ Actual:   ${response.data}
     ]
 
     // insert data points
-    response = hawkularMetrics.post(path: "counters/data", body: [
+    response = hawkularMetrics.post(path: "counters/raw", body: [
         [
             id: 'C1',
             data: c1
@@ -1253,7 +1253,7 @@ Actual:   ${response.data}
     ]
 
     // insert data points
-    response = hawkularMetrics.post(path: "counters/data", body: [
+    response = hawkularMetrics.post(path: "counters/raw", body: [
         [
             id: 'C1',
             data: c1
@@ -1366,17 +1366,17 @@ Actual:   ${response.data}
     ], headers: [(tenantHeaderName): tenantId])
     assertEquals(201, response.status)
 
-    response = hawkularMetrics.post(path: "counters/$metric/data", body: [
+    response = hawkularMetrics.post(path: "counters/$metric/raw", body: [
         [timestamp: new DateTimeService().currentHour().minusHours(2).millis, value: 2]
     ], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.post(path: "counters/$metric/data", body: [
+    response = hawkularMetrics.post(path: "counters/$metric/raw", body: [
         [timestamp: new DateTimeService().currentHour().minusHours(3).millis, value: 3]
     ], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: "counters/$metric/data",
+    response = hawkularMetrics.get(path: "counters/$metric/stats",
         query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])
 
     assertEquals(200, response.status)
@@ -1399,34 +1399,20 @@ Actual:   ${response.data}
     ], headers: [(tenantHeaderName): tenantId])
     assertEquals(201, response.status)
 
-    response = hawkularMetrics.get(path: "counters/$metric/data",
+    response = hawkularMetrics.get(path: "counters/$metric/stats",
       query: [start: 1, end: now().millis, bucketDuration: "1000d"], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
 
-    badGet(path: "counters/$metric/data",
+    badGet(path: "counters/$metric/stats",
         query: [fromEarliest: "true", bucketDuration: "a"], headers: [(tenantHeaderName): tenantId]) {
         exception ->
           assertEquals(400, exception.response.status)
     }
 
-    response = hawkularMetrics.get(path: "counters/$metric/data",
+    response = hawkularMetrics.get(path: "counters/$metric/stats",
         query: [fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId])
     assertEquals(204, response.status)
     assertEquals(null, response.data)
-
-    badGet(path: "counters/$metric/data",
-      query: [fromEarliest: "true"], headers: [(tenantHeaderName): tenantId]) {
-      exception ->
-        // From earliest works only with buckets
-        assertEquals(400, exception.response.status)
-    }
-
-    badGet(path: "counters/$metric/data",
-      query: [start: 0, end: Long.MAX_VALUE, fromEarliest: "true", bucketDuration: "1h"], headers: [(tenantHeaderName): tenantId]) {
-      exception ->
-        // From earliest works only without start & end
-        assertEquals(400, exception.response.status)
-    }
   }
 
   @Test
@@ -1436,7 +1422,7 @@ Actual:   ${response.data}
     String id = 'C1'
 
     def response = hawkularMetrics.post(
-        path: "counters/$id/data",
+        path: "counters/$id/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [
@@ -1457,7 +1443,7 @@ Actual:   ${response.data}
         ]
     )
     assertEquals(200, response.status)
-    response = hawkularMetrics.get(path: "counters/$id/data", headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "counters/$id/raw", headers: [(tenantHeaderName): tenantId])
     def expectedData = [
         [
             timestamp: start.plusMinutes(3).millis,

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/ErrorsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/ErrorsITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,14 +42,14 @@ class ErrorsITest extends RESTTest {
 
   @Test
   void testNotFoundException() {
-    badGet(path: "gaugesssss/test/data", headers: [(tenantHeaderName): tenantId]) { exception ->
+    badGet(path: "gaugesssss/test/raw", headers: [(tenantHeaderName): tenantId]) { exception ->
       assertEquals(404, exception.response.status)
     }
   }
 
   @Test
   void testNumberFormatException() {
-    badGet(path: "gauges/test/data", headers: [(tenantHeaderName): tenantId],
+    badGet(path: "gauges/test/stats", headers: [(tenantHeaderName): tenantId],
         query: [buckets: 999999999999999999999999]) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -58,7 +58,7 @@ class ErrorsITest extends RESTTest {
   @Test
   void testNotAcceptableException() {
     hawkularMetrics.request(GET) { request ->
-      uri.path = "gauges/test/data"
+      uri.path = "gauges/test/raw"
       headers = [(tenantHeaderName): tenantId, Accept: TEXT]
 
       response.success = { response ->
@@ -74,7 +74,7 @@ class ErrorsITest extends RESTTest {
   @Test
   void testNotSupportedException() {
     hawkularMetrics.request(POST) { request ->
-      uri.path = "gauges/test/data"
+      uri.path = "gauges/test/raw"
       body = ""
       requestContentType = TEXT
       headers = [(tenantHeaderName): tenantId, Accept: JSON]

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
@@ -30,7 +30,7 @@ class GaugesITest extends RESTTest {
 
   @Test
   void shouldNotAcceptInvalidTimeRange() {
-    badGet(path: "gauges/test/data", headers: [(tenantHeaderName): tenantId],
+    badGet(path: "gauges/test/raw", headers: [(tenantHeaderName): tenantId],
         query: [start: 1000, end: 500]) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -38,7 +38,7 @@ class GaugesITest extends RESTTest {
 
   @Test
   void shouldNotAcceptInvalidBucketConfig() {
-    badGet(path: "gauges/test/data", headers: [(tenantHeaderName): tenantId],
+    badGet(path: "gauges/test/stats", headers: [(tenantHeaderName): tenantId],
         query: [start: 500, end: 100, buckets: '10', bucketDuration: '10ms']) { exception ->
       assertEquals("Should fail when both bucket params are specified", 400, exception.response.status)
     }
@@ -53,12 +53,12 @@ class GaugesITest extends RESTTest {
 
   @Test
   void shouldNotAddDataForMetricWithEmptyPayload() {
-    badPost(path: "gauges/pimpo/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "gauges/pimpo/raw", headers: [(tenantHeaderName): tenantId],
         body: "" /* Empty Body */) { exception ->
       assertEquals(400, exception.response.status)
     }
 
-    badPost(path: "gauges/pimpo/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "gauges/pimpo/raw", headers: [(tenantHeaderName): tenantId],
         body: [] /* Empty List */) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -66,12 +66,12 @@ class GaugesITest extends RESTTest {
 
   @Test
   void shouldNotAddGaugeDataWithEmptyPayload() {
-    badPost(path: "gauges/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "gauges/raw", headers: [(tenantHeaderName): tenantId],
         body: "" /* Empty Body */) { exception ->
       assertEquals(400, exception.response.status)
     }
 
-    badPost(path: "gauges/data", headers: [(tenantHeaderName): tenantId],
+    badPost(path: "gauges/raw", headers: [(tenantHeaderName): tenantId],
         body: [] /* Empty List */) { exception ->
       assertEquals(400, exception.response.status)
     }
@@ -118,7 +118,7 @@ class GaugesITest extends RESTTest {
     DateTime start = now().minusHours(1)
 
     def response = hawkularMetrics.post(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: start.millis, value: 100.1],
@@ -133,7 +133,7 @@ class GaugesITest extends RESTTest {
     assertEquals(200, response.status)
 
     response = hawkularMetrics.get(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 2]
     )
@@ -146,7 +146,7 @@ class GaugesITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 2, order: "DESC"]
     )
@@ -159,7 +159,7 @@ class GaugesITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 3, order: "ASC"]
     )
@@ -173,7 +173,7 @@ class GaugesITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 3, start: start.plusMinutes(1).millis]
     )
@@ -187,7 +187,7 @@ class GaugesITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 3, end: (start.plusMinutes(5).millis + 1)]
     )
@@ -201,7 +201,7 @@ class GaugesITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: 3, start: (start.plusMinutes(1).millis - 1), order: "DESC"]
     )
@@ -215,7 +215,7 @@ class GaugesITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: -1, order: "DESC"]
     )
@@ -232,7 +232,7 @@ class GaugesITest extends RESTTest {
     assertEquals(expectedData, response.data)
 
     response = hawkularMetrics.get(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         query: [limit: -100, order: "ASC"]
     )
@@ -257,7 +257,7 @@ class GaugesITest extends RESTTest {
     String gauge = 'G1'
 
     def response = hawkularMetrics.post(
-        path: "gauges/$gauge/data",
+        path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [
@@ -278,7 +278,7 @@ class GaugesITest extends RESTTest {
         ]
     )
     assertEquals(200, response.status)
-    response = hawkularMetrics.get(path: "gauges/$gauge/data", headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "gauges/$gauge/raw", headers: [(tenantHeaderName): tenantId])
     def expectedData = [
         [
             timestamp: start.plusMinutes(3).millis,

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
@@ -88,7 +88,7 @@ class MetricsITest extends RESTTest {
     )
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: 'gauges/G1/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'gauges/G1/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -98,7 +98,7 @@ class MetricsITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: 'gauges/G2/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'gauges/G2/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -108,7 +108,7 @@ class MetricsITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: 'counters/C1/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'counters/C1/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -118,7 +118,7 @@ class MetricsITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: 'counters/C2/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'counters/C2/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -129,7 +129,7 @@ class MetricsITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: 'availability/A1/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'availability/A1/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -139,7 +139,7 @@ class MetricsITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: 'availability/A2/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'availability/A2/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -181,7 +181,7 @@ class MetricsITest extends RESTTest {
     )
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: 'counters/GC1/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'counters/GC1/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -191,7 +191,7 @@ class MetricsITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: 'availability/GA1/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'availability/GA1/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -234,7 +234,7 @@ class MetricsITest extends RESTTest {
     assertEquals(200, response.status)
 
 
-    response = hawkularMetrics.get(path: 'gauges/CG1/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'gauges/CG1/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -244,7 +244,7 @@ class MetricsITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: 'availability/CA1/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'availability/CA1/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -286,7 +286,7 @@ class MetricsITest extends RESTTest {
     )
     assertEquals(200, response.status)
 
-    response = hawkularMetrics.get(path: 'gauges/AG1/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'gauges/AG1/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -296,7 +296,7 @@ class MetricsITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: 'counters/AC1/data', headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: 'counters/AC1/raw', headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -132,18 +132,18 @@ ${entity}
     for (i in 0..LARGE_PAYLOAD_SIZE + 10) {
       pointGen(points, i)
     }
-    def response = hawkularMetrics.post(path: "${pathBase}/test/data", headers: [(tenantHeaderName): tenantId],
+    def response = hawkularMetrics.post(path: "${pathBase}/test/raw", headers: [(tenantHeaderName): tenantId],
         body: points)
     assertEquals(200, response.status)
   }
 
   static void invalidPointCheck(String pathBase, String tenantId, def data) {
-    badPost(path: "${pathBase}/data", headers: [(tenantHeaderName): tenantId], body: [
+    badPost(path: "${pathBase}/raw", headers: [(tenantHeaderName): tenantId], body: [
         [id: 'metric', data: data]
     ]) { exception ->
       assertEquals(400, exception.response.status)
     }
-    badPost(path: "${pathBase}/metric/data", headers: [(tenantHeaderName): tenantId], body: data) { exception ->
+    badPost(path: "${pathBase}/metric/raw", headers: [(tenantHeaderName): tenantId], body: data) { exception ->
       assertEquals(400, exception.response.status)
     }
   }


### PR DESCRIPTION
/data endpoint became too complex to maintain since it was serving two purposes (retrieve raw and statistical data). This is also confusing to users because the decision as to what data to return was made at runtime based on the parameters.

Here are the changes in this commit:
- all /data APIs have been deprecated
- POST /data has been moved to POST /raw
- GET $id/data has been split into two
  - $id/raw - to retrieve raw data
  - $id/stats - to retrieve bucketed/statistical data
- Documentation for deprecated APIs has been updated to point to the new APIs.