### PR TITLE
Refactor getMetricTags to remove use of Optional

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -22,7 +22,6 @@ import static org.hawkular.metrics.api.jaxrs.filter.TenantFilter.TENANT_HEADER_N
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.badRequest;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.noContent;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.serverError;
-import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.valueToResponse;
 import static org.hawkular.metrics.model.MetricType.AVAILABILITY;
 
 import java.net.URI;
@@ -181,9 +180,9 @@ public class AvailabilityHandler {
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id
     ) {
-        metricsService.getMetricTags(new MetricId<>(tenantId, AVAILABILITY, id)).subscribe(
-                optional -> asyncResponse.resume(valueToResponse(optional)),
-                t -> asyncResponse.resume(serverError(t)));
+        metricsService.getMetricTags(new MetricId<>(tenantId, AVAILABILITY, id))
+                .map(ApiUtils::mapToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
     }
 
     @PUT

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -22,7 +22,6 @@ import static org.hawkular.metrics.api.jaxrs.filter.TenantFilter.TENANT_HEADER_N
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.badRequest;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.noContent;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.serverError;
-import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.valueToResponse;
 import static org.hawkular.metrics.model.MetricType.COUNTER;
 
 import java.net.URI;
@@ -185,9 +184,8 @@ public class CounterHandler {
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id) {
         metricsService.getMetricTags(new MetricId<>(tenantId, COUNTER, id))
-                .subscribe(
-                        optional -> asyncResponse.resume(valueToResponse(optional)),
-                        t -> asyncResponse.resume(serverError(t)));
+                .map(ApiUtils::mapToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
     }
 
     @PUT

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -180,10 +180,8 @@ public class GaugeHandler {
             @PathParam("id") String id
     ) {
         metricsService.getMetricTags(new MetricId<>(tenantId, GAUGE, id))
-                .subscribe(
-                        optional -> asyncResponse.resume(ApiUtils.valueToResponse(optional)),
-                        t ->asyncResponse.resume(ApiUtils.serverError(t))
-                );
+                .map(ApiUtils::mapToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
     }
 
     @PUT

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/ApiUtils.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/ApiUtils.java
@@ -18,7 +18,6 @@ package org.hawkular.metrics.api.jaxrs.util;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -61,10 +60,6 @@ public class ApiUtils {
 
     public static Response serverError(Throwable t) {
         return serverError(t, "Failed to perform operation due to an error");
-    }
-
-    public static Response valueToResponse(Optional<?> optional) {
-        return optional.map(value -> Response.ok(value).build()).orElse(noContent());
     }
 
     public static Response noContent() {

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -18,7 +18,6 @@ package org.hawkular.metrics.core.service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.hawkular.metrics.model.AvailabilityBucketPoint;
@@ -118,7 +117,7 @@ public interface MetricsService {
     <T> Observable<Metric<T>> findMetricsWithFilters(String tenantId, MetricType<T> type, Map<String, String>
             tagsQueries, Func1<Metric<T>, Boolean>... filters);
 
-    Observable<Optional<Map<String, String>>> getMetricTags(MetricId<?> id);
+    Observable<Map<String, String>> getMetricTags(MetricId<?> id);
 
     Observable<Void> addTags(Metric<?> metric, Map<String, String> tags);
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -32,10 +32,10 @@ import static org.hawkular.metrics.model.Utils.isValidTimeRange;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -509,11 +509,11 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    public Observable<Optional<Map<String, String>>> getMetricTags(MetricId<?> id) {
+    public Observable<Map<String, String>> getMetricTags(MetricId<?> id) {
         return dataAccess.getMetricTags(id)
                 .take(1)
-                .map(row -> Optional.of(row.getMap(0, String.class, String.class)))
-                .defaultIfEmpty(Optional.empty());
+                .map(row -> row.getMap(0, String.class, String.class))
+                .defaultIfEmpty(new HashMap<>());
     }
 
     // Adding/deleting metric tags currently involves writing to three tables - data,


### PR DESCRIPTION
The combination of Optional + Observable is useless as there's nothing extra the Optional could present in this case. This removes it and cleans up the code.