### PR TITLE
HWKMETRICS-420 Add ADMIN AvailabilityType

### DIFF
--- a/bus/src/test/java/org/hawkular/bus/PublishDataPointsTest.java
+++ b/bus/src/test/java/org/hawkular/bus/PublishDataPointsTest.java
@@ -19,6 +19,7 @@ package org.hawkular.bus;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
+import static org.hawkular.metrics.model.AvailabilityType.ADMIN;
 import static org.hawkular.metrics.model.AvailabilityType.DOWN;
 import static org.hawkular.metrics.model.AvailabilityType.UNKNOWN;
 import static org.hawkular.metrics.model.AvailabilityType.UP;
@@ -148,7 +149,8 @@ public class PublishDataPointsTest {
         Metric<AvailabilityType> availability = new Metric<>(new MetricId<>(tenantId, AVAILABILITY, metricId), asList(
                 new DataPoint<>(System.currentTimeMillis(), UP),
                 new DataPoint<>(System.currentTimeMillis() - 1000, DOWN),
-                new DataPoint<>(System.currentTimeMillis() - 2000, UNKNOWN)
+                new DataPoint<>(System.currentTimeMillis() - 2000, UNKNOWN),
+                new DataPoint<>(System.currentTimeMillis() - 3000, ADMIN)
         ));
 
         Observable<Metric<?>> observable = Observable.just(availability);

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/AvailabilityBucketPointMatcher.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/AvailabilityBucketPointMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,11 +37,11 @@ public class AvailabilityBucketPointMatcher extends TypeSafeMatcher<Availability
     @Override
     protected boolean matchesSafely(AvailabilityBucketPoint item) {
         return item.getStart() == expected.getStart()
-               && item.getEnd() == expected.getEnd()
-               && item.getDowntimeCount() == expected.getDowntimeCount()
-               && item.getDowntimeDuration() == expected.getDowntimeDuration()
-               && item.getLastDowntime() == expected.getLastDowntime()
-               && DoubleMath.fuzzyEquals(item.getUptimeRatio(), expected.getUptimeRatio(), 0.001);
+                && item.getEnd() == expected.getEnd()
+                && item.getNotUpCount() == expected.getNotUpCount()
+                && item.getDurationMap().equals(expected.getDurationMap())
+                && item.getLastNotUptime() == expected.getLastNotUptime()
+                && DoubleMath.fuzzyEquals(item.getUptimeRatio(), expected.getUptimeRatio(), 0.001);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class AvailabilityBucketPointMatcher extends TypeSafeMatcher<Availability
     @Factory
     public static Matcher<AvailabilityBucketPoint> matchesAvailabilityBucketPoint(
             AvailabilityBucketPoint expected
-    ) {
+            ) {
         return new AvailabilityBucketPointMatcher(expected);
     }
 }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/AvailabilityITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/AvailabilityITest.java
@@ -23,6 +23,7 @@ import static java.util.Collections.singletonList;
 
 import static org.hawkular.metrics.core.service.DataAccessImpl.DPART;
 import static org.hawkular.metrics.core.service.TimeUUIDUtils.getTimeUUID;
+import static org.hawkular.metrics.model.AvailabilityType.ADMIN;
 import static org.hawkular.metrics.model.AvailabilityType.DOWN;
 import static org.hawkular.metrics.model.AvailabilityType.UNKNOWN;
 import static org.hawkular.metrics.model.AvailabilityType.UP;
@@ -138,7 +139,8 @@ public class AvailabilityITest extends BaseMetricsITest {
                 new DataPoint<>(start.plusMinutes(7).getMillis(), UNKNOWN),
                 new DataPoint<>(start.plusMinutes(8).getMillis(), UNKNOWN),
                 new DataPoint<>(start.plusMinutes(9).getMillis(), DOWN),
-                new DataPoint<>(start.plusMinutes(10).getMillis(), UP)));
+                new DataPoint<>(start.plusMinutes(10).getMillis(), ADMIN),
+                new DataPoint<>(start.plusMinutes(11).getMillis(), UP)));
 
         metricsService.addDataPoints(AVAILABILITY, Observable.just(metric)).toBlocking().lastOrDefault(null);
 
@@ -153,7 +155,8 @@ public class AvailabilityITest extends BaseMetricsITest {
                 metric.getDataPoints().get(5),
                 metric.getDataPoints().get(7),
                 metric.getDataPoints().get(9),
-                metric.getDataPoints().get(10));
+                metric.getDataPoints().get(10),
+                metric.getDataPoints().get(11));
 
         assertEquals(actual, expected, "The availability data does not match the expected values");
     }

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/AvailabilityType.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/AvailabilityType.java
@@ -29,7 +29,9 @@ public enum AvailabilityType {
 
     DOWN((byte) 1, "down"),
 
-    UNKNOWN((byte) 2, "unknown");
+    UNKNOWN((byte) 2, "unknown"),
+
+    ADMIN((byte) 3, "admin");
 
     private byte code;
 
@@ -60,6 +62,7 @@ public enum AvailabilityType {
             case "up"     : return UP;
             case "down"   : return DOWN;
             case "unknown": return UNKNOWN;
+            case "admin"  : return ADMIN;
             default: throw new IllegalArgumentException(s + " is not a recognized availability type");
         }
     }
@@ -69,6 +72,7 @@ public enum AvailabilityType {
             case 0 : return UP;
             case 1 : return DOWN;
             case 2 : return UNKNOWN;
+            case 3 : return ADMIN;
         default: throw new IllegalArgumentException(bytes.array()[0] + " is not a recognized availability type");
         }
     }


### PR DESCRIPTION
- Add ADMIN as avail value=3
- Needed to refactor AvailabilityBucketPoint
  - this was flawed as it assumed only UP and DOWN avail, ignoring UNKNOWN
    and now ADMIN.
  - this is publicly exposed via JSON in the GET avail REST endpoints
    - Kept as deprecated some obsolete fields for JSON back compatibility
    - ??? One question for reviewers: Is it OK to now expose a Map in the
      JSON or do you prefer replacing the map with explicit fields ???

@stefannegrea and/or @jsanda please review.