### PR TITLE
HWKMETRICS-389 Endpoints that use the order param should accept lower case values

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/ConvertersProvider.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/ConvertersProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 
+import org.hawkular.metrics.core.service.Order;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.param.Duration;
 import org.hawkular.metrics.model.param.Percentiles;
@@ -45,15 +46,14 @@ public class ConvertersProvider implements ParamConverterProvider {
                 .put(Duration.class, new DurationConverter())
                 .put(Tags.class, new TagsConverter())
                 .put(MetricType.class, new MetricTypeConverter())
+                .put(Order.class, new OrderConverter())
                 .put(Percentiles.class, new PercentilesConverter())
                 .build();
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> ParamConverter<T> getConverter(
-            Class<T> rawType, Type genericType, Annotation[] annotations
-    ) {
+    public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
         return (ParamConverter<T>) paramConverters.get(rawType);
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/OrderConverter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/OrderConverter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import org.hawkular.metrics.core.service.Order;
+
+/**
+ * @author Thomas Segismont
+ */
+public class OrderConverter implements javax.ws.rs.ext.ParamConverter<Order> {
+    @Override
+    public Order fromString(String value) {
+        return Order.fromText(value);
+    }
+
+    @Override
+    public String toString(Order value) {
+        return value.toString();
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/rest-doc/base.adoc
+++ b/api/metrics-api-jaxrs/src/main/rest-doc/base.adoc
@@ -146,6 +146,9 @@ Limit and order only work with raw data; if used in conjunction with bucketed re
 
 Usage and default value details:
 
+* ascending order parameter value is `asc`
+* descending order parameter value is `desc`
+* parameter value matching is case-insensitive
 * default order is descending
 * no limit imposed if parameter not specified
 * limit of 0 or negative is equivalent to no limit

--- a/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/param/OrderConverterTest.java
+++ b/api/metrics-api-jaxrs/src/test/java/org/hawkular/metrics/api/jaxrs/param/OrderConverterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import static java.util.stream.Collectors.joining;
+
+import static org.hawkular.metrics.core.service.Order.ASC;
+import static org.hawkular.metrics.core.service.Order.DESC;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.hawkular.metrics.core.service.Order;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Thomas Segismont
+ */
+public class OrderConverterTest {
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private OrderConverter orderConverter = new OrderConverter();
+
+    @Test
+    public void shouldIgnoreCase() {
+        assertEquals(ASC, orderConverter.fromString("aSc"));
+        assertEquals(DESC, orderConverter.fromString("DEsc"));
+    }
+
+    @Test
+    public void shouldThrowIllegalArgumentExceptionWithInvalidText() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+
+        String invalidText = Arrays.stream(Order.values()).map(Order::toString).collect(joining("."));
+        orderConverter.fromString(invalidText);
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/Order.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,47 @@
  */
 package org.hawkular.metrics.core.service;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedMap.Builder;
+
 /**
  * @author John Sanda
  */
 public enum Order {
+    ASC("asc"),
+    DESC("desc");
 
-    ASC,
+    private static final Map<String, Order> texts;
 
-    DESC
+    static {
+        Builder<String, Order> builder = ImmutableSortedMap.orderedBy(String.CASE_INSENSITIVE_ORDER);
+        for (Order order : values()) {
+            builder.put(order.text, order);
+        }
+        texts = builder.build();
+    }
+
+    private String text;
+
+    Order(String text) {
+        this.text = text;
+    }
+
+    public static Order fromText(String text) {
+        checkArgument(text != null, "text is null");
+        Order order = texts.get(text);
+        if (order == null) {
+            throw new IllegalArgumentException(text + " is not a recognized order");
+        }
+        return order;
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
 
-import org.hawkular.metrics.model.MetricType
 import org.hawkular.metrics.core.service.DateTimeService
+import org.hawkular.metrics.model.MetricType
 import org.joda.time.DateTime
 import org.junit.Test
 
@@ -351,7 +351,7 @@ class CassandraBackendITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [distinct: "true", order: "ASC"], headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [distinct: "true", order: 'asc'], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -399,8 +399,8 @@ class CassandraBackendITest extends RESTTest {
     )
 
     response = hawkularMetrics.get(path: "availability/$metric/raw",
-      query: [limit: 3, start: start.plusMinutes(4).millis, order: "DESC"],
-      headers: [(tenantHeaderName): tenantId])
+        query: [limit: 3, start: start.plusMinutes(4).millis, order: 'desc'],
+        headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [
@@ -411,7 +411,7 @@ class CassandraBackendITest extends RESTTest {
         response.data
     )
 
-    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [limit: 4, order: "ASC"], headers: [(tenantHeaderName): tenantId])
+    response = hawkularMetrics.get(path: "availability/$metric/raw", query: [limit: 4, order: 'asc'], headers: [(tenantHeaderName): tenantId])
     assertEquals(200, response.status)
     assertEquals(
         [

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -16,13 +16,17 @@
  */
 package org.hawkular.metrics.rest
 
+import static java.lang.Double.NaN
+
+import static org.joda.time.DateTime.now
+import static org.junit.Assert.assertArrayEquals
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
 import org.hawkular.metrics.core.service.DateTimeService
 import org.joda.time.DateTime
 import org.junit.Test
 
-import static java.lang.Double.NaN
-import static org.joda.time.DateTime.now
-import static org.junit.Assert.*
 /**
  * @author John Sanda
  */
@@ -312,7 +316,7 @@ class CountersITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: 2, order: "DESC"]
+        query: [limit: 2, order: 'desc']
     )
     assertEquals(200, response.status)
 
@@ -325,7 +329,7 @@ class CountersITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: 3, order: "ASC"]
+        query: [limit: 3, order: 'asc']
     )
     assertEquals(200, response.status)
 
@@ -367,7 +371,7 @@ class CountersITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: 3, start: (start.plusMinutes(1).millis - 1), order: "DESC"]
+        query: [limit: 3, start: (start.plusMinutes(1).millis - 1), order: 'desc']
     )
     assertEquals(200, response.status)
 
@@ -381,7 +385,7 @@ class CountersITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: -1, order: "DESC"]
+        query: [limit: -1, order: 'desc']
     )
     assertEquals(200, response.status)
 
@@ -398,7 +402,7 @@ class CountersITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "counters/$counter/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: -100, order: "ASC"]
+        query: [limit: -100, order: 'asc']
     )
     assertEquals(200, response.status)
 

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
@@ -148,7 +148,7 @@ class GaugesITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: 2, order: "DESC"]
+        query: [limit: 2, order: 'desc']
     )
     assertEquals(200, response.status)
 
