### PR TITLE
rest-tests enhancements

### DIFF
--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -74,6 +74,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.influxdb</groupId>
       <artifactId>influxdb-java</artifactId>
       <scope>test</scope>

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
@@ -70,26 +70,24 @@ class CORSITest extends RESTTest {
 
   @Test
   void testOptionsWithBadOrigin() {
-    def response = hawkularMetrics.options(path: "gauges/test/raw",
-        headers: [
+    badOptions(path: "gauges/test/raw", headers: [
             (ACCESS_CONTROL_REQUEST_METHOD): "OPTIONS",
             (ORIGIN): "*"
-        ])
-
-    //Expected 400 because this pre-flight call that should never reach the resource router since
-    //the request origin is bad
-    assertEquals(400, response.status)
+    ]) { exception ->
+      //Expected 400 because this pre-flight call that should never reach the resource router since
+      //the request origin is bad
+      assertEquals(400, exception.response.status)
+    }
 
     def wrongSchemeOrigin = testOrigin.replaceAll("http://", "https://")
-    response = hawkularMetrics.options(path: "gauges/test/raw",
-        headers: [
+    badOptions(path: "gauges/test/raw", headers: [
             (ACCESS_CONTROL_REQUEST_METHOD): "GET",
             (ORIGIN): wrongSchemeOrigin
-        ])
-
-    //Expected 400 because this call should never reach the resource router since
-    //the request origin is bad
-    assertEquals(400, response.status)
+    ]) { exception ->
+      //Expected 400 because this call should never reach the resource router since
+      //the request origin is bad
+      assertEquals(400, exception.response.status)
+    }
   }
 
   @Test

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
@@ -27,8 +27,10 @@ import static org.hawkular.metrics.api.jaxrs.util.Headers.DEFAULT_CORS_ACCESS_CO
 import static org.hawkular.metrics.api.jaxrs.util.Headers.ORIGIN
 import static org.joda.time.DateTime.now
 import static org.junit.Assert.assertEquals
+import static org.junit.Assume.assumeTrue
 
 import org.joda.time.DateTime
+import org.junit.Before
 import org.junit.Test
 
 class CORSITest extends RESTTest {
@@ -36,6 +38,11 @@ class CORSITest extends RESTTest {
   static final String testAccessControlAllowHeaders = DEFAULT_CORS_ACCESS_CONTROL_ALLOW_HEADERS + ',' +
     System.getProperty("hawkular-metrics.test.access-control-allow-headers");
 
+  @Before
+  void assumeIsMavenBuild() {
+    def version = System.properties.getProperty('project.version');
+    assumeTrue('This test only works in a Maven build', version != null)
+  }
 
   @Test
   void testOptionsWithOrigin() {

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -1391,7 +1391,7 @@ Actual:   ${response.data}
     assertEquals(200, response.status)
     assertEquals(4, response.data.size)
 
-    def expectedArray = [new BigDecimal(3), new BigDecimal(2),  null, null].toArray()
+    def expectedArray = [3.0, 2.0, null, null].toArray()
     assertArrayEquals(expectedArray, response.data.min.toArray())
     assertArrayEquals(expectedArray, response.data.max.toArray())
     assertArrayEquals(expectedArray, response.data.avg.toArray())

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugeMetricStatisticsITest.groovy
@@ -16,6 +16,12 @@
  */
 package org.hawkular.metrics.rest
 
+import static org.joda.time.DateTime.now
+import static org.joda.time.Seconds.seconds
+import static org.junit.Assert.assertArrayEquals
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
 import org.apache.commons.math3.stat.descriptive.moment.Mean
 import org.apache.commons.math3.stat.descriptive.rank.Max
 import org.apache.commons.math3.stat.descriptive.rank.Min
@@ -26,9 +32,6 @@ import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.junit.Test
 
-import static org.joda.time.DateTime.now
-import static org.joda.time.Seconds.seconds
-import static org.junit.Assert.*
 /**
  * @author Thomas Segismont
  */
@@ -596,7 +599,7 @@ class GaugeMetricStatisticsITest extends RESTTest {
     assertEquals(201, response.status)
 
     // query for data
-    response = hawkularMetrics.get(
+    badGet(
         path: 'gauges/stats',
         query: [
             start: start.millis,
@@ -604,8 +607,9 @@ class GaugeMetricStatisticsITest extends RESTTest {
             buckets: 1
         ],
         headers: [(tenantHeaderName): tenantId]
-    )
-    assertEquals(400, response.status)
+    ) { exception ->
+      assertEquals(400, exception.response.status)
+    }
   }
 
   @Test
@@ -627,7 +631,7 @@ class GaugeMetricStatisticsITest extends RESTTest {
     assertEquals(201, response.status)
 
     // query for data
-    response = hawkularMetrics.get(
+    badGet(
         path: 'gauges/stats',
         query: [
             start: start.millis,
@@ -637,8 +641,9 @@ class GaugeMetricStatisticsITest extends RESTTest {
             metrics: ['G2']
         ],
         headers: [(tenantHeaderName): tenantId]
-    )
-    assertEquals(400, response.status)
+    ) { exception ->
+      assertEquals(400, exception.response.status)
+    }
   }
 
   @Test
@@ -658,7 +663,7 @@ class GaugeMetricStatisticsITest extends RESTTest {
     assertEquals(201, response.status)
 
     // query for data
-    response = hawkularMetrics.get(
+    badGet(
         path: 'gauges/stats',
         query: [
             start: start.millis,
@@ -666,8 +671,9 @@ class GaugeMetricStatisticsITest extends RESTTest {
             tags: 'type:cpu_usage,host:server1|server2'
         ],
         headers: [(tenantHeaderName): tenantId]
-    )
-    assertEquals(400, response.status)
+    ) { exception ->
+      assertEquals(400, exception.response.status)
+    }
   }
 
   @Test
@@ -697,7 +703,7 @@ class GaugeMetricStatisticsITest extends RESTTest {
     assertEquals(200, response.status)
     assertEquals(4, response.data.size)
 
-    def expectedArray = [new BigDecimal(3), new BigDecimal(2), null, null].toArray()
+    def expectedArray = [3.0, 2.0, null, null].toArray()
     assertArrayEquals(expectedArray, response.data.min.toArray())
     assertArrayEquals(expectedArray, response.data.max.toArray())
     assertArrayEquals(expectedArray, response.data.avg.toArray())

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/InfluxITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,12 @@
  */
 package org.hawkular.metrics.rest
 
-import static groovyx.net.http.ContentType.TEXT
-import static groovyx.net.http.Method.POST
 import static org.joda.time.DateTime.now
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.fail
+
+import static groovyx.net.http.ContentType.TEXT
+import static groovyx.net.http.Method.POST
 
 import org.apache.http.util.EntityUtils
 import org.joda.time.DateTime
@@ -197,7 +198,7 @@ class InfluxITest extends RESTTest {
                 columns: ['time', 'mean'],
                 name   : counterName,
                 points : [
-                    [start.plus(4000).millis, 42 as BigDecimal]
+                    [start.plus(4000).millis, 42.0]
                 ]
             ]
         ],

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -111,6 +111,10 @@ ${text}
     badRequest(hawkularMetrics.&delete, args, errorHandler)
   }
 
+  static def badOptions(args, errorHandler) {
+    badRequest(hawkularMetrics.&options, args, errorHandler)
+  }
+
   static def badRequest(method, args, errorHandler, forceContentTypeOnEmptyBody = false) {
     if (forceContentTypeOnEmptyBody && args.body == null) {
       args.headers["Content-Type"] = "application/json"


### PR DESCRIPTION
CORSITest is now ignored if run out of the Maven build (avoid failures in IDE due to missing Maven property)

RESTClient configured to use Jackson instead of JSON-lib. Jackson has configurable deserialization and allows to force conversion to BigDecimal (which works nice with floating literals in Groovy)