### PR TITLE
HWKMETRICS-417 Improve performance of write path

### DIFF
--- a/integration-tests/jmh-benchmark/pom.xml
+++ b/integration-tests/jmh-benchmark/pom.xml
@@ -77,6 +77,18 @@
       <artifactId>java-client</artifactId>
       <version>1.0.9</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.biboudis</groupId>
+      <artifactId>jmh-profilers</artifactId>
+      <version>0.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>4.0.33.Final</version>
+      <classifier>linux-x86_64</classifier>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -196,7 +196,9 @@ class CountersITest extends RESTTest {
     ]
 
     assertEquals(2, response.data.size())
-    assertEquals(expectedData, response.data)
+    expectedData.each { d ->
+      assertTrue(response.data.contains(d))
+    }
   }
 
   @Test


### PR DESCRIPTION
Use mergeWith instead of concat and map the result to null as we don't use it at the moment. On my machine this improved the benchmark writes by about 10% (not including JAX-RS layer).

Also replace the test Observable.create with Observable.from(list) as it reduces the impact of test. Added support for JMC (Java Mission Control) profiler. Also the test uses now Netty native epoll on linux-x86_64, this further improves the performance by another 5-10% by reducing the CPU load of Cassandra driver (we should probably consider using this elsewhere also).