### PR TITLE
Gets around the 'unknown error' message in the log

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -228,7 +228,14 @@ public class MetricsServiceLifecycle {
             session = createSession();
         } catch (Exception t) {
             Throwable rootCause = Throwables.getRootCause(t);
-            log.warnCouldNotConnectToCassandra(rootCause.getLocalizedMessage());
+
+            // to get around HWKMETRICS-415
+            if (rootCause.getLocalizedMessage().equals(this.nodes + ": unknown error")) {
+                log.warnCouldNotConnectToCassandra("Could not resolve hostname: " + rootCause.getLocalizedMessage());
+            } else {
+                log.warnCouldNotConnectToCassandra(rootCause.getLocalizedMessage());
+            }
+
             // cycle between original and more wait time - avoid waiting huge amounts of time
             long delay = 1L + ((connectionAttempts - 1L) % 4L);
             log.warnRetryingConnectingToCassandra(connectionAttempts, delay);


### PR DESCRIPTION
This gets around an issue where users can see an 'unknown error' message in the logs when the Cassandra hostname could not be resolved.

Updates the log message to make it a bit more user friendly