### PR TITLE
[HWKMETRICS-24] Migrate the mixed metrics insertion POST to /raw.

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -160,8 +160,18 @@ public class MetricHandler {
                 });
     }
 
+    @Deprecated
     @POST
     @Path("/data")
+    @ApiOperation(value = "Deprecated. Please use /raw endpoint.")
+    public void deprecatedAddMetricsData(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "List of metrics", required = true) MixedMetricsRequest metricsRequest) {
+        addMetricsData(asyncResponse, metricsRequest);
+    }
+
+    @POST
+    @Path("/raw")
     @ApiOperation(value = "Add data points for multiple metrics in a single call.")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Adding data points succeeded."),

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
@@ -63,7 +63,7 @@ class CORSITest extends RESTTest {
 
   @Test
   void testOptionsWithBadOrigin() {
-    def response = hawkularMetrics.options(path: "gauges/test/data",
+    def response = hawkularMetrics.options(path: "gauges/test/raw",
         headers: [
             (ACCESS_CONTROL_REQUEST_METHOD): "OPTIONS",
             (ORIGIN): "*"
@@ -74,7 +74,7 @@ class CORSITest extends RESTTest {
     assertEquals(400, response.status)
 
     def wrongSchemeOrigin = testOrigin.replaceAll("http://", "https://")
-    response = hawkularMetrics.options(path: "gauges/test/data",
+    response = hawkularMetrics.options(path: "gauges/test/raw",
         headers: [
             (ACCESS_CONTROL_REQUEST_METHOD): "GET",
             (ORIGIN): wrongSchemeOrigin
@@ -89,7 +89,7 @@ class CORSITest extends RESTTest {
   void testOptionsWithSubdomainOrigin() {
     //construct a subdomain with "tester." as prefix
     def subDomainOrigin = testOrigin.substring(0, testOrigin.indexOf("/") + 2) + "tester." + testOrigin.substring(testOrigin.indexOf("/") + 2)
-    def response = hawkularMetrics.options(path: "gauges/test/data",
+    def response = hawkularMetrics.options(path: "gauges/test/raw",
         headers: [
             (ACCESS_CONTROL_REQUEST_METHOD): "GET",
             (ORIGIN): subDomainOrigin

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
@@ -32,7 +32,7 @@ class MetricsITest extends RESTTest {
     DateTime start = DateTime.now().minusMinutes(10)
 
     def response = hawkularMetrics.post(
-        path: "metrics/data",
+        path: "metrics/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             gauges: [
@@ -156,7 +156,7 @@ class MetricsITest extends RESTTest {
     DateTime start = DateTime.now().minusMinutes(10)
 
     def response = hawkularMetrics.post(
-        path: "metrics/data",
+        path: "metrics/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             counters: [
@@ -208,7 +208,7 @@ class MetricsITest extends RESTTest {
     DateTime start = DateTime.now().minusMinutes(10)
 
     def response = hawkularMetrics.post(
-        path: "metrics/data",
+        path: "metrics/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             gauges: [
@@ -261,7 +261,7 @@ class MetricsITest extends RESTTest {
     DateTime start = DateTime.now().minusMinutes(10)
 
     def response = hawkularMetrics.post(
-        path: "metrics/data",
+        path: "metrics/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             gauges: [
@@ -311,7 +311,7 @@ class MetricsITest extends RESTTest {
   void addMixedDataInvalidRequestPayload() {
     String tenantId = nextTenantId()
 
-    badPost( path: "metrics/data",
+    badPost( path: "metrics/raw",
         body: [],
         headers: [(tenantHeaderName): tenantId]) { exception ->
       // Missing type
@@ -323,7 +323,7 @@ class MetricsITest extends RESTTest {
   void addMixedDataMissingRequestPayload() {
     String tenantId = nextTenantId()
 
-    badPost( path: "metrics/data",
+    badPost( path: "metrics/raw",
         body: "",
         headers: [(tenantHeaderName): tenantId]) { exception ->
       // Missing type
@@ -335,7 +335,7 @@ class MetricsITest extends RESTTest {
   void addMixedDataEmptyRequestPayload() {
     String tenantId = nextTenantId()
 
-    badPost( path: "metrics/data",
+    badPost( path: "metrics/raw",
         body: new HashMap(),
         headers: [(tenantHeaderName): tenantId]) { exception ->
       // Missing type
@@ -347,7 +347,7 @@ class MetricsITest extends RESTTest {
   void addMixedDataMissingData() {
     String tenantId = nextTenantId()
 
-    badPost( path: "metrics/data",
+    badPost( path: "metrics/raw",
         body: [
          gauges: [
          ],

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TenantITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TenantITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,7 +91,7 @@ class TenantITest extends RESTTest {
     DateTime start = dateTimeService.getTimeSlice(getTime(), standardMinutes(1))
 
     def response = hawkularMetrics.post(
-        path: "gauges/G1/data",
+        path: "gauges/G1/raw",
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: start.minusMinutes(1).millis, value: 3.14]
@@ -115,7 +115,7 @@ class TenantITest extends RESTTest {
     DateTime start = dateTimeService.getTimeSlice(getTime(), standardMinutes(1))
 
     def response = hawkularMetrics.post(
-        path: 'counters/C1/data',
+        path: 'counters/C1/raw',
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: start.minusMinutes(1).millis, value: 100]
@@ -139,7 +139,7 @@ class TenantITest extends RESTTest {
     DateTime start = dateTimeService.getTimeSlice(getTime(), standardMinutes(1))
 
     def response = hawkularMetrics.post(
-        path: 'availability/A1/data',
+        path: 'availability/A1/raw',
         headers: [(tenantHeaderName): tenantId],
         body: [
             [timestamp: start.minusMinutes(1).millis, value: 'up']


### PR DESCRIPTION
This is the last '/data' endpoint that was not updated to the new '/raw' & '/stats' model.