### PR TITLE
HWKMETRICS-390 Endpoint for fetching rate data points need to support standard query params and sort behavior

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.hawkular.metrics.api.jaxrs.handler;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -339,22 +340,11 @@ public class AvailabilityHandler {
         MetricId<AvailabilityType> metricId = new MetricId<>(tenantId, AVAILABILITY, id);
         Buckets buckets = bucketConfig.getBuckets();
         if (buckets == null) {
-            if (limit != null) {
-                if (order == null) {
-                    if (start == null && end != null) {
-                        order = Order.DESC;
-                    } else if (start != null && end == null) {
-                        order = Order.ASC;
-                    } else {
-                        order = Order.DESC;
-                    }
-                }
-            } else {
+            if (limit == null) {
                 limit = 0;
             }
-
             if (order == null) {
-                order = Order.DESC;
+                order = Order.defaultValue(limit, start, end);
             }
 
             metricsService
@@ -398,22 +388,12 @@ public class AvailabilityHandler {
         }
 
         MetricId<AvailabilityType> metricId = new MetricId<>(tenantId, AVAILABILITY, id);
-        if (limit != null) {
-            if (order == null) {
-                if (start == null && end != null) {
-                    order = Order.DESC;
-                } else if (start != null && end == null) {
-                    order = Order.ASC;
-                } else {
-                    order = Order.DESC;
-                }
-            }
-        } else {
+
+        if (limit == null) {
             limit = 0;
         }
-
         if (order == null) {
-            order = Order.DESC;
+            order = Order.defaultValue(limit, start, end);
         }
 
         metricsService

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.hawkular.metrics.api.jaxrs.handler;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -340,22 +341,11 @@ public class GaugeHandler {
                 return;
             }
 
-            if (limit != null) {
-                if (order == null) {
-                    if (start == null && end != null) {
-                        order = Order.DESC;
-                    } else if (start != null && end == null) {
-                        order = Order.ASC;
-                    } else {
-                        order = Order.DESC;
-                    }
-                }
-            } else {
+            if (limit == null) {
                 limit = 0;
             }
-
             if (order == null) {
-                order = Order.DESC;
+                order = Order.defaultValue(limit, start, end);
             }
 
             metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd(), limit, order)
@@ -449,22 +439,11 @@ public class GaugeHandler {
             return;
         }
 
-        if (limit != null) {
-            if (order == null) {
-                if (start == null && end != null) {
-                    order = Order.DESC;
-                } else if (start != null && end == null) {
-                    order = Order.ASC;
-                } else {
-                    order = Order.DESC;
-                }
-            }
-        } else {
+        if (limit == null) {
             limit = 0;
         }
-
         if (order == null) {
-            order = Order.DESC;
+            order = Order.defaultValue(limit, start, end);
         }
 
         metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd(), limit, order)

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.hawkular.metrics.core.service;
 
 import java.util.List;
@@ -274,14 +275,16 @@ public interface MetricsService {
      * Fetches counter data points and calculates per-minute rates. Resets events are detected and values reported
      * after a reset are filtered out before doing calculations in order to avoid inaccurate rates.
      *
-     * @param id This is the id of the counter metric
+     * @param id    This is the id of the counter metric
      * @param start The start time which is inclusive
-     * @param end The end time which is exclusive
+     * @param end   The end time which is exclusive
+     * @param limit      limit the number of data points
+     * @param order      the sort order for the results
      *
      * @return An Observable of {@link DataPoint data points} which are emitted in ascending order. In other words,
      * the most recent data is emitted first.
      */
-    Observable<DataPoint<Double>> findRateData(MetricId<Long> id, long start, long end);
+    Observable<DataPoint<Double>> findRateData(MetricId<Long> id, long start, long end, int limit, Order order);
 
     /**
      * Computes stats on a counter rate.

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/Order.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/Order.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.hawkular.metrics.core.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -53,6 +54,18 @@ public enum Order {
             throw new IllegalArgumentException(text + " is not a recognized order");
         }
         return order;
+    }
+
+    /**
+     * Determines a default value based on API parameters.
+     *
+     * @param limit maximum of rows returned
+     * @param start time range start
+     * @param end   time range end
+     * @return {@link #ASC} if limit is positive, start is not null and end is null; {@link #DESC} otherwise
+     */
+    public static Order defaultValue(int limit, Long start, Long end) {
+        return limit > 0 && start != null && end == null ? ASC : DESC;
     }
 
     @Override

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/PatternUtil.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/PatternUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.core.service;
+
+import java.util.regex.Pattern;
+
+/**
+ * @author Thomas Segismont
+ */
+public class PatternUtil {
+
+    /**
+     * Allow special cases to Pattern matching, such as "*" -> ".*" and ! indicating the match shouldn't
+     * happen. The first ! indicates the rest of the pattern should not match.
+     *
+     * @param inputRegexp Regexp given by the user
+     * @return Pattern modified to allow special cases in the query language
+     */
+    public static Pattern filterPattern(String inputRegexp) {
+        if (inputRegexp.equals("*")) {
+            inputRegexp = ".*";
+        } else if (inputRegexp.startsWith("!")) {
+            inputRegexp = inputRegexp.substring(1);
+        }
+        return Pattern.compile(inputRegexp); // Catch incorrect patterns..
+    }
+
+    private PatternUtil() {
+        // Utility class
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/NumericBucketPointTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/NumericBucketPointTransformer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.core.service.transformers;
+
+import java.util.List;
+
+import org.hawkular.metrics.model.Buckets;
+import org.hawkular.metrics.model.DataPoint;
+import org.hawkular.metrics.model.NumericBucketPoint;
+
+import rx.Observable;
+import rx.Observable.Transformer;
+
+/**
+ * @author Thomas Segismont
+ */
+public class NumericBucketPointTransformer
+        implements Transformer<DataPoint<? extends Number>, List<NumericBucketPoint>> {
+
+    private final Buckets buckets;
+    private final List<Double> percentiles;
+
+    public NumericBucketPointTransformer(Buckets buckets, List<Double> percentiles) {
+        this.buckets = buckets;
+        this.percentiles = percentiles;
+    }
+
+    @Override
+    public Observable<List<NumericBucketPoint>> call(Observable<DataPoint<? extends Number>> dataPoints) {
+        return dataPoints
+                .groupBy(dataPoint -> buckets.getIndex(dataPoint.getTimestamp()))
+                .flatMap(group -> group.collect(()
+                                -> new NumericDataPointCollector(buckets, group.getKey(), percentiles),
+                        NumericDataPointCollector::increment))
+                .map(NumericDataPointCollector::toBucketPoint)
+                .toMap(NumericBucketPoint::getStart)
+                .map(pointMap -> NumericBucketPoint.toList(pointMap, buckets));
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/NumericDataPointCollector.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/NumericDataPointCollector.java
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.service;
+
+package org.hawkular.metrics.core.service.transformers;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +27,7 @@ import org.apache.commons.math3.stat.descriptive.rank.Max;
 import org.apache.commons.math3.stat.descriptive.rank.Min;
 import org.apache.commons.math3.stat.descriptive.rank.PSquarePercentile;
 import org.apache.commons.math3.stat.descriptive.summary.Sum;
+import org.hawkular.metrics.core.service.PercentileWrapper;
 import org.hawkular.metrics.model.Buckets;
 import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.NumericBucketPoint;
@@ -36,12 +38,12 @@ import org.hawkular.metrics.model.Percentile;
  *
  * @author Thomas Segismont
  */
-final class NumericDataPointCollector {
+public final class NumericDataPointCollector {
 
     /**
      * This is a test hook. See {@link Percentile} for details.
      */
-    static Function<Double, PercentileWrapper> createPercentile = p -> new PercentileWrapper() {
+    public static Function<Double, PercentileWrapper> createPercentile = p -> new PercentileWrapper() {
 
         PSquarePercentile percentile = new PSquarePercentile(p);
 
@@ -70,14 +72,14 @@ final class NumericDataPointCollector {
     private Sum sum = new Sum();
     private List<PSquarePercentile> percentiles;
 
-    NumericDataPointCollector(Buckets buckets, int bucketIndex, List<Double> percentileList) {
+    public NumericDataPointCollector(Buckets buckets, int bucketIndex, List<Double> percentileList) {
         this.buckets = buckets;
         this.bucketIndex = bucketIndex;
         this.percentiles = new ArrayList<>();
         percentileList.stream().forEach(d -> percentiles.add(new PSquarePercentile(d)));
     }
 
-    void increment(DataPoint<? extends Number> dataPoint) {
+    public void increment(DataPoint<? extends Number> dataPoint) {
         Number value = dataPoint.getValue();
         min.increment(value.doubleValue());
         average.increment(value.doubleValue());
@@ -88,7 +90,7 @@ final class NumericDataPointCollector {
         percentiles.stream().forEach(p -> p.increment(value.doubleValue()));
     }
 
-    NumericBucketPoint toBucketPoint() {
+    public NumericBucketPoint toBucketPoint() {
         long from = buckets.getBucketStart(bucketIndex);
         long to = from + buckets.getStep();
         return new NumericBucketPoint.Builder(from, to)

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/TaggedBucketPointTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/TaggedBucketPointTransformer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.core.service.transformers;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import static org.hawkular.metrics.core.service.PatternUtil.filterPattern;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.hawkular.metrics.model.DataPoint;
+import org.hawkular.metrics.model.TaggedBucketPoint;
+
+import rx.Observable;
+import rx.Observable.Transformer;
+import rx.functions.Func1;
+
+/**
+ * @author Thomas Segismont
+ */
+public class TaggedBucketPointTransformer
+        implements Transformer<DataPoint<? extends Number>, Map<String, TaggedBucketPoint>> {
+
+    private final Map<String, String> tags;
+    private final List<Double> percentiles;
+
+    public TaggedBucketPointTransformer(Map<String, String> tags, List<Double> percentiles) {
+        this.tags = tags;
+        this.percentiles = percentiles;
+    }
+
+    @Override
+    public Observable<Map<String, TaggedBucketPoint>> call(Observable<DataPoint<? extends Number>> dataPoints) {
+        List<Func1<DataPoint<? extends Number>, Boolean>> tagFilters = tags.entrySet().stream().map(e -> {
+            boolean positive = (!e.getValue().startsWith("!"));
+            Pattern pattern = filterPattern(e.getValue());
+            Func1<DataPoint<? extends Number>, Boolean> filter = dataPoint ->
+                    dataPoint.getTags().containsKey(e.getKey()) &&
+                            (positive == pattern.matcher(dataPoint.getTags().get(e.getKey())).matches());
+            return filter;
+        }).collect(toList());
+
+        // TODO refactor this to be more functional and replace java 8 streams with rx operators
+        return dataPoints
+                .filter(dataPoint -> {
+                    for (Func1<DataPoint<? extends Number>, Boolean> tagFilter : tagFilters) {
+                        if (!tagFilter.call(dataPoint)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                })
+                .groupBy(dataPoint -> tags.entrySet().stream().collect(
+                        toMap(Map.Entry::getKey, e -> dataPoint.getTags().get(e.getKey()))))
+                .flatMap(group -> group.collect(() -> new TaggedDataPointCollector(group.getKey(), percentiles),
+                        TaggedDataPointCollector::increment))
+                .map(TaggedDataPointCollector::toBucketPoint)
+                .toMap(bucketPoint -> bucketPoint.getTags().entrySet().stream().map(e ->
+                        e.getKey() + ":" + e.getValue()).collect(joining(",")));
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/TaggedDataPointCollector.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/TaggedDataPointCollector.java
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.core.service;
+
+package org.hawkular.metrics.core.service.transformers;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,13 +47,13 @@ public class TaggedDataPointCollector {
     private PSquarePercentile median = new PSquarePercentile(50.0);
     private List<PSquarePercentile> percentiles;
 
-    TaggedDataPointCollector(Map<String, String> tags, List<Double> percentiles) {
+    public TaggedDataPointCollector(Map<String, String> tags, List<Double> percentiles) {
         this.tags = tags;
         this.percentiles = new ArrayList<>();
         percentiles.stream().forEach(d -> this.percentiles.add(new PSquarePercentile(d)));
     }
 
-    void increment(DataPoint<? extends Number> dataPoint) {
+    public void increment(DataPoint<? extends Number> dataPoint) {
         Number value = dataPoint.getValue();
         min.increment(value.doubleValue());
         average.increment(value.doubleValue());
@@ -63,7 +64,7 @@ public class TaggedDataPointCollector {
         percentiles.stream().forEach(p -> p.increment(value.doubleValue()));
     }
 
-    TaggedBucketPoint toBucketPoint() {
+    public TaggedBucketPoint toBucketPoint() {
         List<Percentile> results = percentiles.stream()
                 .map(p -> new Percentile(p.quantile(), p.getResult())).collect(Collectors.toList());
         return new TaggedBucketPoint(tags, min.getResult(), average.getResult(), median.getResult(), max.getResult(),

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/GenerateRateITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/GenerateRateITest.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.hawkular.metrics.core.service;
 
 import static java.util.Arrays.asList;
@@ -101,11 +102,11 @@ public class GenerateRateITest extends MetricsITest {
         generateRate.call(task);
 
         List<DataPoint<Double>> c1Rate = getOnNextEvents(() -> metricsService.findRateData(c1.getMetricId(),
-                start.getMillis(), start.plusMinutes(1).getMillis()));
+                start.getMillis(), start.plusMinutes(1).getMillis(), 0, Order.ASC));
         List<DataPoint<Double>> c2Rate = getOnNextEvents(() -> metricsService.findRateData(c2.getMetricId(),
-                start.getMillis(), start.plusMinutes(1).getMillis()));
+                start.getMillis(), start.plusMinutes(1).getMillis(), 0, Order.ASC));
         List<DataPoint<Double>> c3Rate = getOnNextEvents(() -> metricsService.findRateData(c3.getMetricId(),
-                start.getMillis(), start.plusMinutes(1).getMillis()));
+                start.getMillis(), start.plusMinutes(1).getMillis(), 0, Order.ASC));
 
         assertEquals(c1Rate, singletonList(new DataPoint<>(start.plusSeconds(30).getMillis(), calculateRate(30, start,
                 start.plusMinutes(1)))));

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/RatesITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/RatesITest.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.hawkular.metrics.core.service;
 
 import static java.util.Arrays.asList;
@@ -143,11 +144,11 @@ public class RatesITest extends MetricsITest {
         subscriber.assertTerminalEvent();
 
         List<DataPoint<Double>> c1Rate = getOnNextEvents(() -> metricsService.findRateData(c1.getMetricId(),
-                start.getMillis(), start.plusMinutes(1).getMillis()));
+                start.getMillis(), start.plusMinutes(1).getMillis(), 0, Order.ASC));
         List<DataPoint<Double>> c2Rate = getOnNextEvents(() -> metricsService.findRateData(c2.getMetricId(),
-                start.getMillis(), start.plusMinutes(1).getMillis()));
+                start.getMillis(), start.plusMinutes(1).getMillis(), 0, Order.ASC));
         List<DataPoint<Double>> c3Rate = getOnNextEvents(() -> metricsService.findRateData(c3.getMetricId(),
-                start.getMillis(), start.plusMinutes(1).getMillis()));
+                start.getMillis(), start.plusMinutes(1).getMillis(), 0, Order.ASC));
 
         assertEquals(c1Rate, singletonList(new DataPoint<>(start.getMillis(), calculateRate(25, start,
                 start.plusMinutes(1)))));

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -549,7 +549,7 @@ class CountersITest extends RESTTest {
     response = hawkularMetrics.get(
         path: "counters/$counter/rate",
         headers: [(tenantHeaderName): tenantId],
-        query: [start: 0]
+        query: [start: 0, order: 'asc']
     )
     assertEquals(200, response.status)
 
@@ -604,7 +604,7 @@ Actual:   ${response.data}
     response = hawkularMetrics.get(
         path: "counters/$counter/rate",
         headers: [(tenantHeaderName): tenantId],
-        query: [start: 0]
+        query: [start: 0, order: 'asc']
     )
     assertEquals(200, response.status)
 


### PR DESCRIPTION
I added a method in Order.java which factors out the logic to determine a default order. I updated the considering endpoints.

I change the get rate endpoint to support the new parameters. While its bucket parameters are deprecated and not removed, we need to check that they can't be set if order and limit are.

While updating the code in MetricsServiceImpl to adapt to the new  findRate signature, I extracted the code of #bucketize methods and created separated Transformer classes. Using these transformers with #compose is a more natural RxJava construct.