### PR TITLE
Add JMH benchmarking capabilities

### DIFF
--- a/integration-tests/jmh-benchmark/pom.xml
+++ b/integration-tests/jmh-benchmark/pom.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>hawkular-metrics-parent</artifactId>
+    <groupId>org.hawkular.metrics</groupId>
+    <version>0.17.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>hawkular-metrics-jmh-benchmark</artifactId>
+
+  <properties>
+    <jmh.version>1.12</jmh.version>
+    <jar.name>benchmark</jar.name>
+    <javac.target>1.8</javac.target>
+  </properties>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>org.hawkular.metrics</groupId>
+      <artifactId>hawkular-metrics-core-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>${version.io.reactivex.rxjava}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <version>${version.org.jboss.logging}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scassandra</groupId>
+      <artifactId>java-client</artifactId>
+      <version>1.0.9</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <compilerVersion>${javac.target}</compilerVersion>
+          <source>${javac.target}</source>
+          <target>${javac.target}</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${jar.name}</finalName>
+              <!--<minimizeJar>false</minimizeJar>-->
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <!--
+                      Shading signed JARs will fail without this.
+                      http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                  -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.5</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.9.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.6</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.2.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.17</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/integration-tests/jmh-benchmark/run.sh
+++ b/integration-tests/jmh-benchmark/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#mvn clean install
+java -Xmx2048m -Xms1024m -jar target/benchmark.jar

