### PR TITLE
[HWKMETRICS-148]

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -104,7 +104,8 @@ public class AvailabilityHandler {
     public void createAvailabilityMetric(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(required = true) Metric<AvailabilityType> metric,
-            @ApiParam(value = "Overwrite previously created metric if it exists. Defaults to false.",
+            @ApiParam(value = "Overwrite previously created metric configuration if it exists. "
+                    + "Only data retention and tags are overwriten; existing data points are unnafected. Defaults to false.",
                     required = false) @DefaultValue("false") @QueryParam("overwrite") Boolean overwrite,
             @Context UriInfo uriInfo
     ) {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -104,6 +104,8 @@ public class AvailabilityHandler {
     public void createAvailabilityMetric(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(required = true) Metric<AvailabilityType> metric,
+            @ApiParam(value = "Overwrite previously created metric if it exists. Defaults to false.",
+                    required = false) @DefaultValue("false") @QueryParam("overwrite") Boolean overwrite,
             @Context UriInfo uriInfo
     ) {
         if (metric.getType() != null
@@ -116,7 +118,7 @@ public class AvailabilityHandler {
         metric = new Metric<>(
                 new MetricId<>(tenantId, AVAILABILITY, metric.getMetricId().getName()), metric.getTags(),
                 metric.getDataRetention());
-        metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
+        metricsService.createMetric(metric, overwrite).subscribe(new MetricCreatedObserver(asyncResponse, location));
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -109,7 +109,8 @@ public class CounterHandler {
     public void createCounter(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(required = true) Metric<Long> metric,
-            @ApiParam(value = "Overwrite previously created metric if it exists. Defaults to false.",
+            @ApiParam(value = "Overwrite previously created metric configuration if it exists. "
+                    + "Only data retention and tags are overwriten; existing data points are unnafected. Defaults to false.",
                     required = false) @DefaultValue("false") @QueryParam("overwrite") Boolean overwrite,
             @Context UriInfo uriInfo
     ) {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -109,6 +109,8 @@ public class CounterHandler {
     public void createCounter(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(required = true) Metric<Long> metric,
+            @ApiParam(value = "Overwrite previously created metric if it exists. Defaults to false.",
+                    required = false) @DefaultValue("false") @QueryParam("overwrite") Boolean overwrite,
             @Context UriInfo uriInfo
     ) {
         if (metric.getType() != null
@@ -121,7 +123,7 @@ public class CounterHandler {
         metric = new Metric<>(new MetricId<>(tenantId, COUNTER, metric.getId()),
                 metric.getTags(), metric.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/counters/{id}").build(metric.getMetricId().getName());
-        metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
+        metricsService.createMetric(metric, overwrite).subscribe(new MetricCreatedObserver(asyncResponse, location));
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -106,6 +106,8 @@ public class GaugeHandler {
     public void createGaugeMetric(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(required = true) Metric<Double> metric,
+            @ApiParam(value = "Overwrite previously created metric if it exists. Defaults to false.",
+                    required = false) @DefaultValue("false") @QueryParam("overwrite") Boolean overwrite,
             @Context UriInfo uriInfo
     ) {
         if (metric.getType() != null
@@ -117,7 +119,7 @@ public class GaugeHandler {
         metric = new Metric<>(new MetricId<>(tenantId, GAUGE, metric.getId()), metric.getTags(),
                 metric.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/gauges/{id}").build(metric.getMetricId().getName());
-        metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
+        metricsService.createMetric(metric, overwrite).subscribe(new MetricCreatedObserver(asyncResponse, location));
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -106,7 +106,8 @@ public class GaugeHandler {
     public void createGaugeMetric(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(required = true) Metric<Double> metric,
-            @ApiParam(value = "Overwrite previously created metric if it exists. Defaults to false.",
+            @ApiParam(value = "Overwrite previously created metric configuration if it exists. "
+                    + "Only data retention and tags are overwriten; existing data points are unnafected. Defaults to false.",
                     required = false) @DefaultValue("false") @QueryParam("overwrite") Boolean overwrite,
             @Context UriInfo uriInfo
     ) {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -31,6 +31,7 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -100,6 +101,8 @@ public class MetricHandler {
     public <T> void createMetric(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(required = true) Metric<T> metric,
+            @ApiParam(value = "Overwrite previously created metric if it exists. Defaults to false.",
+                    required = false) @DefaultValue("false") @QueryParam("overwrite") Boolean overwrite,
             @Context UriInfo uriInfo
     ) {
         if (metric.getType() == null || !metric.getType().isUserType()) {
@@ -109,7 +112,7 @@ public class MetricHandler {
         metric = new Metric<>(id, metric.getTags(), metric.getDataRetention());
         URI location = uriInfo.getBaseUriBuilder().path("/{type}/{id}").build(MetricTypeTextConverter.getLongForm(id
                 .getType()), id.getName());
-        metricsService.createMetric(metric).subscribe(new MetricCreatedObserver(asyncResponse, location));
+        metricsService.createMetric(metric, overwrite).subscribe(new MetricCreatedObserver(asyncResponse, location));
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/TenantsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/TenantsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,10 +25,12 @@ import java.net.URI;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
@@ -73,10 +75,14 @@ public class TenantsHandler {
     public void createTenant(
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(required = true) TenantDefinition tenantDefinition,
+            @ApiParam(value = "Overwrite previously created tenant configuration if it exists. "
+                    + "Only data retention settings are overwriten; existing metrics and data points are unnafected. "
+                    + "Defaults to false.",
+                    required = false) @DefaultValue("false") @QueryParam("overwrite") Boolean overwrite,
             @Context UriInfo uriInfo
     ) {
         URI location = uriInfo.getBaseUriBuilder().path("/tenants").build();
-        metricsService.createTenant(tenantDefinition.toTenant())
+        metricsService.createTenant(tenantDefinition.toTenant(), overwrite)
                 .subscribe(new TenantCreatedObserver(asyncResponse, location));
     }
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -45,7 +45,7 @@ public interface DataAccess {
 
     Observable<Row> findTenant(String id);
 
-    <T> ResultSetFuture insertMetricInMetricsIndex(Metric<T> metric);
+    <T> ResultSetFuture insertMetricInMetricsIndex(Metric<T> metric, boolean overwrite);
 
     <T> Observable<Row> findMetric(MetricId<T> id);
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -39,7 +39,7 @@ import rx.Observable;
 public interface DataAccess {
     Observable<ResultSet> insertTenant(String tenantId);
 
-    Observable<ResultSet> insertTenant(Tenant tenant);
+    Observable<ResultSet> insertTenant(Tenant tenant, boolean overwrite);
 
     Observable<Row> findAllTenantIds();
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -37,7 +37,6 @@ import rx.Observable;
  * @author John Sanda
  */
 public interface DataAccess {
-    Observable<ResultSet> insertTenant(String tenantId);
 
     Observable<ResultSet> insertTenant(Tenant tenant, boolean overwrite);
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
@@ -65,8 +65,6 @@ public class DataAccessImpl implements DataAccess {
 
     private PreparedStatement insertTenantOverwrite;
 
-    private PreparedStatement insertTenantId;
-
     private PreparedStatement findAllTenantIds;
 
     private PreparedStatement findAllTenantIdsFromMetricsIdx;
@@ -150,8 +148,6 @@ public class DataAccessImpl implements DataAccess {
     }
 
     protected void initPreparedStatements() {
-        insertTenantId = session.prepare("INSERT INTO tenants (id) VALUES (?)");
-
         insertTenant = session.prepare(
             "INSERT INTO tenants (id, retentions) VALUES (?, ?) IF NOT EXISTS");
 
@@ -341,10 +337,6 @@ public class DataAccessImpl implements DataAccess {
                 "SELECT tenant_id, type, metric " +
                 "FROM metrics_tags_idx " +
                 "WHERE tenant_id = ? AND tname = ? AND tvalue = ?");
-    }
-
-    @Override public Observable<ResultSet> insertTenant(String tenantId) {
-        return rxSession.execute(insertTenantId.bind(tenantId));
     }
 
     @Override

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -84,13 +84,14 @@ public interface MetricsService {
      * </p>
      *
      * @param metric The metric to create
+     * @param overwrite Flag to force overwrite previous metric definition if it exists
      *
      * @return This method only has side effects and does not return any data. As such,
      * {@link rx.Observer#onNext(Object) onNext} is not called. {@link rx.Observer#onCompleted()}  onCompleted}
      * is called when the operation completes successfully, and {@link rx.Observer#onError(Throwable)}  onError}
      * is called when it fails.
      */
-    Observable<Void> createMetric(Metric<?> metric);
+    Observable<Void> createMetric(Metric<?> metric, boolean overwrite);
 
     <T> Observable<Metric<T>> findMetric(MetricId<T> id);
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -57,11 +57,12 @@ public interface MetricsService {
      *
      * @param tenant
      *            The {@link Tenant tenant} to create
+     * @param overwrite Flag to force overwrite previous tenant definition if it exists
      * @return void
      * @throws org.hawkular.metrics.core.api.exception.TenantAlreadyExistsException
      *             tenant already exists
      */
-    Observable<Void> createTenant(Tenant tenant);
+    Observable<Void> createTenant(Tenant tenant, boolean overwrite);
 
     Observable<Tenant> getTenants();
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -341,9 +341,9 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    public Observable<Void> createTenant(final Tenant tenant) {
+    public Observable<Void> createTenant(final Tenant tenant, boolean overwrite) {
         return Observable.create(subscriber -> {
-            Observable<Void> updates = dataAccess.insertTenant(tenant).flatMap(resultSet -> {
+            Observable<Void> updates = dataAccess.insertTenant(tenant, overwrite).flatMap(resultSet -> {
                 if (!resultSet.wasApplied()) {
                     throw new TenantAlreadyExistsException(tenant.getId());
                 }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
@@ -78,9 +78,9 @@ public class DataAccessITest extends MetricsITest {
         Tenant tenant2 = new Tenant("tenant-2", ImmutableMap.of(GAUGE, 14));
 
 
-        dataAccess.insertTenant(tenant1).toBlocking().lastOrDefault(null);
+        dataAccess.insertTenant(tenant1, false).toBlocking().lastOrDefault(null);
 
-        dataAccess.insertTenant(tenant2).toBlocking().lastOrDefault(null);
+        dataAccess.insertTenant(tenant2, false).toBlocking().lastOrDefault(null);
 
         Tenant actual = dataAccess.findTenant(tenant1.getId())
                                   .map(Functions::getTenant)
@@ -90,8 +90,8 @@ public class DataAccessITest extends MetricsITest {
 
     @Test
     public void doNotAllowDuplicateTenants() throws Exception {
-        dataAccess.insertTenant(new Tenant("tenant-1")).toBlocking().lastOrDefault(null);
-        ResultSet resultSet = dataAccess.insertTenant(new Tenant("tenant-1"))
+        dataAccess.insertTenant(new Tenant("tenant-1"), false).toBlocking().lastOrDefault(null);
+        ResultSet resultSet = dataAccess.insertTenant(new Tenant("tenant-1"), false)
                                         .toBlocking()
                                         .lastOrDefault(null);
         assertFalse(resultSet.wasApplied(), "Tenants should not be overwritten");

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -65,8 +65,8 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public <T> ResultSetFuture insertMetricInMetricsIndex(Metric<T> metric) {
-        return delegate.insertMetricInMetricsIndex(metric);
+    public <T> ResultSetFuture insertMetricInMetricsIndex(Metric<T> metric, boolean overwrite) {
+        return delegate.insertMetricInMetricsIndex(metric, overwrite);
     }
 
     @Override

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -50,8 +50,8 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> insertTenant(Tenant tenant) {
-        return delegate.insertTenant(tenant);
+    public Observable<ResultSet> insertTenant(Tenant tenant, boolean overwrite) {
+        return delegate.insertTenant(tenant, overwrite);
     }
 
     @Override

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -45,11 +45,6 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<ResultSet> insertTenant(String tenantId) {
-        return delegate.insertTenant(tenantId);
-    }
-
-    @Override
     public Observable<ResultSet> insertTenant(Tenant tenant, boolean overwrite) {
         return delegate.insertTenant(tenant, overwrite);
     }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/GenerateRateITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/GenerateRateITest.java
@@ -79,9 +79,9 @@ public class GenerateRateITest extends MetricsITest {
         Metric<Long> c2 = new Metric<>(new MetricId<>(tenant, COUNTER, "C2"));
         Metric<Long> c3 = new Metric<>(new MetricId<>(tenant, COUNTER, "C3"));
 
-        doAction(() -> metricsService.createMetric(c1));
-        doAction(() -> metricsService.createMetric(c2));
-        doAction(() -> metricsService.createMetric(c3));
+        doAction(() -> metricsService.createMetric(c1, false));
+        doAction(() -> metricsService.createMetric(c2, false));
+        doAction(() -> metricsService.createMetric(c3, false));
 
         doAction(() -> metricsService.addDataPoints(COUNTER, Observable.from(asList(
                 new Metric<>(c1.getMetricId(), asList(new DataPoint<>(start.getMillis(), 10L),

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/MetricsServiceITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/MetricsServiceITest.java
@@ -181,7 +181,7 @@ public class MetricsServiceITest extends MetricsITest {
     @Test
     public void createMetricsIdxTenants() throws Exception {
         Metric<Double> em1 = new Metric<>(new MetricId<>("t123", GAUGE, "em1"));
-        metricsService.createMetric(em1).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(em1, false).toBlocking().lastOrDefault(null);
 
         Metric<Double> actual = metricsService.<Double> findMetric(em1.getMetricId())
                 .toBlocking()
@@ -203,7 +203,7 @@ public class MetricsServiceITest extends MetricsITest {
     @Test
     public void createAndFindMetrics() throws Exception {
         Metric<Double> em1 = new Metric<>(new MetricId<>("t1", GAUGE, "em1"));
-        metricsService.createMetric(em1).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(em1, false).toBlocking().lastOrDefault(null);
         Metric<Double> actual = metricsService.<Double> findMetric(em1.getMetricId())
                 .toBlocking()
                 .lastOrDefault(null);
@@ -212,14 +212,14 @@ public class MetricsServiceITest extends MetricsITest {
         assertEquals(actual, em2, "The metric does not match the expected value");
 
         Metric<Double> m1 = new Metric<>(new MetricId<>("t1", GAUGE, "m1"), ImmutableMap.of("a1", "1", "a2", "2"), 24);
-        metricsService.createMetric(m1).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(m1, false).toBlocking().lastOrDefault(null);
 
         actual = metricsService.<Double> findMetric(m1.getMetricId()).toBlocking().last();
         assertEquals(actual, m1, "The metric does not match the expected value");
 
         Metric<AvailabilityType> m2 = new Metric<>(new MetricId<>("t1", AVAILABILITY, "m2"),
                 ImmutableMap.of("a3", "3", "a4", "3"), DEFAULT_TTL);
-        metricsService.createMetric(m2).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(m2, false).toBlocking().lastOrDefault(null);
 
         // Find definitions with given tags
         Map<String, String> tagMap = new HashMap<>();
@@ -229,7 +229,7 @@ public class MetricsServiceITest extends MetricsITest {
         // Test that distinct filtering does not remove same name from different types
         Metric<Double> gm2 = new Metric<>(new MetricId<>("t1", GAUGE, "m2"),
                 ImmutableMap.of("a3", "3", "a4", "3"), null);
-        metricsService.createMetric(gm2).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(gm2, false).toBlocking().lastOrDefault(null);
 
         Metric<AvailabilityType> actualAvail = metricsService.<AvailabilityType> findMetric(m2.getMetricId())
                 .toBlocking()
@@ -238,7 +238,7 @@ public class MetricsServiceITest extends MetricsITest {
 
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
-        metricsService.createMetric(m1).subscribe(
+        metricsService.createMetric(m1, false).subscribe(
                 nullArg -> {
                 },
                 t -> {
@@ -251,11 +251,11 @@ public class MetricsServiceITest extends MetricsITest {
                 "Expected a " + MetricAlreadyExistsException.class.getSimpleName() + " to be thrown");
 
         Metric<Double> m3 = new Metric<>(new MetricId<>("t1", GAUGE, "m3"), emptyMap(), 24);
-        metricsService.createMetric(m3).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(m3, false).toBlocking().lastOrDefault(null);
 
         Metric<Double> m4 = new Metric<>(new MetricId<>("t1", GAUGE, "m4"),
                 ImmutableMap.of("a1", "A", "a2", ""), null);
-        metricsService.createMetric(m4).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(m4, false).toBlocking().lastOrDefault(null);
 
         assertMetricIndexMatches("t1", GAUGE, asList(new Metric<>(em1.getMetricId(), 7), m1,
                 new Metric<>(gm2.getMetricId(), gm2.getTags(), 7),
@@ -314,7 +314,8 @@ public class MetricsServiceITest extends MetricsITest {
         }
 
         // Insert gauges
-        Observable.from(metricsToAdd).subscribe(m -> metricsService.createMetric(m).toBlocking().lastOrDefault(null));
+        Observable.from(metricsToAdd)
+                .subscribe(m -> metricsService.createMetric(m, false).toBlocking().lastOrDefault(null));
 
         return metricsToAdd;
     }
@@ -448,7 +449,7 @@ public class MetricsServiceITest extends MetricsITest {
         MetricId<Long> id = new MetricId<>(tenantId, COUNTER, name);
 
         Metric<Long> counter = new Metric<>(id);
-        metricsService.createMetric(counter).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(counter, false).toBlocking().lastOrDefault(null);
 
         Metric<Long> actual = metricsService.<Long> findMetric(id).toBlocking().lastOrDefault(null);
 
@@ -464,7 +465,7 @@ public class MetricsServiceITest extends MetricsITest {
         Map<String, String> tags = ImmutableMap.of("x", "1", "y", "2");
 
         Metric<Long> counter = new Metric<>(id, tags, null);
-        metricsService.createMetric(counter).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(counter, false).toBlocking().lastOrDefault(null);
 
         Metric<Long> actual = metricsService.findMetric(id).toBlocking().lastOrDefault(null);
         Metric<Long> ec = new Metric<>(counter.getMetricId(), counter.getTags(), 7);
@@ -482,7 +483,7 @@ public class MetricsServiceITest extends MetricsITest {
         Integer retention = 100;
 
         Metric<Long> counter = new Metric<>(id, emptyMap(), retention);
-        metricsService.createMetric(counter).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(counter, false).toBlocking().lastOrDefault(null);
 
         Metric<Long> actual = metricsService.<Long> findMetric(id).toBlocking().lastOrDefault(null);
         assertEquals(actual, counter, "The counter metric does not match");
@@ -493,7 +494,8 @@ public class MetricsServiceITest extends MetricsITest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void doNotAllowCreationOfCounterRateMetric() {
-        metricsService.createMetric(new Metric<>(new MetricId<>("test", COUNTER_RATE, "counter-rate"))).toBlocking()
+        metricsService.createMetric(new Metric<>(new MetricId<>("test", COUNTER_RATE, "counter-rate")), false)
+                .toBlocking()
                 .lastOrDefault(null);
     }
 
@@ -516,7 +518,7 @@ public class MetricsServiceITest extends MetricsITest {
     public void updateMetricTags() throws Exception {
         Metric<Double> metric = new Metric<>(new MetricId<>("t1", GAUGE, "m1"),
                 ImmutableMap.of("a1", "1", "a2", "2"), DEFAULT_TTL);
-        metricsService.createMetric(metric).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(metric, false).toBlocking().lastOrDefault(null);
 
         Map<String, String> additions = ImmutableMap.of("a2", "two", "a3", "3");
         metricsService.addTags(metric, additions).toBlocking().lastOrDefault
@@ -1623,7 +1625,7 @@ public class MetricsServiceITest extends MetricsITest {
                 new DataPoint<>(start.plusSeconds(30).getMillis(), 55.5),
                 new DataPoint<>(end.getMillis(), 66.6)
         ));
-        metricsService.createMetric(m4).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(m4, false).toBlocking().lastOrDefault(null);
 
         metricsService.addDataPoints(GAUGE, Observable.just(m1, m2, m3, m4)).toBlocking().lastOrDefault(null);
 
@@ -1691,7 +1693,7 @@ public class MetricsServiceITest extends MetricsITest {
                 asList(
                 new DataPoint<>(start.plusMinutes(2).getMillis(), UP),
                 new DataPoint<>(end.plusMinutes(2).getMillis(), UP)));
-        metricsService.createMetric(m4).toBlocking().lastOrDefault(null);
+        metricsService.createMetric(m4, false).toBlocking().lastOrDefault(null);
 
         metricsService.addDataPoints(AVAILABILITY, Observable.just(m4)).toBlocking().lastOrDefault(null);
 
@@ -1851,6 +1853,45 @@ public class MetricsServiceITest extends MetricsITest {
 
         assertEquals(actual.size(), expected.size());
         assertTrue(actual.containsAll(expected));
+    }
+
+    @Test
+    public void createCounterMetricExists() throws Exception {
+        String tenantId = "metric-exists";
+        String name = "basic-metric";
+        int dataRetention = 20;
+        MetricId<Long> id = new MetricId<>(tenantId, COUNTER, name);
+
+        Metric<Long> metric = new Metric<>(id, dataRetention);
+        metricsService.createMetric(metric, false).toBlocking().lastOrDefault(null);
+
+        Metric<Long> actual = metricsService.<Long> findMetric(id).toBlocking().last();
+
+        assertEquals(actual, new Metric<>(metric.getMetricId(), dataRetention), "The counter metric does not match");
+        assertMetricIndexMatches(tenantId, COUNTER, singletonList(new Metric<>(metric.getMetricId(), dataRetention)));
+
+        try {
+            metricsService.createMetric(metric, false).toBlocking().lastOrDefault(null);
+            fail("Metrics should already be stored and not overwritten.");
+        } catch (MetricAlreadyExistsException e) {
+
+        }
+
+        dataRetention = 100;
+        Map<String, String> tags = new HashMap<String, String>();
+        tags.put("test", "test2");
+        metric = new Metric<>(id, tags, dataRetention);
+        try {
+            metricsService.createMetric(metric, true).toBlocking().lastOrDefault(null);
+        } catch (MetricAlreadyExistsException e) {
+            fail("Metrics should already be stored and not overwritten.");
+        }
+
+        actual = metricsService.<Long> findMetric(id).toBlocking().last();
+        assertEquals(actual, new Metric<>(metric.getMetricId(), tags, dataRetention),
+                "The counter metric does not match");
+        assertMetricIndexMatches(tenantId, COUNTER,
+                singletonList(new Metric<>(metric.getMetricId(), tags, dataRetention)));
     }
 
     private <T> List<T> toList(Observable<T> observable) {

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/RatesITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/RatesITest.java
@@ -120,9 +120,9 @@ public class RatesITest extends MetricsITest {
 
         doAction(() -> metricsService.createTenant(new Tenant(tenant)));
 
-        doAction(() -> metricsService.createMetric(c1));
-        doAction(() -> metricsService.createMetric(c2));
-        doAction(() -> metricsService.createMetric(c3));
+        doAction(() -> metricsService.createMetric(c1, false));
+        doAction(() -> metricsService.createMetric(c2, false));
+        doAction(() -> metricsService.createMetric(c3, false));
 
         doAction(() -> metricsService.addDataPoints(COUNTER, Observable.from(asList(
                 new Metric<>(c1.getMetricId(), asList(new DataPoint<>(start.getMillis(), 10L),

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/RatesITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/RatesITest.java
@@ -118,7 +118,7 @@ public class RatesITest extends MetricsITest {
         Metric<Long> c2 = new Metric<>(new MetricId<>(tenant, COUNTER, "C2"));
         Metric<Long> c3 = new Metric<>(new MetricId<>(tenant, COUNTER, "C3"));
 
-        doAction(() -> metricsService.createTenant(new Tenant(tenant)));
+        doAction(() -> metricsService.createTenant(new Tenant(tenant), false));
 
         doAction(() -> metricsService.createMetric(c1, false));
         doAction(() -> metricsService.createMetric(c2, false));

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -629,51 +629,52 @@ class CassandraBackendITest extends RESTTest {
     assertEquals(201, response.status)
     assertEquals("http://$baseURI/tenants".toString(), response.getFirstHeader('location').value)
 
-    metricTypes.each {
+    for (metricType in metricTypes) {
       //create metric
-      response = hawkularMetrics.post(path: it.path, body: [
+      response = hawkularMetrics.post(path: metricType.path, body: [
           id: 'm2',
           tags: [a: '1', b: '2'],
           dataRetention: 24
       ], headers: [(tenantHeaderName): tenantId])
       assertEquals(201, response.status)
-      assertEquals("http://$baseURI/${it.path}/m2".toString(), response.getFirstHeader('location').value)
+      assertEquals("http://$baseURI/${metricType.path}/m2".toString(), response.getFirstHeader('location').value)
 
-      response = hawkularMetrics.get(path: "${it.path}/m2", headers: [(tenantHeaderName): tenantId])
+      response = hawkularMetrics.get(path: "${metricType.path}/m2", headers: [(tenantHeaderName): tenantId])
       assertEquals(200, response.status)
       assertEquals([
             dataRetention: 24,
             id: 'm2',
             tags: [a: '1', b: '2'],
             tenantId: tenantId,
-            type: it.type
+            type: metricType.type
       ], response.data)
 
       //try to create the metric again
-      response = hawkularMetrics.post(path: it.path, body: [
+      badPost(path: metricType.path, body: [
           id: 'm2',
           tags: [a: '1', b: '2'],
           dataRetention: 24
-      ], headers: [(tenantHeaderName): tenantId])
-      assertEquals(409, response.status)
+      ], headers: [(tenantHeaderName): tenantId]) { exception ->
+        assertEquals(409, exception.response.status)
+      }
 
       //try to create the metric again but with overwrite
-      response = hawkularMetrics.post(path: it.path, query: [overwrite: true], body: [
+      response = hawkularMetrics.post(path: metricType.path, query: [overwrite: true], body: [
           id: 'm2',
           tags: [c: '3', d: '4'],
           dataRetention: 55
       ], headers: [(tenantHeaderName): tenantId])
       assertEquals(201, response.status)
-      assertEquals("http://$baseURI/${it.path}/m2".toString(), response.getFirstHeader('location').value)
+      assertEquals("http://$baseURI/${metricType.path}/m2".toString(), response.getFirstHeader('location').value)
 
-      response = hawkularMetrics.get(path: "${it.path}/m2", headers: [(tenantHeaderName): tenantId])
+      response = hawkularMetrics.get(path: "${metricType.path}/m2", headers: [(tenantHeaderName): tenantId])
       assertEquals(200, response.status)
       assertEquals([
             dataRetention: 55,
             id: 'm2',
             tags: [c: '3', d: '4'],
             tenantId: tenantId,
-            type: it.type
+            type: metricType.type
       ], response.data)
     }
   }
@@ -686,54 +687,55 @@ class CassandraBackendITest extends RESTTest {
     assertEquals(201, response.status)
     assertEquals("http://$baseURI/tenants".toString(), response.getFirstHeader('location').value)
 
-    metricTypes.each {
+    for (metricType in metricTypes) {
       //create metric
       response = hawkularMetrics.post(path: 'metrics', body: [
           id: 'm2',
           tags: [a: '1', b: '2'],
           dataRetention: 24,
-          type: it.type
+          type: metricType.type
       ], headers: [(tenantHeaderName): tenantId])
       assertEquals(201, response.status)
-      assertEquals("http://$baseURI/${it.path}/m2".toString(), response.getFirstHeader('location').value)
+      assertEquals("http://$baseURI/${metricType.path}/m2".toString(), response.getFirstHeader('location').value)
 
-      response = hawkularMetrics.get(path: "${it.path}/m2", headers: [(tenantHeaderName): tenantId])
+      response = hawkularMetrics.get(path: "${metricType.path}/m2", headers: [(tenantHeaderName): tenantId])
       assertEquals(200, response.status)
       assertEquals([
             dataRetention: 24,
             id: 'm2',
             tags: [a: '1', b: '2'],
             tenantId: tenantId,
-            type: it.type
+            type: metricType.type
       ], response.data)
 
       //try to create the metric again
-      response = hawkularMetrics.post(path: 'metrics', body: [
+      badPost(path: 'metrics', body: [
           id: 'm2',
           tags: [a: '1', b: '2'],
           dataRetention: 24,
-          type: it.type
-      ], headers: [(tenantHeaderName): tenantId])
-      assertEquals(409, response.status)
+          type: metricType.type
+      ], headers: [(tenantHeaderName): tenantId])  { exception ->
+        assertEquals(409, exception.response.status)
+      }
 
       //try to create the metric again but with overwrite
       response = hawkularMetrics.post(path: 'metrics', query: [overwrite: true], body: [
           id: 'm2',
           tags: [c: '3', d: '4'],
           dataRetention: 55,
-          type: it.type
+          type: metricType.type
       ], headers: [(tenantHeaderName): tenantId])
       assertEquals(201, response.status)
-      assertEquals("http://$baseURI/${it.path}/m2".toString(), response.getFirstHeader('location').value)
+      assertEquals("http://$baseURI/${metricType.path}/m2".toString(), response.getFirstHeader('location').value)
 
-      response = hawkularMetrics.get(path: "${it.path}/m2", headers: [(tenantHeaderName): tenantId])
+      response = hawkularMetrics.get(path: "${metricType.path}/m2", headers: [(tenantHeaderName): tenantId])
       assertEquals(200, response.status)
       assertEquals([
             dataRetention: 55,
             id: 'm2',
             tags: [c: '3', d: '4'],
             tenantId: tenantId,
-            type: it.type
+            type: metricType.type
       ], response.data)
     }
   }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -620,4 +620,121 @@ class CassandraBackendITest extends RESTTest {
         assertNotNull(exception.response.data['errorMsg'])
     }
   }
+
+  @Test
+  void insertMetricsWithOverwriteViaTypeEndpoint() {
+    def tenantId = nextTenantId()
+
+    def response = hawkularMetrics.post(path: 'tenants', body: [id: tenantId])
+    assertEquals(201, response.status)
+    assertEquals("http://$baseURI/tenants".toString(), response.getFirstHeader('location').value)
+
+    metricTypes.each {
+      //create metric
+      response = hawkularMetrics.post(path: it.path, body: [
+          id: 'm2',
+          tags: [a: '1', b: '2'],
+          dataRetention: 24
+      ], headers: [(tenantHeaderName): tenantId])
+      assertEquals(201, response.status)
+      assertEquals("http://$baseURI/${it.path}/m2".toString(), response.getFirstHeader('location').value)
+
+      response = hawkularMetrics.get(path: "${it.path}/m2", headers: [(tenantHeaderName): tenantId])
+      assertEquals(200, response.status)
+      assertEquals([
+            dataRetention: 24,
+            id: 'm2',
+            tags: [a: '1', b: '2'],
+            tenantId: tenantId,
+            type: it.type
+      ], response.data)
+
+      //try to create the metric again
+      response = hawkularMetrics.post(path: it.path, body: [
+          id: 'm2',
+          tags: [a: '1', b: '2'],
+          dataRetention: 24
+      ], headers: [(tenantHeaderName): tenantId])
+      assertEquals(409, response.status)
+
+      //try to create the metric again but with overwrite
+      response = hawkularMetrics.post(path: it.path, query: [overwrite: true], body: [
+          id: 'm2',
+          tags: [c: '3', d: '4'],
+          dataRetention: 55
+      ], headers: [(tenantHeaderName): tenantId])
+      assertEquals(201, response.status)
+      assertEquals("http://$baseURI/${it.path}/m2".toString(), response.getFirstHeader('location').value)
+
+      response = hawkularMetrics.get(path: "${it.path}/m2", headers: [(tenantHeaderName): tenantId])
+      assertEquals(200, response.status)
+      assertEquals([
+            dataRetention: 55,
+            id: 'm2',
+            tags: [c: '3', d: '4'],
+            tenantId: tenantId,
+            type: it.type
+      ], response.data)
+    }
+  }
+
+  @Test
+  void insertMetricsWithOverwriteViaMetricsEndpoint() {
+    def tenantId = nextTenantId()
+
+    def response = hawkularMetrics.post(path: 'tenants', body: [id: tenantId])
+    assertEquals(201, response.status)
+    assertEquals("http://$baseURI/tenants".toString(), response.getFirstHeader('location').value)
+
+    metricTypes.each {
+      //create metric
+      response = hawkularMetrics.post(path: 'metrics', body: [
+          id: 'm2',
+          tags: [a: '1', b: '2'],
+          dataRetention: 24,
+          type: it.type
+      ], headers: [(tenantHeaderName): tenantId])
+      assertEquals(201, response.status)
+      assertEquals("http://$baseURI/${it.path}/m2".toString(), response.getFirstHeader('location').value)
+
+      response = hawkularMetrics.get(path: "${it.path}/m2", headers: [(tenantHeaderName): tenantId])
+      assertEquals(200, response.status)
+      assertEquals([
+            dataRetention: 24,
+            id: 'm2',
+            tags: [a: '1', b: '2'],
+            tenantId: tenantId,
+            type: it.type
+      ], response.data)
+
+      //try to create the metric again
+      response = hawkularMetrics.post(path: 'metrics', body: [
+          id: 'm2',
+          tags: [a: '1', b: '2'],
+          dataRetention: 24,
+          type: it.type
+      ], headers: [(tenantHeaderName): tenantId])
+      assertEquals(409, response.status)
+
+      //try to create the metric again but with overwrite
+      response = hawkularMetrics.post(path: 'metrics', query: [overwrite: true], body: [
+          id: 'm2',
+          tags: [c: '3', d: '4'],
+          dataRetention: 55,
+          type: it.type
+      ], headers: [(tenantHeaderName): tenantId])
+      assertEquals(201, response.status)
+      assertEquals("http://$baseURI/${it.path}/m2".toString(), response.getFirstHeader('location').value)
+
+      response = hawkularMetrics.get(path: "${it.path}/m2", headers: [(tenantHeaderName): tenantId])
+      assertEquals(200, response.status)
+      assertEquals([
+            dataRetention: 55,
+            id: 'm2',
+            tags: [c: '3', d: '4'],
+            tenantId: tenantId,
+            type: it.type
+      ], response.data)
+    }
+  }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -44,6 +44,12 @@ class RESTTest {
   static ObjectMapper objectMapper = new ObjectMapper()
   static RESTClient hawkularMetrics
 
+  static metricTypes =  [
+    ["path": "gauges", "type": "gauge"],
+    ["path": "availability", "type": "availability"],
+    ["path": "counters", "type": "counter"]
+  ];
+
   @BeforeClass
   static void initClient() {
     objectMapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -27,12 +27,6 @@ import org.junit.Test
  */
 class TagsITest extends RESTTest {
 
-  static metricTypes =  [
-    ["path": "gauges", "type": "gauge"],
-    ["path": "availability", "type": "availability"],
-    ["path": "counters", "type": "counter"]
-  ];
-
   @Test
   void shouldNotAcceptMissingOrInvalidTags() {
     metricTypes.each {

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TenantITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TenantITest.groovy
@@ -34,7 +34,7 @@ class TenantITest extends RESTTest {
 
   @Test
   void createAndReadTest() {
-    String secondTenantId = nextTenantId()
+    def secondTenantId = nextTenantId()
 
     def response = hawkularMetrics.post(path: "tenants", body: [
         id        : tenantId,
@@ -74,6 +74,23 @@ class TenantITest extends RESTTest {
     badPost(path: 'tenants', body: [id: tenantId]) { exception ->
       assertEquals(409, exception.response.status)
     }
+
+    response = hawkularMetrics.post(path: 'tenants', query: [overwrite: true], body: [
+        id: tenantId,
+        retentions: [gauge: 145, availability: 130, counter: 113]
+    ])
+    assertEquals(201, response.status)
+    assertEquals("http://$baseURI/tenants".toString(), response.getFirstHeader('location').value)
+
+    response = hawkularMetrics.get(path: "tenants")
+    def expectedData = [
+        [
+            id        : tenantId,
+            retentions: [gauge: 145, availability: 130, counter: 113]
+        ]
+    ]
+
+    assertTrue("${expectedData} not in ${response.data}", response.data.containsAll((expectedData)))
   }
 
   @Test


### PR DESCRIPTION
Update metrics creation to allow users to overwrite previously created metric definitions. The flag defaults to false and is not required.