### PR TITLE
HWKMETRICS-383 Allow fetch min and max timestamp for a metric

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
+import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransformer;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.api.jaxrs.util.MetricTypeTextConverter;
 import org.hawkular.metrics.core.service.Functions;
@@ -162,6 +163,7 @@ public class MetricHandler {
             return;
         }
 
+        @SuppressWarnings("unchecked")
         Func1<Metric<T>, Boolean>[] metricFuncs = ObjectArrays.newArray(Func1.class, 0);
         if(!Strings.isNullOrEmpty(id)) {
             metricFuncs = ObjectArrays.concat(metricFuncs, metricsService.idFilter(id));
@@ -172,6 +174,7 @@ public class MetricHandler {
                 : metricsService.findMetricsWithFilters(tenantId, metricType, tags.getTags(), metricFuncs);
 
         metricObservable
+                .compose(new MinMaxTimestampTransformer<>(metricsService))
                 .toList()
                 .map(ApiUtils::collectionToResponse)
                 .subscribe(asyncResponse::resume, t -> {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/transformer/MinMaxTimestampTransformer.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/transformer/MinMaxTimestampTransformer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.api.jaxrs.handler.transformer;
+
+import org.hawkular.metrics.core.service.MetricsService;
+import org.hawkular.metrics.core.service.Order;
+import org.hawkular.metrics.model.Metric;
+import org.hawkular.metrics.model.MetricId;
+
+import rx.Observable;
+import rx.Observable.Transformer;
+
+/**
+ * Transforms a sequence of {@code Metric} to provide min and max timestamp fields.
+ *
+ * @author Thomas Segismont
+ */
+public class MinMaxTimestampTransformer<T> implements Transformer<Metric<T>, Metric<T>> {
+    private final MetricsService metricsService;
+
+    public MinMaxTimestampTransformer(MetricsService metricsService) {
+        this.metricsService = metricsService;
+    }
+
+    @Override
+    public Observable<Metric<T>> call(Observable<Metric<T>> metricObservable) {
+        return metricObservable.flatMap(metric -> {
+            long now = System.currentTimeMillis();
+            MetricId<T> metricId = metric.getMetricId();
+            return metricsService.findDataPoints(metricId, 0, now, 1, Order.ASC)
+                    .zipWith(metricsService.findDataPoints(metricId, 0, now, 1, Order.DESC), (p1, p2) -> {
+                        return new Metric<>(metric, p1.getTimestamp(), p2.getTimestamp());
+                    })
+                    .switchIfEmpty(Observable.just(metric));
+        });
+    }
+}

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/Metric.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/Metric.java
@@ -50,6 +50,8 @@ public class Metric<T> {
     private final Map<String, String> tags;
     private final Integer dataRetention;
     private final List<DataPoint<T>> dataPoints;
+    private final Long minTimestamp;
+    private final Long maxTimestamp;
 
     @SuppressWarnings("unchecked")
     @JsonCreator(mode = Mode.PROPERTIES)
@@ -82,6 +84,7 @@ public class Metric<T> {
         this.tags = tags == null ? emptyMap() : unmodifiableMap(tags);
         this.dataRetention = dataRetention;
         this.dataPoints = data == null || data.isEmpty() ? emptyList() : unmodifiableList(data);
+        this.minTimestamp = this.maxTimestamp = null;
     }
 
     public Metric(String id, Map<String, String> tags, Integer dataRetention, MetricType<T> type,
@@ -117,6 +120,23 @@ public class Metric<T> {
         this.tags = unmodifiableMap(tags);
         this.dataRetention = dataRetention;
         this.dataPoints = unmodifiableList(dataPoints);
+        this.minTimestamp = this.maxTimestamp = null;
+    }
+
+    /**
+     * Creates a new instance by copying the specified one, except the min and max timestamp fields.
+     *
+     * @param other        the instance to copy
+     * @param minTimestamp the new value for min timestamp
+     * @param maxTimestamp the new value for max timestamp
+     */
+    public Metric(Metric<T> other, long minTimestamp, long maxTimestamp) {
+        this.id = other.id;
+        this.tags = other.tags;
+        this.dataRetention = other.dataRetention;
+        this.dataPoints = other.dataPoints;
+        this.minTimestamp = minTimestamp;
+        this.maxTimestamp = maxTimestamp;
     }
 
     public String getId() {
@@ -153,6 +173,18 @@ public class Metric<T> {
     @JsonSerialize(include = Inclusion.NON_EMPTY)
     public List<DataPoint<T>> getDataPoints() {
         return dataPoints;
+    }
+
+    @ApiModelProperty("Timestamp of the metric's oldest data point")
+    @JsonSerialize(include = Inclusion.NON_EMPTY)
+    public Long getMinTimestamp() {
+        return minTimestamp;
+    }
+
+    @ApiModelProperty("Timestamp of the metric's most recent data point")
+    @JsonSerialize(include = Inclusion.NON_EMPTY)
+    public Long getMaxTimestamp() {
+        return maxTimestamp;
     }
 
     @Override

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CORSITest.groovy
@@ -141,13 +141,10 @@ class CORSITest extends RESTTest {
     response = hawkularMetrics.get(path: "metrics", query: [type: "gauge"], headers: [(tenantHeaderName): tenantId])
 
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            [dataRetention: 7, tenantId: tenantId, id: "m11", type: "gauge"],
-            [dataRetention: 7, tenantId: tenantId, id: "m12", type: "gauge"],
-        ],
-        response.data
-    )
+    assertEquals([
+        [dataRetention: 7, tenantId: tenantId, id: "m11", type: "gauge", minTimestamp: start.millis, maxTimestamp: start.plusMinutes(1).millis],
+        [dataRetention: 7, tenantId: tenantId, id: "m12", type: "gauge", minTimestamp: start.millis, maxTimestamp: start.plusMinutes(1).millis],
+    ], (response.data as List).sort({ m1, m2 -> m1.id.compareTo(m2.id) }))
 
     //Send a CORS pre-flight request and make sure it returns no data
     response = hawkularMetrics.options(path: "metrics",
@@ -182,13 +179,10 @@ class CORSITest extends RESTTest {
     responseHeaders += "==== Response Headers = End ====\n"
 
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            [dataRetention: 7, tenantId: tenantId, id: "m11", type: "gauge"],
-            [dataRetention: 7, tenantId: tenantId, id: "m12", type: "gauge"],
-        ],
-        response.data
-    )
+    assertEquals([
+        [dataRetention: 7, tenantId: tenantId, id: "m11", type: "gauge", minTimestamp: start.millis, maxTimestamp: start.plusMinutes(1).millis],
+        [dataRetention: 7, tenantId: tenantId, id: "m12", type: "gauge", minTimestamp: start.millis, maxTimestamp: start.plusMinutes(1).millis],
+    ], (response.data as List).sort({ m1, m2 -> m1.id.compareTo(m2.id) }))
     assertEquals(responseHeaders, DEFAULT_CORS_ACCESS_CONTROL_ALLOW_METHODS, response.headers[ACCESS_CONTROL_ALLOW_METHODS].value)
     assertEquals(responseHeaders, testAccessControlAllowHeaders, response.headers[ACCESS_CONTROL_ALLOW_HEADERS].value)
     assertEquals(responseHeaders, testOrigin, response.headers[ACCESS_CONTROL_ALLOW_ORIGIN].value)

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CassandraBackendITest.groovy
@@ -497,14 +497,11 @@ class CassandraBackendITest extends RESTTest {
     response = hawkularMetrics.get(path: "metrics", query: [type: 'gauge'], headers: [(tenantHeaderName): tenantId])
 
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            [dataRetention: 7, tenantId: tenantId, id: 'm11', type: 'gauge'],
-            [dataRetention: 7, tenantId: tenantId, id: 'm12', type: 'gauge'],
-            [tenantId: tenantId, id: 'm13', tags: [a1: 'A', B1: 'B'], dataRetention: 32, type: 'gauge']
-        ],
-        response.data
-    )
+    assertEquals([
+        [dataRetention: 7, tenantId: tenantId, id: 'm11', type: 'gauge', minTimestamp: start.millis, maxTimestamp: start.plusMinutes(1).millis],
+        [dataRetention: 7, tenantId: tenantId, id: 'm12', type: 'gauge', minTimestamp: start.millis, maxTimestamp: start.plusMinutes(1).millis],
+        [tenantId: tenantId, id: 'm13', tags: [a1: 'A', B1: 'B'], dataRetention: 32, type: 'gauge']
+    ], (response.data as List).sort({ m1, m2 -> m1.id.compareTo(m2.id) }))
 
     // Create a couple availability metrics by only inserting data
     response = hawkularMetrics.post(path: "availability/raw", body: [
@@ -537,14 +534,11 @@ class CassandraBackendITest extends RESTTest {
     response = hawkularMetrics.get(path: "metrics", query: [type: 'availability'], headers: [(tenantHeaderName): tenantId])
 
     assertEquals(200, response.status)
-    assertEquals(
-        [
-            [dataRetention: 7, tenantId: tenantId, id: 'm14', type: 'availability'],
-            [dataRetention: 7, tenantId: tenantId, id: 'm15', type: 'availability'],
-            [tenantId: tenantId, id: 'm16', tags: [a10: '10', a11: '11'], dataRetention: 7, type: 'availability']
-        ],
-        response.data
-    )
+    assertEquals([
+        [dataRetention: 7, tenantId: tenantId, id: 'm14', type: 'availability', minTimestamp: start.millis, maxTimestamp: start.plusMinutes(1).millis],
+        [dataRetention: 7, tenantId: tenantId, id: 'm15', type: 'availability', minTimestamp: start.millis, maxTimestamp: start.plusMinutes(1).millis],
+        [tenantId: tenantId, id: 'm16', tags: [a10: '10', a11: '11'], dataRetention: 7, type: 'availability']
+    ], (response.data as List).sort({ m1, m2 -> m1.id.compareTo(m2.id) }))
 
     // Explicitly create metrics with payload type
     response = hawkularMetrics.post(path: "metrics", body: [

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
@@ -18,6 +18,7 @@ package org.hawkular.metrics.rest
 
 import static org.joda.time.DateTime.now
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
 
 import org.joda.time.DateTime
 import org.junit.Test
@@ -297,5 +298,55 @@ class GaugesITest extends RESTTest {
         ]
     ]
     assertEquals(expectedData, response.data)
+  }
+
+  @Test
+  void minMaxTimestamps() {
+    def tenantId = nextTenantId()
+    def metricId = 'minmaxtest'
+
+    def response = hawkularMetrics.post(path: 'gauges', headers: [(tenantHeaderName): tenantId], body: [
+        id: metricId
+    ])
+    assertEquals(201, response.status)
+
+    response = hawkularMetrics.get(path: "gauges/${metricId}", headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    assertFalse("Metric should not have the minTimestamp attribute: ${response.data}", response.data.containsKey('minTimestamp'))
+    assertFalse("Metric should not have the maxTimestamp attribute: ${response.data}", response.data.containsKey('maxTimestamp'))
+
+    response = hawkularMetrics.post(path: "gauges/${metricId}/raw", headers: [(tenantHeaderName): tenantId], body: [
+        [timestamp: 3, value: 4.2]
+    ])
+    assertEquals(200, response.status)
+
+    response = hawkularMetrics.get(path: "gauges/${metricId}", headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    assertEquals(3, response.data.minTimestamp)
+    assertEquals(3, response.data.maxTimestamp)
+
+    response = hawkularMetrics.post(path: "gauges/${metricId}/raw", headers: [(tenantHeaderName): tenantId], body: [
+        [timestamp: 1, value: 2.2],
+        [timestamp: 2, value: 1.2],
+        [timestamp: 4, value: 7.2],
+    ])
+    assertEquals(200, response.status)
+
+    response = hawkularMetrics.get(path: "gauges/${metricId}", headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    assertEquals(1, response.data.minTimestamp)
+    assertEquals(4, response.data.maxTimestamp)
+
+    response = hawkularMetrics.get(path: "gauges", headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    def metric = (response.data as List).find { it.id.equals(metricId) }
+    assertEquals(1, metric.minTimestamp)
+    assertEquals(4, metric.maxTimestamp)
+
+    response = hawkularMetrics.get(path: "metrics", headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    metric = (response.data as List).find { it.id.equals(metricId) }
+    assertEquals(1, metric.minTimestamp)
+    assertEquals(4, metric.maxTimestamp)
   }
 }


### PR DESCRIPTION
Added a MinMaxTimestampTransformer which loads min and max timestamp for each metric in a sequence.
Applied the transformer to all endpoints fetching metric definitions.