### PR TITLE
[HWKMETRICS-422] Add metrics index caches to avoid updating the metri…

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -30,6 +30,8 @@ import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_R
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_USESSL;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.DEFAULT_TTL;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.DISABLE_METRICS_JMX;
+import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.METRICS_INDEX_CACHE_EXPIRE_MINUTES;
+import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.METRICS_INDEX_CACHE_MAXIMUM_SIZE;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.USE_VIRTUAL_CLOCK;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.WAIT_FOR_SERVICE;
 
@@ -166,6 +168,16 @@ public class MetricsServiceLifecycle {
     private String disableMetricsJmxReporting;
 
     @Inject
+    @Configurable
+    @ConfigurationProperty(METRICS_INDEX_CACHE_EXPIRE_MINUTES)
+    private String metricsIndexCacheExpireMinutes;
+
+    @Inject
+    @Configurable
+    @ConfigurationProperty(METRICS_INDEX_CACHE_MAXIMUM_SIZE)
+    private String metricsIndexCacheMaximumSize;
+
+    @Inject
     @ServiceReady
     Event<ServiceReadyEvent> metricsServiceReady;
 
@@ -262,6 +274,9 @@ public class MetricsServiceLifecycle {
             metricsService.setTaskScheduler(taskScheduler);
             metricsService.setConfigurationService(configurationService);
             metricsService.setDefaultTTL(getDefaultTTL());
+
+            metricsService.resetCacheConfiguration(getDefaultMetricsIndexCacheExpireMinutes(),
+                    getDefaultMetricsIndexCacheMaximumSize());
 
             MetricRegistry metricRegistry = MetricRegistryProvider.INSTANCE.getMetricRegistry();
             if (!Boolean.parseBoolean(disableMetricsJmxReporting)) {
@@ -396,6 +411,25 @@ public class MetricsServiceLifecycle {
         } catch (NumberFormatException e) {
             log.warnInvalidDefaultTTL(defaultTTL, DEFAULT_TTL.defaultValue());
             return Integer.parseInt(DEFAULT_TTL.defaultValue());
+        }
+    }
+
+    private int getDefaultMetricsIndexCacheExpireMinutes() {
+        try {
+            return Integer.parseInt(metricsIndexCacheExpireMinutes);
+        } catch (NumberFormatException e) {
+            log.warnInvalidDefaultTTL(metricsIndexCacheExpireMinutes,
+                    METRICS_INDEX_CACHE_EXPIRE_MINUTES.defaultValue());
+            return Integer.parseInt(METRICS_INDEX_CACHE_EXPIRE_MINUTES.defaultValue());
+        }
+    }
+
+    private int getDefaultMetricsIndexCacheMaximumSize() {
+        try {
+            return Integer.parseInt(metricsIndexCacheMaximumSize);
+        } catch (NumberFormatException e) {
+            log.warnInvalidDefaultTTL(metricsIndexCacheMaximumSize, METRICS_INDEX_CACHE_MAXIMUM_SIZE.defaultValue());
+            return Integer.parseInt(METRICS_INDEX_CACHE_EXPIRE_MINUTES.defaultValue());
         }
     }
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -41,7 +41,11 @@ public enum ConfigurationKey {
     WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
     USE_VIRTUAL_CLOCK("hawkular.metrics.use-virtual-clock", "false", "USE_VIRTUAL_CLOCK", false),
     DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false),
-    DISABLE_METRICS_JMX("hawkular.metrics.disable-metrics-jmx-reporting", null, "DISABLE_METRICS_JMX", true);
+    DISABLE_METRICS_JMX("hawkular.metrics.disable-metrics-jmx-reporting", null, "DISABLE_METRICS_JMX", true),
+    METRICS_INDEX_CACHE_EXPIRE_MINUTES("hawkular.metrics.metrics-index-cache-expire-minutes",
+            "60", "METRICS_INDEX_CACHE_EXPIRE_MINUTES", false),
+    METRICS_INDEX_CACHE_MAXIMUM_SIZE("hawkular.metrics.metrics-index-cache-maximum-size",
+            "40000", "METRICS_INDEX_CACHE_MAXIMUM_SIZE", false);
 
     private final String name;
     private final String env;

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -262,7 +262,7 @@ public class MetricsServiceImpl implements MetricsService {
                 .put(STRING, Functions::getStringDataPoint)
                 .build();
 
-        metricsIdxCache = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).maximumSize(40000).build();
+        metricsIdxCache = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.MINUTES).maximumSize(40000).build();
 
         initStringSize(session);
         initMetrics();
@@ -270,6 +270,15 @@ public class MetricsServiceImpl implements MetricsService {
 
     public void clearMetricsIdxCaches() {
         metricsIdxCache.invalidateAll();
+    }
+
+    public void resetCacheConfiguration(int expireAfterMinutes, int maximumSize) {
+        if (metricsIdxCache != null) {
+            metricsIdxCache.invalidateAll();
+        }
+
+        metricsIdxCache = CacheBuilder.newBuilder().expireAfterAccess(expireAfterMinutes, TimeUnit.MINUTES)
+                .maximumSize(maximumSize).build();
     }
 
     void loadDataRetentions() {

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
@@ -98,6 +98,8 @@ public abstract class BaseMetricsITest extends BaseITest {
         session.execute("TRUNCATE leases");
 
         metricsService.setDataAccess(dataAccess);
+        metricsService.clearMetricsIdxCaches();
+
         NumericDataPointCollector.createPercentile = defaultCreatePercentile;
     }
 


### PR DESCRIPTION
…cs index if it was recently update. The max cache size in 20k items with automatica eviction of 1 hour since last read.