@@ -161,7 +161,7 @@ class GaugesITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: 3, order: "ASC"]
+        query: [limit: 3, order: 'asc']
     )
     assertEquals(200, response.status)
 
@@ -203,7 +203,7 @@ class GaugesITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: 3, start: (start.plusMinutes(1).millis - 1), order: "DESC"]
+        query: [limit: 3, start: (start.plusMinutes(1).millis - 1), order: 'desc']
     )
     assertEquals(200, response.status)
 
@@ -217,7 +217,7 @@ class GaugesITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: -1, order: "DESC"]
+        query: [limit: -1, order: 'desc']
     )
     assertEquals(200, response.status)
 
@@ -234,7 +234,7 @@ class GaugesITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "gauges/$gauge/raw",
         headers: [(tenantHeaderName): tenantId],
-        query: [limit: -100, order: "ASC"]
+        query: [limit: -100, order: 'asc']
     )
     assertEquals(200, response.status)
 

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RootITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RootITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package org.hawkular.metrics.rest
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotEquals
 import static org.junit.Assert.assertNotNull
+import static org.junit.Assume.assumeTrue
 
 import org.junit.Test
 
@@ -29,14 +30,15 @@ class RootITest extends RESTTest {
 
     @Test
     void getServiceInformation() {
-        def response = hawkularMetrics.get(path: "");
+        def version = System.properties.getProperty('project.version');
+        assumeTrue('This test only works in a Maven build', version != null)
 
-        def version = System.properties.getProperty("project.version");
-
+        def response = hawkularMetrics.get(path: '');
         assertEquals(200, response.status)
-        assertEquals("Hawkular-Metrics", response.data.name)
-        assertEquals(version, response.data["Implementation-Version"])
-        assertNotNull(response.data["Built-From-Git-SHA1"])
-        assertNotEquals("Unknown", response.data["Built-From-Git-SHA1"])
+
+        assertEquals('Hawkular-Metrics', response.data.name)
+        assertEquals(version, response.data['Implementation-Version'])
+        assertNotNull(response.data['Built-From-Git-SHA1'])
+        assertNotEquals('Unknown', response.data['Built-From-Git-SHA1'])
     }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StatusITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StatusITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package org.hawkular.metrics.rest
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotEquals
 import static org.junit.Assert.assertNotNull
+import static org.junit.Assume.assumeTrue
 
 import org.junit.Test
 
@@ -28,17 +29,17 @@ import org.junit.Test
 class StatusITest extends RESTTest {
     @Test
     void getStatus() {
-        def response = hawkularMetrics.get(path: "status")
+        def version = System.properties.getProperty('project.version');
+        assumeTrue('This test only works in a Maven build', version != null)
 
-        def version = System.properties.getProperty("project.version");
-
+        def response = hawkularMetrics.get(path: 'status')
         assertEquals(200, response.status)
 
-        def expectedState = ["MetricsService" : "STARTED"]
+        def expectedState = ['MetricsService': 'STARTED']
 
         assertEquals(expectedState.MetricsService, response.data.MetricsService)
-        assertEquals(version, response.data["Implementation-Version"])
-        assertNotNull(response.data["Built-From-Git-SHA1"])
-        assertNotEquals("Unknown", response.data["Built-From-Git-SHA1"])
+        assertEquals(version, response.data['Implementation-Version'])
+        assertNotNull(response.data['Built-From-Git-SHA1'])
+        assertNotEquals('Unknown', response.data['Built-From-Git-SHA1'])
     }
 }


### PR DESCRIPTION
Added new converter and updated enum.

Also, updated two tests which must not run when not in a Maven build