### PR TITLE
[HWKMETRICS-425] fix schema upgrade bugs

### DIFF
--- a/core/metrics-core-service/pom.xml
+++ b/core/metrics-core-service/pom.xml
@@ -165,6 +165,9 @@
           <name>!skipTests</name>
         </property>
       </activation>
+      <properties>
+        <resetdb>true</resetdb>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -188,6 +191,7 @@
                 <exclude>**/CreateTenantsSchedulerITest.java</exclude>
               </excludes>
               <systemPropertyVariables>
+                <resetdb>${resetdb}</resetdb>
                 <keyspace>${test.keyspace}</keyspace>
                 <nodes>${nodes}</nodes>
               </systemPropertyVariables>

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/BaseITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/BaseITest.java
@@ -71,7 +71,7 @@ public abstract class BaseITest {
         rxSession = new RxSessionImpl(session);
 
         SchemaService schemaService = new SchemaService();
-        schemaService.run(session, getKeyspace(), true);
+        schemaService.run(session, getKeyspace(), Boolean.valueOf(System.getProperty("resetdb", "true")));
 
         session.execute("USE " + getKeyspace());
     }

--- a/core/schema/src/main/resources/org/hawkular/schema/bootstrap.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/bootstrap.groovy
@@ -47,11 +47,11 @@ if (!reset && keyspaceExists(keyspace)) {
     def expectedTables = [
         'tenants', 'tenants_by_time', 'data', 'metrics_tags_idx', 'metrics_idx', 'retentions_idx',
         'tasks', 'task_queue', 'leases'
-    ]
-    def expectedTypes = ['aggregation_template', 'aggregate_data', 'trigger_def', ]
+    ] as Set
+    def expectedTypes = ['aggregation_template', 'aggregate_data', 'trigger_def', ] as Set
 
-    def actualTables = getTables(keyspace)
-    def actualTypes = getUDTs(keyspace)
+    def actualTables = getTables(keyspace) as Set
+    def actualTypes = getUDTs(keyspace) as Set
 
     if (actualTables != expectedTables) {
       throw new RuntimeException("The schema is in an unknown state and cannot be versioned. Expected tables to be " +
@@ -59,7 +59,7 @@ if (!reset && keyspaceExists(keyspace)) {
     }
     if (actualTypes != expectedTypes) {
       throw new RuntimeException("The schema is in an unknown state and cannot be versioned. Expected user defined " +
-        "types to be $actualTypes but found $actualTypes")
+        "types to be $expectedTypes but found $actualTypes")
     }
   }
 } else {

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <test.keyspace>hawkulartest</test.keyspace>
     <nodes>127.0.0.1</nodes>
     <!-- Dependencies versions -->
-    <version.org.cassalog>0.1.2</version.org.cassalog>
+    <version.org.cassalog>0.2.1</version.org.cassalog>
     <version.org.hawkular.accounts>2.0.26.Final</version.org.hawkular.accounts>
     <version.org.hawkular.commons>0.7.1.Final</version.org.hawkular.commons>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>


### PR DESCRIPTION
There were a couple bugs in cassalog that broke upgrades. I have fix and
released a new version of cassalog. This commit bumps the cassalog version and
also fixes a couple issues in bootstrap.groovy. Lastly,I have made resetting
schema during integration tests in metrics-core-service optional with the
resetdb system property which expects a value of true or false.