### PR TITLE
HWKMETRICS-385 Deleting tags should only require the tag keys and not the values

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -228,13 +228,6 @@
           <plugin>
             <groupId>org.codehaus.gmavenplus</groupId>
             <artifactId>gmavenplus-plugin</artifactId>
-            <dependencies>
-              <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <version>${version.org.codehaus.groovy}</version>
-              </dependency>
-            </dependencies>
             <configuration>
               <properties>
                 <baseFile>${restDocDirectory}/base.adoc</baseFile>

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -229,7 +229,8 @@ public class AvailabilityHandler {
     public void deleteMetricTags(
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id,
-            @ApiParam("Tag list") @PathParam("tags") TagNames tags
+            @ApiParam(value = "Tag names", allowableValues = "Comma-separated list of tag names")
+            @PathParam("tags") TagNames tags
     ) {
         Metric<AvailabilityType> metric = new Metric<>(new MetricId<>(tenantId, AVAILABILITY, id));
         metricsService.deleteTags(metric, tags.getNames()).subscribe(new ResultSetObserver(asyncResponse));

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -62,6 +62,7 @@ import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
+import org.hawkular.metrics.model.param.TagNames;
 import org.hawkular.metrics.model.param.Tags;
 import org.hawkular.metrics.model.param.TimeRange;
 
@@ -228,10 +229,10 @@ public class AvailabilityHandler {
     public void deleteMetricTags(
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id,
-            @ApiParam("Tag list") @PathParam("tags") Tags tags
+            @ApiParam("Tag list") @PathParam("tags") TagNames tags
     ) {
         Metric<AvailabilityType> metric = new Metric<>(new MetricId<>(tenantId, AVAILABILITY, id));
-        metricsService.deleteTags(metric, tags.getTags()).subscribe(new ResultSetObserver(asyncResponse));
+        metricsService.deleteTags(metric, tags.getNames()).subscribe(new ResultSetObserver(asyncResponse));
     }
 
     @POST

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -65,6 +65,7 @@ import org.hawkular.metrics.model.exception.RuntimeApiError;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
 import org.hawkular.metrics.model.param.Percentiles;
+import org.hawkular.metrics.model.param.TagNames;
 import org.hawkular.metrics.model.param.Tags;
 import org.hawkular.metrics.model.param.TimeRange;
 
@@ -230,9 +231,9 @@ public class CounterHandler {
     public void deleteMetricTags(
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id,
-            @ApiParam("Tag list") @PathParam("tags") Tags tags) {
+            @ApiParam("Tag list") @PathParam("tags") TagNames tags) {
         Metric<Long> metric = new Metric<>(new MetricId<>(tenantId, COUNTER, id));
-        metricsService.deleteTags(metric, tags.getTags()).subscribe(new ResultSetObserver(asyncResponse));
+        metricsService.deleteTags(metric, tags.getNames()).subscribe(new ResultSetObserver(asyncResponse));
     }
 
     @POST

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -231,7 +231,9 @@ public class CounterHandler {
     public void deleteMetricTags(
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id,
-            @ApiParam("Tag list") @PathParam("tags") TagNames tags) {
+            @ApiParam(value = "Tag names", allowableValues = "Comma-separated list of tag names")
+            @PathParam("tags") TagNames tags
+    ) {
         Metric<Long> metric = new Metric<>(new MetricId<>(tenantId, COUNTER, id));
         metricsService.deleteTags(metric, tags.getNames()).subscribe(new ResultSetObserver(asyncResponse));
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -228,7 +228,8 @@ public class GaugeHandler {
     public void deleteMetricTags(
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id,
-            @ApiParam("Tag list") @PathParam("tags") TagNames tags
+            @ApiParam(value = "Tag names", allowableValues = "Comma-separated list of tag names")
+            @PathParam("tags") TagNames tags
     ) {
         Metric<Double> metric = new Metric<>(new MetricId<>(tenantId, GAUGE, id));
         metricsService.deleteTags(metric, tags.getNames()).subscribe(new ResultSetObserver(asyncResponse));

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -64,6 +64,7 @@ import org.hawkular.metrics.model.exception.RuntimeApiError;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
 import org.hawkular.metrics.model.param.Percentiles;
+import org.hawkular.metrics.model.param.TagNames;
 import org.hawkular.metrics.model.param.Tags;
 import org.hawkular.metrics.model.param.TimeRange;
 
@@ -227,10 +228,10 @@ public class GaugeHandler {
     public void deleteMetricTags(
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id,
-            @ApiParam("Tag list") @PathParam("tags") Tags tags
+            @ApiParam("Tag list") @PathParam("tags") TagNames tags
     ) {
         Metric<Double> metric = new Metric<>(new MetricId<>(tenantId, GAUGE, id));
-        metricsService.deleteTags(metric, tags.getTags()).subscribe(new ResultSetObserver(asyncResponse));
+        metricsService.deleteTags(metric, tags.getNames()).subscribe(new ResultSetObserver(asyncResponse));
     }
 
     @POST

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/ConvertersProvider.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/ConvertersProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,7 @@ import javax.ws.rs.ext.Provider;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.param.Duration;
 import org.hawkular.metrics.model.param.Percentiles;
+import org.hawkular.metrics.model.param.TagNames;
 import org.hawkular.metrics.model.param.Tags;
 
 import com.google.common.collect.ImmutableMap;
@@ -44,6 +45,7 @@ public class ConvertersProvider implements ParamConverterProvider {
         paramConverters = paramConvertersBuilder
                 .put(Duration.class, new DurationConverter())
                 .put(Tags.class, new TagsConverter())
+                .put(TagNames.class, new TagNamesConverter())
                 .put(MetricType.class, new MetricTypeConverter())
                 .put(Percentiles.class, new PercentilesConverter())
                 .build();

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagNamesConverter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagNamesConverter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import javax.ws.rs.ext.ParamConverter;
+
+import org.hawkular.metrics.model.param.TagNames;
+import org.hawkular.metrics.model.param.Tags;
+
+
+/**
+ * A JAX-RS {@link ParamConverter} for {@link TagNames} parameters. The string format is a list of tags in the {@code
+ * name(:value)} form, comma-separated.
+ *
+ * @author Thomas Segismont
+ */
+public class TagNamesConverter implements ParamConverter<TagNames> {
+
+    @Override
+    public TagNames fromString(String value) {
+        String[] tokens = value.split(",", -1);
+        Set<String> names = Arrays.stream(tokens).map(token -> {
+            if (token.trim().isEmpty()) {
+                throw new IllegalArgumentException("Invalid tag list:" + value);
+            }
+            String[] parts = token.split(":", -1);
+            if (parts.length > 2) {
+                throw new IllegalArgumentException("Invalid tag list:" + value);
+            }
+            String key = parts[0];
+            if (key.trim().isEmpty()) {
+                throw new IllegalArgumentException("Invalid tag list:" + value);
+            }
+            return key;
+        }).collect(toSet());
+        return new TagNames(names);
+    }
+
+    @Override
+    public String toString(TagNames value) {
+        return value.getNames().stream().collect(joining(Tags.LIST_DELIMITER));
+    }
+}

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/param/InvalidTagNamesConverterTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/param/InvalidTagNamesConverterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import java.util.Arrays;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * @author Thomas Segismont
+ */
+@RunWith(Parameterized.class)
+public class InvalidTagNamesConverterTest {
+
+    @Parameters(name = "{0}")
+    public static Iterable<Object[]> params() {
+        return Arrays.asList(
+                new Object[][]{
+                        {""},
+                        {" s jdq,,sdqsds"},
+                        {"sqdksqml,,"},
+                        {",dsqd,sqd"},
+                        {"dsqd:lsqdkm:lqsk,sqd"},
+                        {"dsqd,sqd::lqsk"},
+                }
+        );
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private String value;
+
+    public InvalidTagNamesConverterTest(String value) {
+        this.value = value;
+    }
+
+    @Test
+    public void fromString() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        new TagNamesConverter().fromString(value);
+    }
+
+}

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/param/TagNamesConverterTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/param/TagNamesConverterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * @author Thomas Segismont
+ */
+@RunWith(Parameterized.class)
+public class TagNamesConverterTest {
+
+    @Parameters(name = "{0}")
+    public static Iterable<Object[]> params() {
+        return Arrays.asList(
+                new Object[][]{
+                        {"1:2", ImmutableSet.of("1")},
+                        {"a:b,c:defg", ImmutableSet.of("a", "c")},
+                        {"3:b,c:d4 efg ,   7 : 2", ImmutableSet.of("3", "c", "   7 ")},
+                        {"1", ImmutableSet.of("1")},
+                        {"a,c", ImmutableSet.of("a", "c")},
+                        {"3,c,   7 ", ImmutableSet.of("3", "c", "   7 ")},
+                }
+        );
+    }
+
+    private String value;
+    private Set<String> tags;
+
+    public TagNamesConverterTest(String value, Set<String> tags) {
+        this.value = value;
+        this.tags = tags;
+    }
+
+    @Test
+    public void fromString() throws Exception {
+        assertEquals(tags, new TagNamesConverter().fromString(value).getNames());
+    }
+
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -50,7 +50,7 @@ public interface MetricsService {
      * with the same id already exists.
      * </p>
      * <p>
-     * All data is associated with a {@link org.hawkular.metrics.core.api.Tenant tenant} via the tenant id; however, the
+     * All data is associated with a {@link Tenant tenant} via the tenant id; however, the
      * foreign key like relationship is not enforced. Data can be inserted with a non-existent tenant id. More
      * importantly, data could be inserted with a tenant id that already exists.
      * </p>
@@ -58,8 +58,7 @@ public interface MetricsService {
      * @param tenant
      *            The {@link Tenant tenant} to create
      * @return void
-     * @throws org.hawkular.metrics.core.api.exception.TenantAlreadyExistsException
-     *             tenant already exists
+     * @throws org.hawkular.metrics.model.exception.TenantAlreadyExistsException tenant already exists
      */
     Observable<Void> createTenant(Tenant tenant);
 
@@ -133,7 +132,7 @@ public interface MetricsService {
 
     Observable<Void> addTags(Metric<?> metric, Map<String, String> tags);
 
-    Observable<Void> deleteTags(Metric<?> metric, Map<String, String> tags);
+    Observable<Void> deleteTags(Metric<?> metric, Set<String> tags);
 
     /**
      * Insert data points for the specified {@code metrics}.

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -599,9 +599,16 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    public Observable<Void> deleteTags(Metric<?> metric, Map<String, String> tags) {
-        return dataAccess.deleteTags(metric, tags.keySet()).mergeWith(
-                dataAccess.deleteFromMetricsTagsIndex(metric, tags)).toList().map(r -> null);
+    public Observable<Void> deleteTags(Metric<?> metric, Set<String> tags) {
+        return getMetricTags(metric.getMetricId())
+                .map(loadedTags -> {
+                    loadedTags.keySet().retainAll(tags);
+                    return loadedTags;
+                })
+                .flatMap(tagsToDelete -> {
+                    return dataAccess.deleteTags(metric, tagsToDelete.keySet()).mergeWith(
+                            dataAccess.deleteFromMetricsTagsIndex(metric, tagsToDelete)).toList().map(r -> null);
+                });
     }
 
     @Override

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/MetricsServiceITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/MetricsServiceITest.java
@@ -522,7 +522,7 @@ public class MetricsServiceITest extends MetricsITest {
         metricsService.addTags(metric, additions).toBlocking().lastOrDefault
                 (null);
 
-        Map<String, String> deletions = ImmutableMap.of("a1", "1");
+        Set<String> deletions = ImmutableSet.of("a1");
         metricsService.deleteTags(metric, deletions).toBlocking()
                 .lastOrDefault(null);
 

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/param/TagNames.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/param/TagNames.java
@@ -19,46 +19,40 @@ package org.hawkular.metrics.model.param;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Map;
-import java.util.stream.Stream;
+import java.util.Set;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
- * Tags holder. This class is meant to be used only as a JAX−RS method parameter.
+ * Tag names holder. This class is meant to be used only as a JAX−RS method parameter.
  *
  * @author Thomas Segismont
  */
-public class Tags {
-    public static final String LIST_DELIMITER = ",";
-    public static final String TAG_DELIMITER = ":";
-
-    private final Map<String, String> tags;
+public class TagNames {
+    private final Set<String> names;
 
     /**
-     * Null or blank names or values are not permitted. Names and values can't have
-     *
-     * @param tags values as a {@link Map}
+     * Null or blank names are not permitted.
      */
-    public Tags(Map<String, String> tags) {
-        checkArgument(tags != null, "tags is null");
-        Stream<Map.Entry<String, String>> entryStream = tags.entrySet().stream();
-        checkArgument(entryStream.allMatch(Tags::isValid), "Invalid tag name or value: %s", tags);
-        this.tags = ImmutableMap.copyOf(tags);
+    public TagNames(Set<String> names) {
+        checkArgument(names != null, "names is null");
+        checkArgument(names.stream().allMatch(Tags::isValid), "Invalid tag name: %s", names);
+        this.names = ImmutableSet.copyOf(names);
     }
 
     private static boolean isValid(Map.Entry<String, String> tag) {
         return isValid(tag.getKey()) && isValid(tag.getValue());
     }
 
-    static boolean isValid(String s) {
+    private static boolean isValid(String s) {
         return s != null && !s.trim().isEmpty();
     }
 
     /**
-     * @return tag values as a {@link Map}
+     * @return tag names as a {@link Map}
      */
-    public Map<String, String> getTags() {
-        return tags;
+    public Set<String> getNames() {
+        return names;
     }
 
     @Override
@@ -69,20 +63,20 @@ public class Tags {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Tags tags1 = (Tags) o;
-        return tags.equals(tags1.tags);
+        TagNames tagNames = (TagNames) o;
+        return names.equals(tagNames.names);
 
     }
 
     @Override
     public int hashCode() {
-        return tags.hashCode();
+        return names.hashCode();
     }
 
     @Override
     public String toString() {
-        return "Tags[" +
-               "tags=" + tags +
-               ']';
+        return "TagNames{" +
+                "names=" + names +
+                '}';
     }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -128,8 +128,8 @@ class TagsITest extends RESTTest {
       assertEquals(200, response.status)
       assertEquals(['  a  1   ': '   A', a1: 'one', a2: '2', b1: 'B', 'bsq   d1': 'B   '], response.data)
 
-      // Delete a gauge metric tag
-      response = hawkularMetrics.delete(path: it.path + "/N1/tags/a2:2,b1:B", headers: [(tenantHeaderName): tenantId])
+      // Delete a gauge metric tag (list may contain plain names or name:value pairs)
+      response = hawkularMetrics.delete(path: it.path + "/N1/tags/a2,b1:B", headers: [(tenantHeaderName): tenantId])
       assertEquals(200, response.status)
       response = hawkularMetrics.get(path: it.path + "/N1/tags", headers: [(tenantHeaderName): tenantId])
       assertEquals(['  a  1   ': '   A', a1: 'one', 'bsq   d1': 'B   '], response.data)

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,6 @@
     <version.org.apache.felix.maven-bundle-plugin>2.5.3</version.org.apache.felix.maven-bundle-plugin>
     <version.org.apache.maven.plugins.maven-jar-plugin>2.6</version.org.apache.maven.plugins.maven-jar-plugin>
     <version.org.apache.maven.plugins.maven-project-info-reports-plugin>2.7</version.org.apache.maven.plugins.maven-project-info-reports-plugin>
-    <version.org.codehaus.groovy.groovy-all>2.4.5</version.org.codehaus.groovy.groovy-all>
     <version.org.codehaus.groovy.modules.http-builder>0.7</version.org.codehaus.groovy.modules.http-builder>
     <version.org.codehaus.mojo.dashboard-maven-plugin>1.0.0-beta-1</version.org.codehaus.mojo.dashboard-maven-plugin>
     <version.org.jmxtrans.embedded.embedded-jmxtrans>1.0.15</version.org.jmxtrans.embedded.embedded-jmxtrans>
@@ -233,7 +232,7 @@
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
-        <version>${version.org.codehaus.groovy.groovy-all}</version>
+        <version>${version.org.codehaus.groovy}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>


### PR DESCRIPTION
Added a new JAX-RS param class. It allows to map a list of plain names mixed with name:value pairs (for backwared compatibility)
Updated the core service implementation so that tag values are loaded and from metric index. This is needed otherwise we can't delete rows from the tags index table (tvalue is part of the primary key).