### PR TITLE
[HWKMETRICS-197] Add ability to fetch tag values

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -168,6 +168,22 @@ public class AvailabilityHandler {
     }
 
     @GET
+    @Path("/tags/{tags}")
+    @ApiOperation(value = "Retrieve gauge type's tag values", response = Map.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Tags successfully retrieved."),
+            @ApiResponse(code = 204, message = "No matching tags were found"),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching tags.",
+                    response = ApiError.class)
+    })
+    public void getTags(@Suspended final AsyncResponse asyncResponse,
+                        @ApiParam("Tag query") @PathParam("tags") Tags tags) {
+        metricsService.getTagValues(tenantId, AVAILABILITY, tags.getTags())
+                .map(ApiUtils::mapToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
+    }
+
+    @GET
     @Path("/{id}/tags")
     @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = String.class,
                   responseContainer = "Map")

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -173,6 +173,22 @@ public class CounterHandler {
     }
 
     @GET
+    @Path("/tags/{tags}")
+    @ApiOperation(value = "Retrieve gauge type's tag values", response = Map.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Tags successfully retrieved."),
+            @ApiResponse(code = 204, message = "No matching tags were found"),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching tags.",
+                    response = ApiError.class)
+    })
+    public void getTags(@Suspended final AsyncResponse asyncResponse,
+                        @ApiParam("Tag query") @PathParam("tags") Tags tags) {
+        metricsService.getTagValues(tenantId, COUNTER, tags.getTags())
+                .map(ApiUtils::mapToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
+    }
+
+    @GET
     @Path("/{id}/tags")
     @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Map.class)
     @ApiResponses(value = {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -168,6 +168,22 @@ public class GaugeHandler {
     }
 
     @GET
+    @Path("/tags/{tags}")
+    @ApiOperation(value = "Retrieve gauge type's tag values", response = Map.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Tags successfully retrieved."),
+            @ApiResponse(code = 204, message = "No matching tags were found"),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching tags.",
+                    response = ApiError.class)
+    })
+    public void getTags(@Suspended final AsyncResponse asyncResponse,
+                        @ApiParam("Tag query") @PathParam("tags") Tags tags) {
+        metricsService.getTagValues(tenantId, GAUGE, tags.getTags())
+                .map(ApiUtils::mapToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
+    }
+
+    @GET
     @Path("/{id}/tags")
     @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Map.class)
     @ApiResponses(value = {

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -18,6 +18,7 @@ package org.hawkular.metrics.core.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.hawkular.metrics.model.AvailabilityBucketPoint;
@@ -116,6 +117,17 @@ public interface MetricsService {
      */
     <T> Observable<Metric<T>> findMetricsWithFilters(String tenantId, MetricType<T> type, Map<String, String>
             tagsQueries, Func1<Metric<T>, Boolean>... filters);
+
+    /**
+     * Returns distinct tag values for a given tag query (using the same query format as findMetricsWithFilters).
+     *
+     * @param tenantId
+     * @param metricType If type is null, no type filtering is used (values are merged)
+     * @param tagsQueries If tagsQueries is empty, empty Observable is returned
+     * @return A map with key as the tagname and set of possible values restricted by the query
+     */
+    Observable<Map<String, Set<String>>> getTagValues(String tenantId, MetricType<?> metricType,
+                                                             Map<String, String> tagsQueries);
 
     Observable<Map<String, String>> getMetricTags(MetricId<?> id);
 

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/MetricsServiceITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/MetricsServiceITest.java
@@ -272,11 +272,7 @@ public class MetricsServiceITest extends MetricsITest {
         ));
     }
 
-    @Test
-    public void createAndFindMetricsWithTags() throws Exception {
-
-        String tenantId = "t1";
-
+    private List<Metric> createTagMetrics(String tenantId) throws Exception {
         ImmutableList<MetricId> ids = ImmutableList.of(
                 new MetricId<>(tenantId, GAUGE, "m1"),
                 new MetricId<>(tenantId, GAUGE, "m2"),
@@ -292,7 +288,7 @@ public class MetricsServiceITest extends MetricsITest {
                 new MetricId<>(tenantId, GAUGE, "mF"),
                 new MetricId<>(tenantId, GAUGE, "mG"),
                 new MetricId<>(tenantId, AVAILABILITY, "a1")
-                );
+        );
         ImmutableList<ImmutableMap<String, String>> maps = ImmutableList.of(
                 ImmutableMap.of("a1", "1"),
                 ImmutableMap.of("a1", "2", "a3", "3"),
@@ -308,7 +304,7 @@ public class MetricsServiceITest extends MetricsITest {
                 ImmutableMap.of("owner", "hades"),
                 ImmutableMap.of("owner", "had"),
                 ImmutableMap.of("a1","4")
-                );
+        );
         assertEquals(ids.size(), maps.size(), "ids' size should equal to maps' size");
 
         // Create the gauges
@@ -320,86 +316,129 @@ public class MetricsServiceITest extends MetricsITest {
         // Insert gauges
         Observable.from(metricsToAdd).subscribe(m -> metricsService.createMetric(m).toBlocking().lastOrDefault(null));
 
+        return metricsToAdd;
+    }
+
+    @Test
+    public void createAndFindMetricsWithTags() throws Exception {
+
+        String tenantId = "t1";
+
+        List<Metric> metricsToAdd = createTagMetrics(tenantId);
+
         // Check different scenarios..
-        List<Metric<Double>> gauges = metricsService.findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a1", "*"))
+        List<Metric<Double>> gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*"))
                 .toList()
                 .toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 5, "Metrics m1-m5 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a1", "*", "a2", "2"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*", "a2", "2"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 1, "Only metric m3 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a1", "*", "a2", "2|3"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE,
+                ImmutableMap.of("a1", "*", "a2", "2|3")).toList().toBlocking().lastOrDefault(null);
+        assertEquals(gauges.size(), 2, "Metrics m3-m4 should have been returned");
+
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a2", "2|3"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Metrics m3-m4 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a2", "2|3"))
-                .toList().toBlocking().lastOrDefault(null);
-        assertEquals(gauges.size(), 2, "Metrics m3-m4 should have been returned");
-
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a1", "*", "a2", "*"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*", "a2", "*"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 3, "Metrics m3-m5 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a1", "*", "a5", "*"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*", "a5", "*"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 0, "No gauges should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a4", "*", "a5", "none"))
-                .toList().toBlocking().lastOrDefault(null);
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE,
+                ImmutableMap.of("a4", "*", "a5", "none")).toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 0, "No gauges should have been returned");
 
