### PR TITLE
HWKMETRICS-412 Add CORS filters back to hawkular component

### DIFF
--- a/hawkular-component/pom.xml
+++ b/hawkular-component/pom.xml
@@ -135,11 +135,6 @@
             <overlay>
               <groupId>${project.groupId}</groupId>
               <artifactId>hawkular-metrics-api-jaxrs</artifactId>
-              <excludes>
-                <exclude>**/CorsRequestFilter.class</exclude>
-                <exclude>**/CorsResponseFilter.class</exclude>
-                <exclude>**/OriginValidation.class</exclude>
-              </excludes>
             </overlay>
           </overlays>
         </configuration>


### PR DESCRIPTION
When Metrics was integrated with Accounts, the CORS filters were removed
because CORS had to be managed by Keycloak.

Now that Accounts is removed, we must add them back, otherwise we can't
send CORS requests to Metrics.