### PR TITLE
[BZ 1316275] add support for altering gc_grace_seconds in data table

### DIFF
--- a/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-common/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,8 @@ public enum ConfigurationKey {
     CASSANDRA_USESSL("hawkular-metrics.cassandra-use-ssl", "false", "CASSANDRA_USESSL", false),
     WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
     USE_VIRTUAL_CLOCK("hawkular.metrics.use-virtual-clock", "false", "USE_VIRTUAL_CLOCK", false),
-    DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false);
+    DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false),
+    DATA_GC_GRACE_SECONDS("hawkular.metrics.data.gc-grace-seconds", "86400", "DATA_GC_GRACE_SECONDS", false);
 
     private final String name;
     private final String env;


### PR DESCRIPTION
A new config property has been added. It is called DATA_GC_GRACE_SECONDS. At start up we query the system tables to get the current value of gc_grace_seconds for the data table. If the current value does not match the config value, which defaults to 1 day, we update gc_grace_seconds.