--- a/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/InsertBenchmark.java
+++ b/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/InsertBenchmark.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.benchmark.jmh;
+
+import static org.hawkular.metrics.model.MetricType.GAUGE;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.hawkular.metrics.benchmark.jmh.util.LiveCassandraManager;
+import org.hawkular.metrics.benchmark.jmh.util.MetricServiceManager;
+import org.hawkular.metrics.core.service.MetricsService;
+import org.hawkular.metrics.model.DataPoint;
+import org.hawkular.metrics.model.Metric;
+import org.hawkular.metrics.model.MetricId;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * Creates benchmarks that use MetricsServiceImpl directly, without creating JSON or REST overhead. This should
+ * allow testing the internal speed of our MetricsService/DataAccess implementations. The backend of Session
+ * object is configurable.
+ *
+ * @author Michael Burman
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10) // Reduce the amount of iterations if you start to see GC interference
+public class InsertBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class ServiceCreator {
+        private MetricsService metricsService;
+        private MetricServiceManager metricsManager;
+
+        @Setup
+        public void setup() {
+            metricsManager = new MetricServiceManager(new LiveCassandraManager());
+//            metricsManager = new MetricServiceManager(new SCassandraManager());
+//            metricsManager = new MetricServiceManager(new MockCassandraManager());
+            metricsService = metricsManager.getMetricsService();
+        }
+
+        @TearDown
+        public void shutdown() {
+            metricsManager.shutdown();
+        }
+
+        public MetricsService getMetricsService() {
+            return metricsService;
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class GaugeMetricCreator {
+
+        @Param({"100000"}) // 1M caused some GC issues and unstable test results
+        public int size;
+
+        @Param({"1", "10"})
+        public int datapointsPerMetric;
+
+        private Observable<Metric<Double>> metricObservable;
+
+        @Setup
+        public void setup() {
+            size = size*datapointsPerMetric;
+            final long timestamp = System.currentTimeMillis();
+
+            metricObservable = Observable.create(s -> {
+                for (int i = 0; i < size; i += datapointsPerMetric) {
+                    List<DataPoint<Double>> points = new ArrayList<>();
+                    for (int j = 0; j < datapointsPerMetric; j++) {
+                        points.add(new DataPoint<>(timestamp + i, (double) j));
+                    }
+                    Metric<Double> metric =
+                            new Metric<>(new MetricId<>("b", GAUGE, "insert.metrics.test." + i), points);
+                    s.onNext(metric);
+                }
+                s.onCompleted();
+            });
+        }
+
+        public Observable<Metric<Double>> getMetricObservable() {
+            return metricObservable;
+        }
+    }
+
+    // Equivalent to REST-tests for inserting size-amount of metrics in one call
+    @Benchmark
+    @OperationsPerInvocation(100000) // Note, this is metric amount from param size, not datapoints
+    public void insertBenchmark(GaugeMetricCreator creator, ServiceCreator service, Blackhole bh) {
+        GenericSubscriber<Void> insertSubscriber = new GenericSubscriber<>(Long.MAX_VALUE, bh);
+        bh.consume(insertSubscriber);
+
+        bh.consume(service.getMetricsService().addDataPoints(GAUGE, creator.getMetricObservable())
+                .toBlocking().lastOrDefault(null));
+    }
+
+    // Equivalent of REST-test for inserting for single-metric id one call
+    @Benchmark
+//    @Warmup(batchSize = 50000, iterations = 5)
+//    @Measurement(batchSize = 50000, iterations = 5)
+//    @BenchmarkMode(Mode.SingleShotTime)
+    @OperationsPerInvocation(100000) // Note, this is metric amount from param size, not datapoints
+    public void insertBenchmarkSingle(GaugeMetricCreator creator, ServiceCreator service, Blackhole bh) {
+        GenericSubscriber<Void> insertSubscriber = new GenericSubscriber<>(Long.MAX_VALUE, bh);
+        bh.consume(insertSubscriber);
+
+        bh.consume(creator.getMetricObservable()
+                .flatMap(m -> service.getMetricsService().addDataPoints(GAUGE, Observable.just(m)))
+                .toBlocking().lastOrDefault(null));
+    }
+
+    private static final class GenericSubscriber<T> extends Subscriber<T> {
+        final Blackhole bh;
+        public GenericSubscriber(long r, Blackhole bh) {
+            this.bh = bh;
+            request(r);
+        }
+
+        @Override
+        public void onNext(T t) {
+            bh.consume(t);
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            e.printStackTrace();
+        }
+
+        @Override
+        public void onCompleted() {
+
+        }
+    }
+}

--- a/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/ClusterManager.java
+++ b/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/ClusterManager.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.benchmark.jmh.util;
+
+import com.datastax.driver.core.Session;
+
+/**
+ * @author Michael Burman
+ */
+public interface ClusterManager {
+
+    void startCluster();
+    Session createSession();
+    void shutdown();
+}

--- a/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/LiveCassandraManager.java
+++ b/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/LiveCassandraManager.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.benchmark.jmh.util;
+
+import java.util.Arrays;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+
+/**
+ * Maintains the session and cluster lifecycle of real Cassandra connection.
+ *
+ * @author Michael Burman
+ */
+public class LiveCassandraManager implements ClusterManager {
+
+    private Cluster cluster;
+    private Session session;
+    private String nodes;
+
+    @Override
+    public void startCluster() {
+        nodes = System.getProperty("hawkular-metrics.cassandra-nodes", "127.0.0.1");
+    }
+
+    @Override
+    public Session createSession() {
+        Cluster.Builder clusterBuilder = new Cluster.Builder();
+
+        Arrays.stream(nodes.split(",")).forEach(clusterBuilder::addContactPoints);
+        clusterBuilder.withPort(9042);
+        clusterBuilder.withoutJMXReporting();
+
+        cluster = clusterBuilder.build();
+        cluster.init();
+        try {
+            session = cluster.connect("system");
+            return session;
+        } finally {
+            if (session == null) {
+                cluster.close();
+            }
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        session.close();
+        cluster.close();
+    }
+}

--- a/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/MetricServiceManager.java
+++ b/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/MetricServiceManager.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.benchmark.jmh.util;
+
+import org.hawkular.metrics.core.service.DataAccessImpl;
+import org.hawkular.metrics.core.service.MetricsServiceImpl;
+import org.hawkular.metrics.schema.SchemaService;
+import org.hawkular.metrics.sysconfig.ConfigurationService;
+import org.hawkular.rx.cassandra.driver.RxSessionImpl;
+
+import com.codahale.metrics.MetricRegistry;
+import com.datastax.driver.core.Session;
+
+/**
+ * MetricsService lifecycle management, influenced by the MetricsServiceLifecycle from JAX-RS module
+ *
+ * @author Michael Burman
+ */
+public class MetricServiceManager {
+
+    private static final int DEFAULT_TTL = 7;
+    private MetricsServiceImpl metricsService;
+    private ClusterManager manager;
+    private String keyspace;
+
+    public MetricServiceManager(ClusterManager manager) {
+        this.manager = manager;
+        manager.startCluster();
+        Session session = manager.createSession();
+        keyspace = System.getProperty("cassandra.keyspace", "benchmark");
+        metricsService = createMetricsService(session);
+    }
+
+    private MetricsServiceImpl createMetricsService(Session session) {
+        SchemaService schemaService = new SchemaService();
+        schemaService.run(session, keyspace, true);
+
+        ConfigurationService configurationService = new ConfigurationService();
+        configurationService.init(new RxSessionImpl(session));
+
+        selectKeyspace(session);
+
+        metricsService = new MetricsServiceImpl();
+        metricsService.setDataAccess(new DataAccessImpl(session));
+        metricsService.setConfigurationService(configurationService);
+        metricsService.setDefaultTTL(DEFAULT_TTL);
+
+        MetricRegistry metricRegistry = new MetricRegistry();
+
+        metricsService.startUp(session, keyspace, false, false, metricRegistry);
+
+        return metricsService;
+    }
+
+    private void selectKeyspace(Session session) {
+        session.execute("USE " + keyspace);
+    }
+
+    public MetricsServiceImpl getMetricsService() {
+        return metricsService;
+    }
+
+    public void shutdown() {
+        metricsService.shutdown();
+        manager.shutdown();
+    }
+}

--- a/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/MockCassandraManager.java
+++ b/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/MockCassandraManager.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.benchmark.jmh.util;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.mockito.Mockito;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.RegularStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+
+/**
+ * ClusterManager based on the idea of Mocking the Session object
+ *
+ * @author Michael Burman
+ */
+public class MockCassandraManager implements ClusterManager {
+
+    @Override
+    public void startCluster() {
+
+    }
+
+    @Override
+    public Session createSession() {
+        Session session = mock(Session.class);
+        ResultSet result = mock(ResultSet.class);
+
+        List<Row> rows = new ArrayList<>();
+        Mockito.doReturn(rows).when(result).all();
+        Mockito.doReturn(true).when(result).isFullyFetched();
+
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        BoundStatement boundStatement = mock(BoundStatement.class);
+        when(session.prepare(any(RegularStatement.class))).thenReturn(preparedStatement);
+        when(preparedStatement.bind()).thenReturn(boundStatement);
+        when(boundStatement.setString(any(String.class), any(String.class))).thenReturn(boundStatement);
+
+        ResultSetFuture future = mock(ResultSetFuture.class);
+        try {
+            Mockito.doReturn(result).when(future).get();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        }
+        Mockito.doReturn(future).when(session).executeAsync(Mockito.anyString());
+        return session;
+    }
+
+    @Override public void shutdown() {
+
+    }
+}

--- a/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/SCassandraManager.java
+++ b/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/util/SCassandraManager.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.benchmark.jmh.util;
+
+import static org.scassandra.http.client.PrimingRequest.PrimingRequestBuilder;
+import static org.scassandra.http.client.PrimingRequest.then;
+
+import org.scassandra.Scassandra;
+import org.scassandra.ScassandraFactory;
+import org.scassandra.http.client.ActivityClient;
+import org.scassandra.http.client.PrimingClient;
+import org.scassandra.http.client.PrimingRequest;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * ClusterManager that maintains the Scassandra implementation. Add additional statements to primeStatements if you
+ * wish to test additional features (or behavior change).
+ *
+ * @author Michael Burman
+ */
+public class SCassandraManager implements ClusterManager {
+
+    private Scassandra scassandra;
+    private PrimingClient primingClient;
+    private ActivityClient activityClient;
+
+    private Session session;
+    private Cluster cluster;
+
+    public SCassandraManager() {
+    }
+
+    @Override
+    public void startCluster() {
+        scassandra = ScassandraFactory.createServer();
+        scassandra.start();
+        primingClient = scassandra.primingClient();
+        activityClient = scassandra.activityClient();
+
+        primeStatements();
+    }
+
+    public Session createSession() {
+        if(cluster == null || session == null) {
+            cluster = Cluster.builder()
+                    .addContactPoint("localhost")
+                    .withPort(8042)
+                    .build();
+            session = cluster.connect("scassandra");
+        }
+        return session;
+    }
+
+    // Selected queries copied from DataAccessImpl
+    private void primeStatements() {
+        PrimingRequestBuilder findAllTenantIds = PrimingRequest.preparedStatementBuilder()
+                .withQuery("SELECT DISTINCT id FROM tenants")
+                .withThen(then()
+                        .withRows(ImmutableMap.of("id", "hawkular")));
+        primingClient.prime(findAllTenantIds);
+
+        PrimingRequestBuilder findAllTenantIdsFromMetricsIdx = PrimingRequest.preparedStatementBuilder()
+                .withQuery("SELECT DISTINCT tenant_id, type FROM metrics_idx");
+
+        primingClient.prime(findAllTenantIdsFromMetricsIdx);
+    }
+
+    public void shutdown() {
+        session.close();
+        cluster.close();
+        scassandra.stop();
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -46,5 +46,11 @@
         <module>load-tests</module>
       </modules>
     </profile>
+    <profile>
+      <id>benchmark</id>
+      <modules>
+        <module>jmh-benchmark</module>
+      </modules>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This PR creates JMH based benchmarking setups to assist in finding the bottlenecks. Completely skips the REST-layer, JSON transformations and runtime (Wildfly), instead writing directly to the core-service.

The output looks like:

```
# Run complete. Total time: 00:09:58

Benchmark                              (datapointsPerMetric)  (size)  Mode  Cnt   Score   Error  Units
InsertBenchmark.insertBenchmark                            1  100000  avgt   10   4.489 ± 0.193   s/op
InsertBenchmark.insertBenchmark                           10  100000  avgt   10   8.655 ± 3.612   s/op
InsertBenchmark.insertBenchmarkSingle                      1  100000  avgt   10   8.881 ± 2.360   s/op
InsertBenchmark.insertBenchmarkSingle                     10  100000  avgt   10  11.152 ± 2.108   s/op
```

The Scassandra implementation and Mockito implementations do not work. The Scassandra throws some Scala induced issues at this point (Akka actor stuff) and Mockito requires more mocks to get MetricsService to understand findAllTenantIds and such methods (they cause NPE at this point).