### PR TITLE
HWKMETRICS-388 Allow the status page to be loaded over https without errors

### DIFF
--- a/api/metrics-api-jaxrs/src/main/webapp/static/index.html
+++ b/api/metrics-api-jaxrs/src/main/webapp/static/index.html
@@ -19,8 +19,9 @@
 <head>
     <title>Hawkular Metrics</title>
     <link rel="shortcut icon" href="/hawkular/metrics/static/favicon.ico" type="image/x-icon">
-    <link rel="StyleSheet" href="/hawkular/metrics/static/welcome.css" type="text/css">
-    <script src="/hawkular/metrics/static/status.js"></script>
+    <link rel="stylesheet" href="/hawkular/metrics/static/welcome.css" type="text/css">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Exo+2" type="text/css">
+    <script src="/hawkular/metrics/static/status.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/api/metrics-api-jaxrs/src/main/webapp/static/welcome.css
+++ b/api/metrics-api-jaxrs/src/main/webapp/static/welcome.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import url(http://fonts.googleapis.com/css?family=Exo+2);
-
 html {
   width: 100%;
 }
@@ -28,7 +26,7 @@ body {
   margin-left: auto;
   margin-right: auto;
   max-width: 100%;
-  width: 50em
+  width: 50em;
   padding: 1em;
   text-align: center;
 }


### PR DESCRIPTION
Use leading double-slash to inherit the protocol from the webpage

Also, fixed a missing semicolon and removed import from CSS to let the browser load CSS resources in parallel (instead of waiting for the welcome CSS to be loaded).