-        List<Metric<Object>> metrics = metricsService.findMetricsWithFilters("t1", null, ImmutableMap.of("a1", "*"))
+        List<Metric<Object>> metrics = metricsService.findMetricsWithFilters(tenantId, null, ImmutableMap.of("a1", "*"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(metrics.size(), 6, "Metrics m1-m5 and a1 should have been returned");
 
         // Test that we actually get correct gauges also, not just correct size
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a1", "2", "a2", "2"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "2", "a2", "2"))
                 .toList().toBlocking().lastOrDefault(null);
         Metric m3 = metricsToAdd.get(2);
         assertEquals(gauges.size(), 1, "Only metric m3 should have been returned");
         assertEquals(gauges.get(0), m3, "m3 did not match the original inserted metric");
 
         // Test for NOT operator
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a2", "!4"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a2", "!4"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only gauges m3-m4 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE,ImmutableMap.of("a1", "2", "a2", "!4"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE,ImmutableMap.of("a1", "2", "a2", "!4"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only gauges m3-m4 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a2", "!4|3"))
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a2", "!4|3"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 1, "Only gauges m3 should have been returned");
         assertEquals(gauges.get(0), m3, "m3 did not match the original inserted metric");
 
         // What about incorrect query?
         try {
-            metricsService.findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("a2","**"))
+            metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a2","**"))
                     .toList().toBlocking().lastOrDefault(null);
             fail("Should have thrown an PatternSyntaxException");
         } catch (PatternSyntaxException ignored) {
         }
 
         // More regexp tests
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("hostname", "web.*"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("hostname", "web.*"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only websrv01 and websrv02 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("hostname", ".*01"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("hostname", ".*01"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only websrv01 and backend01 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("owner", "h[e|a]de(s?)"))
-                .toList().toBlocking().lastOrDefault(null);
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE,
+                ImmutableMap.of("owner", "h[e|a]de(s?)")).toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Both hede and hades should have been returned, but not 'had'");
 
-        gauges = metricsService.<Double> findMetricsWithFilters("t1", GAUGE, ImmutableMap.of("owner", "h[e|a]de(s?)"),
-                metricsService.idFilter(".F"))
+        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE,
+                ImmutableMap.of("owner", "h[e|a]de(s?)"), metricsService.idFilter(".F"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 1, "Only hades should have been returned");
+    }
+
+    @Test
+    public void tagValueSearch() throws Exception {
+        String tenantId = "t1tag";
+
+        List<Metric> metricsToAdd = createTagMetrics(tenantId);
+
+        // Test only tags value fetching
+        Map<String, Set<String>> tagMap =
+                metricsService.<Double>getTagValues(tenantId, null, ImmutableMap.of("hostname", "*"))
+                        .toBlocking()
+                        .lastOrDefault(null);
+
+        Set<String> hostnameSet = tagMap.get("hostname");
+        assertEquals(hostnameSet.size(), 4, "There should have been 4 hostname tag values");
+
+        tagMap = metricsService.<Double>getTagValues(tenantId, null, ImmutableMap.of("a1", "*", "a2", "*"))
+                .toBlocking()
+                .lastOrDefault(null);
+
+        assertEquals(tagMap.size(), 2, "We should have two keys, a1 and a2");
+        assertEquals(tagMap.get("a1").size(), 1, "a1 should have only one valid value");
+        assertEquals(tagMap.get("a2").size(), 3, "a2 should have three values");
+
+        // Fetch empty
+//        List<Map<String, Set<String>>> d1 =
+//                metricsService.<Double>getTagValues(tenantId, GAUGE, ImmutableMap.of("d1", "B:A"))
+//                        .toList()
+//                        .toBlocking()
+//                        .single();
+//
+//        assertNull(d1);
     }
 
     @Test


### PR DESCRIPTION
This feature adds the ability to fetch only the tag values (ignoring metric definitions) using the same tag-query-language that we have currently in the metric definition fetching.

WIP: Missing REST-tests, I'm suggesting @Path("/tags/{tags}") (for all types separately and then in the metrics for fetching all the metrics)