### PR TITLE
HWKMETRICS-365 Support rate data for gauge metrics

### DIFF
--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -272,10 +272,11 @@ public interface MetricsService {
             long start, long end, List<Double> percentiles);
 
     /**
-     * Fetches counter data points and calculates per-minute rates. Resets events are detected and values reported
-     * after a reset are filtered out before doing calculations in order to avoid inaccurate rates.
+     * Fetches gauge or counter data points and calculates per-minute rates.
+     * For {@link MetricType#COUNTER}, reset events are detected and values reported after a reset are filtered out
+     * before doing calculations in order to avoid inaccurate rates.
      *
-     * @param id    This is the id of the counter metric
+     * @param id    This is the id of the metric
      * @param start The start time which is inclusive
      * @param end   The end time which is exclusive
      * @param limit      limit the number of data points
@@ -284,20 +285,21 @@ public interface MetricsService {
      * @return An Observable of {@link DataPoint data points} which are emitted in ascending order. In other words,
      * the most recent data is emitted first.
      */
-    Observable<DataPoint<Double>> findRateData(MetricId<Long> id, long start, long end, int limit, Order order);
+    Observable<DataPoint<Double>> findRateData(MetricId<? extends Number> id, long start, long end, int limit,
+                                               Order order);
 
     /**
-     * Computes stats on a counter rate.
+     * Computes stats on a counter or gauge rate.
      *
-     * @param id      counter metric id
+     * @param id      metric id
      * @param start   start time, inclusive
      * @param end     end time, exclusive
      * @param buckets bucket configuration
      *
      * @return an {@link Observable} emitting a single {@link List} of {@link NumericBucketPoint}
      */
-    Observable<List<NumericBucketPoint>> findRateStats(MetricId<Long> id, long start, long end, Buckets buckets,
-                                                       List<Double> percentiles);
+    Observable<List<NumericBucketPoint>> findRateStats(MetricId<? extends Number> id, long start, long end,
+                                                       Buckets buckets, List<Double> percentiles);
 
     /**
      * <p>

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/MetricType.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/MetricType.java
@@ -35,12 +35,20 @@ public final class MetricType<T> {
     public static final MetricType<Long> COUNTER = new MetricType<>((byte) 2, "counter", true);
     public static final MetricType<Double> COUNTER_RATE = new MetricType<>((byte) 3, "counter_rate", false);
     public static final MetricType<String> STRING = new MetricType<>((byte) 4, "string", true);
+    public static final MetricType<Double> GAUGE_RATE = new MetricType<>((byte) 5, "gauge_rate", false);
 
     @SuppressWarnings("rawtypes")
     public static final MetricType UNDEFINED = new MetricType((byte) 127, "undefined", false);
     // If you add a new type: don't forget to update the "all" and "userTypes" sets
 
-    private static final Set<MetricType<?>> all = ImmutableSet.of(GAUGE, AVAILABILITY, COUNTER, COUNTER_RATE);
+    private static final Set<MetricType<?>> all = new ImmutableSet.Builder<MetricType<?>>()
+            .add(GAUGE)
+            .add(AVAILABILITY)
+            .add(COUNTER)
+            .add(COUNTER_RATE)
+            .add(STRING)
+            .add(GAUGE_RATE)
+            .build();
 
     private static final Set<MetricType<?>> userTypes;
     private static final Map<Byte, MetricType<?>> codes;

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -693,11 +693,6 @@ Actual:   ${response.data}
     assertNumericBucketsEquals(expectedData, response.data ?: [])
   }
 
-  static void assertRateEquals(String msg, def expected, def actual) {
-    assertEquals(msg, expected.timestamp, actual.timestamp)
-    assertDoubleEquals(msg, expected.value, actual.value)
-  }
-
   @Test
   void shouldStoreLargePayload() {
     checkLargePayload("counters", tenantId, { points, i -> points.push([timestamp: i, value: i]) })

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -191,7 +191,7 @@ Actual: ${actual}
 
   static double avg(List values) {
     Mean mean = new Mean()
-    values.each { mean.increment(it) }
+    values.each { mean.increment(it as double) }
     return mean.result
   }
 
@@ -202,5 +202,10 @@ Actual: ${actual}
     assertDoubleEquals(expected.avg, actual.avg)
     assertDoubleEquals(expected.median, actual.median)
     assertEquals(expected.samples, actual.samples)
+  }
+
+  static void assertRateEquals(String msg, def expected, def actual) {
+    assertEquals(msg, expected.timestamp, actual.timestamp)
+    assertDoubleEquals(msg, expected.value, actual.value)
   }
 }


### PR DESCRIPTION
Added rate related endpoints to GaugeHandler
Added GAUGE_RATE internal type (also, added missing STRING type to the "all" set in MetricType)
Changed MetricsService API so that rate and rate stats work on Metric<? extends Number> instead of Metric<Long>
Updated multiple metric stats algorithms to support GAUGE_RATE