### PR TITLE
HWKMETRICS-397 Intermittent failure in ptrans tests on Travis

### DIFF
--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/backend/MetricsSenderITest.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/backend/MetricsSenderITest.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.hawkular.metrics.clients.ptrans.backend;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -72,7 +73,6 @@ public class MetricsSenderITest {
         CountDownLatch latch = new CountDownLatch(1);
         vertx.deployVerticle(new MetricsSender(configuration), handler -> latch.countDown());
         latch.await();
-
     }
 
     @Test
@@ -101,12 +101,14 @@ public class MetricsSenderITest {
         }
 
         ServerDataHelper dataHelper = new ServerDataHelper(tenant);
-        List<Point> serverData;
-        do {
+        List<Point> serverData = null;
+        for (int i = 0; i < 10; i++) {
             Thread.sleep(1000);
             serverData = dataHelper.getServerData();
+            if (serverData.size() == expectedData.size()) {
+                break;
+            }
         }
-        while (serverData.size() != expectedData.size());
 
         Collections.sort(expectedData, Point.POINT_COMPARATOR);
         Collections.sort(serverData, Point.POINT_COMPARATOR);

--- a/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/data/ServerDataHelper.java
+++ b/clients/ptranslator/src/test/java/org/hawkular/metrics/clients/ptrans/data/ServerDataHelper.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.hawkular.metrics.clients.ptrans.data;
 
 import static java.util.stream.Collectors.toList;
@@ -82,6 +83,10 @@ public class ServerDataHelper {
             urlConnection.setRequestProperty(String.valueOf(TENANT_HEADER_NAME), tenant);
             urlConnection.connect();
             responseCode = urlConnection.getResponseCode();
+
+            if (responseCode == HttpURLConnection.HTTP_NO_CONTENT) {
+                continue;
+            }
             if (responseCode != HttpURLConnection.HTTP_OK) {
                 fail("Could not load metric data from server: " + responseCode);
             }


### PR DESCRIPTION
Do not fail the test if ServerDataHelper receives 204 No content. Give the test a chance to complete later.

Also, fail MetricsSenderITest if data size does not match expected data after ten pause-and-try cycles