### PR TITLE
[HWKMETRICS-426] Change Percentiles to return original percentile

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -60,6 +60,7 @@ import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.NumericBucketPoint;
+import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.exception.RuntimeApiError;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
@@ -432,7 +433,7 @@ public class CounterHandler extends MetricsServiceHandler {
         }
 
         final Percentiles lPercentiles = percentiles != null ? percentiles
-                : new Percentiles(Collections.<Double> emptyList());
+                : new Percentiles(Collections.<Percentile> emptyList());
 
         observableConfig
                 .flatMap((config) -> metricsService.findCounterStats(metricId,
@@ -563,7 +564,7 @@ public class CounterHandler extends MetricsServiceHandler {
         }
 
         final Percentiles lPercentiles = percentiles != null ? percentiles
-                : new Percentiles(Collections.<Double> emptyList());
+                : new Percentiles(Collections.<Percentile> emptyList());
 
         observableConfig
                 .flatMap((config) -> metricsService.findCounterStats(metricId,
@@ -640,7 +641,7 @@ public class CounterHandler extends MetricsServiceHandler {
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
         } else {
             if(percentiles == null) {
-                percentiles = new Percentiles(Collections.<Double>emptyList());
+                percentiles = new Percentiles(Collections.<Percentile>emptyList());
             }
 
             metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
@@ -697,7 +698,7 @@ public class CounterHandler extends MetricsServiceHandler {
         Buckets buckets = bucketConfig.getBuckets();
 
         if (percentiles == null) {
-            percentiles = new Percentiles(Collections.<Double> emptyList());
+            percentiles = new Percentiles(Collections.<Percentile> emptyList());
         }
 
         metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
@@ -757,7 +758,7 @@ public class CounterHandler extends MetricsServiceHandler {
         }
 
         if (percentiles == null) {
-            percentiles = new Percentiles(Collections.<Double> emptyList());
+            percentiles = new Percentiles(Collections.<Percentile> emptyList());
         }
 
         if (metricNames.isEmpty()) {
@@ -844,7 +845,7 @@ public class CounterHandler extends MetricsServiceHandler {
         }
 
         if (percentiles == null) {
-            percentiles = new Percentiles(Collections.<Double> emptyList());
+            percentiles = new Percentiles(Collections.<Percentile> emptyList());
         }
 
         if (metricNames.isEmpty()) {
@@ -908,7 +909,7 @@ public class CounterHandler extends MetricsServiceHandler {
         }
         MetricId<Long> metricId = new MetricId<>(tenantId, COUNTER, id);
         final Percentiles lPercentiles = percentiles != null ? percentiles
-                : new Percentiles(Collections.<Double> emptyList());
+                : new Percentiles(Collections.<Percentile> emptyList());
         metricsService.findCounterStats(metricId, tags.getTags(), timeRange.getStart(), timeRange.getEnd(),
                 lPercentiles.getPercentiles())
                 .map(ApiUtils::mapToResponse)

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -61,6 +61,7 @@ import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.NumericBucketPoint;
+import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.exception.RuntimeApiError;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
@@ -434,7 +435,7 @@ public class GaugeHandler extends MetricsServiceHandler {
 
         observableConfig
                 .flatMap((config) -> {
-                    List<Double> perc = percentiles == null ? Collections.emptyList() : percentiles.getPercentiles();
+                    List<Percentile> perc = percentiles == null ? Collections.emptyList() : percentiles.getPercentiles();
                     return metricsService.findGaugeStats(metricId, config, perc);
                 })
                 .flatMap(Observable::from)
@@ -559,7 +560,7 @@ public class GaugeHandler extends MetricsServiceHandler {
 
         observableConfig
                 .flatMap((config) -> {
-                    List<Double> perc = percentiles == null ? Collections.emptyList() : percentiles.getPercentiles();
+                    List<Percentile> perc = percentiles == null ? Collections.emptyList() : percentiles.getPercentiles();
                     return metricsService.findGaugeStats(metricId, config, perc);
                 })
                 .flatMap(Observable::from)

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/PercentilesConverter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/PercentilesConverter.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import javax.ws.rs.ext.ParamConverter;
 
+import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.param.Percentiles;
 
 
@@ -32,11 +33,12 @@ import org.hawkular.metrics.model.param.Percentiles;
 public class PercentilesConverter implements ParamConverter<Percentiles> {
     @Override
     public Percentiles fromString(String param) {
-        return new Percentiles(Arrays.stream(param.split(",")).map(Double::valueOf).collect(Collectors.toList()));
+        return new Percentiles(Arrays.stream(param.split(",")).map(Percentile::new).collect(Collectors.toList()));
     }
 
     @Override
     public String toString(Percentiles percentiles) {
-        return percentiles.getPercentiles().stream().map(Object::toString).collect(Collectors.joining(","));
+        return percentiles.getPercentiles().stream().map(Percentile::getOriginalQuantile)
+                .collect(Collectors.joining(","));
     }
 }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -31,6 +31,7 @@ import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.NamedDataPoint;
 import org.hawkular.metrics.model.NumericBucketPoint;
+import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.TaggedBucketPoint;
 import org.hawkular.metrics.model.Tenant;
 import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
@@ -181,7 +182,7 @@ public interface MetricsService {
                                     Func1<Observable<DataPoint<Double>>, Observable<T>>... funcs);
 
     Observable<List<NumericBucketPoint>> findGaugeStats(MetricId<Double> metricId, BucketConfig bucketConfig,
-            List<Double> percentiles);
+            List<Percentile> percentiles);
 
     /**
      * Queries data points from a single metric and groups results using tag filter expressions that are applied
@@ -197,7 +198,7 @@ public interface MetricsService {
      * the form tag_name:tag_value,tag_name:tag_value.
      */
     Observable<Map<String, TaggedBucketPoint>> findGaugeStats(MetricId<Double> metricId, Map<String, String> tags,
-            long start, long end, List<Double> percentiles);
+            long start, long end, List<Percentile> percentiles);
 
     /**
      * Fetches data points from multiple metrics that are determined by a tags filter query. Down sampling is performed
@@ -213,7 +214,7 @@ public interface MetricsService {
      * @return An {@link Observable} that emits a single list of {@link NumericBucketPoint}
      */
     <T extends Number> Observable<List<NumericBucketPoint>> findNumericStats(String tenantId, MetricType<T> metricType,
-            Map<String, String> tagFilters, long start, long end, Buckets buckets, List<Double> percentiles,
+            Map<String, String> tagFilters, long start, long end, Buckets buckets, List<Percentile> percentiles,
             boolean stacked);
 
     /**
@@ -230,7 +231,7 @@ public interface MetricsService {
      * @return An {@link Observable} that emits a single list of {@link NumericBucketPoint}
      */
     <T extends Number> Observable<List<NumericBucketPoint>> findNumericStats(String tenantId, MetricType<T> metricType,
-            List<String> metrics, long start, long end, Buckets buckets, List<Double> percentiles, boolean stacked);
+            List<String> metrics, long start, long end, Buckets buckets, List<Percentile> percentiles, boolean stacked);
 
     Observable<DataPoint<AvailabilityType>> findAvailabilityData(MetricId<AvailabilityType> id, long start, long end,
             boolean distinct, int limit, Order order);
@@ -257,7 +258,7 @@ public interface MetricsService {
      * @return an {@link Observable} emitting a single {@link List} of {@link NumericBucketPoint}
      */
     Observable<List<NumericBucketPoint>> findCounterStats(MetricId<Long> id, long start, long end, Buckets buckets,
-                                                          List<Double> percentiles);
+                                                          List<Percentile> percentiles);
 
     /**
      * Queries data points from a single metric and groups results using tag filter expressions that are applied
@@ -273,7 +274,7 @@ public interface MetricsService {
      * the form tag_name:tag_value,tag_name:tag_value.
      */
     Observable<Map<String, TaggedBucketPoint>> findCounterStats(MetricId<Long> metricId, Map<String, String> tags,
-            long start, long end, List<Double> percentiles);
+            long start, long end, List<Percentile> percentiles);
 
     /**
      * Fetches gauge or counter data points and calculates per-minute rates.
@@ -306,7 +307,7 @@ public interface MetricsService {
      * @return an {@link Observable} emitting a single {@link List} of {@link NumericBucketPoint}
      */
     Observable<List<NumericBucketPoint>> findRateStats(MetricId<? extends Number> id, long start, long end,
-                                                       Buckets buckets, List<Double> percentiles);
+                                                       Buckets buckets, List<Percentile> percentiles);
 
     /**
      * <p>

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -61,6 +61,7 @@ import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.NamedDataPoint;
 import org.hawkular.metrics.model.NumericBucketPoint;
+import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.Retention;
 import org.hawkular.metrics.model.TaggedBucketPoint;
 import org.hawkular.metrics.model.Tenant;
@@ -765,7 +766,7 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     public Observable<List<NumericBucketPoint>> findRateStats(MetricId<? extends Number> id, long start, long end,
-                                                              Buckets buckets, List<Double> percentiles) {
+                                                              Buckets buckets, List<Percentile> percentiles) {
         checkArgument(isValidTimeRange(start, end), "Invalid time range");
         return findRateData(id, start, end, 0, ASC)
                 .compose(new NumericBucketPointTransformer(buckets, percentiles));
@@ -781,7 +782,7 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     public Observable<List<NumericBucketPoint>> findGaugeStats(MetricId<Double> metricId, BucketConfig bucketConfig,
-                List<Double> percentiles) {
+                List<Percentile> percentiles) {
         TimeRange timeRange = bucketConfig.getTimeRange();
         checkArgument(isValidTimeRange(timeRange.getStart(), timeRange.getEnd()), "Invalid time range");
         return findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd(), 0, Order.DESC)
@@ -790,7 +791,7 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     public Observable<Map<String, TaggedBucketPoint>> findGaugeStats(MetricId<Double> metricId,
-            Map<String, String> tags, long start, long end, List<Double> percentiles) {
+            Map<String, String> tags, long start, long end, List<Percentile> percentiles) {
         return findDataPoints(metricId, start, end, 0, Order.DESC)
                 .compose(new TaggedBucketPointTransformer(tags, percentiles));
     }
@@ -798,7 +799,7 @@ public class MetricsServiceImpl implements MetricsService {
     @Override
     public <T extends Number> Observable<List<NumericBucketPoint>> findNumericStats(String tenantId,
             MetricType<T> metricType, Map<String, String> tagFilters, long start, long end, Buckets buckets,
-            List<Double> percentiles, boolean stacked) {
+            List<Percentile> percentiles, boolean stacked) {
 
         checkArgument(isValidTimeRange(start, end), "Invalid time range");
         checkArgument(metricType == GAUGE || metricType == GAUGE_RATE
@@ -847,7 +848,7 @@ public class MetricsServiceImpl implements MetricsService {
     @Override
     public <T extends Number> Observable<List<NumericBucketPoint>> findNumericStats(String tenantId,
             MetricType<T> metricType, List<String> metrics, long start, long end, Buckets buckets,
-            List<Double> percentiles, boolean stacked) {
+            List<Percentile> percentiles, boolean stacked) {
 
         checkArgument(isValidTimeRange(start, end), "Invalid time range");
         checkArgument(metricType == GAUGE || metricType == GAUGE_RATE
@@ -951,7 +952,7 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     public Observable<List<NumericBucketPoint>> findCounterStats(MetricId<Long> id, long start, long end,
-            Buckets buckets, List<Double> percentiles) {
+            Buckets buckets, List<Percentile> percentiles) {
         checkArgument(isValidTimeRange(start, end), "Invalid time range");
         return findDataPoints(id, start, end, 0, ASC)
                 .compose(new NumericBucketPointTransformer(buckets, percentiles));
@@ -959,7 +960,7 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     public Observable<Map<String, TaggedBucketPoint>> findCounterStats(MetricId<Long> metricId,
-            Map<String, String> tags, long start, long end, List<Double> percentiles) {
+            Map<String, String> tags, long start, long end, List<Percentile> percentiles) {
         return findDataPoints(metricId, start, end, 0, ASC)
                 .compose(new TaggedBucketPointTransformer(tags, percentiles));
     }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/NumericBucketPointTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/NumericBucketPointTransformer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.hawkular.metrics.model.Buckets;
 import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.NumericBucketPoint;
+import org.hawkular.metrics.model.Percentile;
 
 import rx.Observable;
 import rx.Observable.Transformer;
@@ -33,9 +34,9 @@ public class NumericBucketPointTransformer
         implements Transformer<DataPoint<? extends Number>, List<NumericBucketPoint>> {
 
     private final Buckets buckets;
-    private final List<Double> percentiles;
+    private final List<Percentile> percentiles;
 
-    public NumericBucketPointTransformer(Buckets buckets, List<Double> percentiles) {
+    public NumericBucketPointTransformer(Buckets buckets, List<Percentile> percentiles) {
         this.buckets = buckets;
         this.percentiles = percentiles;
     }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/NumericDataPointCollector.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/NumericDataPointCollector.java
@@ -20,7 +20,6 @@ package org.hawkular.metrics.core.service.transformers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.apache.commons.math3.stat.descriptive.rank.Max;
@@ -67,41 +66,53 @@ public final class NumericDataPointCollector {
     private int samples = 0;
     private Min min = new Min();
     private Mean average = new Mean();
-    private PercentileWrapper median = createPercentile.apply(50.0);
     private Max max = new Max();
     private Sum sum = new Sum();
-    private List<PSquarePercentile> percentiles;
+    private List<PercentileWrapper> percentiles;
+    private List<Percentile> percentileList;
 
-    public NumericDataPointCollector(Buckets buckets, int bucketIndex, List<Double> percentileList) {
+    public NumericDataPointCollector(Buckets buckets, int bucketIndex, List<Percentile> percentilesList) {
         this.buckets = buckets;
         this.bucketIndex = bucketIndex;
-        this.percentiles = new ArrayList<>();
-        percentileList.stream().forEach(d -> percentiles.add(new PSquarePercentile(d)));
+        this.percentiles = new ArrayList<>(percentilesList.size() + 1);
+        this.percentileList = percentilesList;
+        percentilesList.stream().forEach(d -> percentiles.add(createPercentile.apply(d.getQuantile())));
+        percentiles.add(createPercentile.apply(50.0)); // Important to be the last one
     }
 
     public void increment(DataPoint<? extends Number> dataPoint) {
         Number value = dataPoint.getValue();
         min.increment(value.doubleValue());
         average.increment(value.doubleValue());
-        median.addValue(value.doubleValue());
         max.increment(value.doubleValue());
         sum.increment(value.doubleValue());
         samples++;
-        percentiles.stream().forEach(p -> p.increment(value.doubleValue()));
+        percentiles.stream().forEach(p -> p.addValue(value.doubleValue()));
     }
 
     public NumericBucketPoint toBucketPoint() {
         long from = buckets.getBucketStart(bucketIndex);
         long to = from + buckets.getStep();
+
+        // Original percentilesList can't be modified as it is used elsewhere
+        List<Percentile> percentileReturns = new ArrayList<>(percentileList.size());
+
+        if(percentileList.size() > 0) {
+            for(int i = 0; i < percentileList.size(); i++) {
+                Percentile p = percentileList.get(i);
+                PercentileWrapper pw = percentiles.get(i);
+                percentileReturns.add(new Percentile(p.getOriginalQuantile(), pw.getResult()));
+            }
+        }
+
         return new NumericBucketPoint.Builder(from, to)
                 .setMin(min.getResult())
                 .setAvg(average.getResult())
-                .setMedian(median.getResult())
+                .setMedian(this.percentiles.get(this.percentiles.size() - 1).getResult())
                 .setMax(max.getResult())
                 .setSum(sum.getResult())
                 .setSamples(samples)
-                .setPercentiles(percentiles.stream()
-                        .map(p -> new Percentile(p.quantile(), p.getResult())).collect(Collectors.toList()))
+                .setPercentiles(percentileReturns)
                 .build();
     }
 }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/TaggedBucketPointTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/TaggedBucketPointTransformer.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.hawkular.metrics.model.DataPoint;
+import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.TaggedBucketPoint;
 
 import rx.Observable;
@@ -41,9 +42,9 @@ public class TaggedBucketPointTransformer
         implements Transformer<DataPoint<? extends Number>, Map<String, TaggedBucketPoint>> {
 
     private final Map<String, String> tags;
-    private final List<Double> percentiles;
+    private final List<Percentile> percentiles;
 
-    public TaggedBucketPointTransformer(Map<String, String> tags, List<Double> percentiles) {
+    public TaggedBucketPointTransformer(Map<String, String> tags, List<Percentile> percentiles) {
         this.tags = tags;
         this.percentiles = percentiles;
     }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/BaseITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/BaseITest.java
@@ -128,7 +128,8 @@ public abstract class BaseITest {
     protected <T> List<T> getOnNextEvents(Supplier<Observable<T>> fn) {
         TestSubscriber<T> subscriber = new TestSubscriber<>();
         Observable<T> observable = fn.get();
-        observable.subscribe(subscriber);
+        observable.doOnError(Throwable::printStackTrace)
+                .subscribe(subscriber);
         subscriber.awaitTerminalEvent(5, SECONDS);
         subscriber.assertNoErrors();
         subscriber.assertCompleted();

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
@@ -156,10 +156,10 @@ public abstract class BaseMetricsITest extends BaseITest {
             assertEquals(actual.getSum(), expected.getSum(), 0.001, msg);
             assertEquals(actual.getSamples(), expected.getSamples(), 0, msg);
             for(int i = 0; i < expected.getPercentiles().size(); i++) {
-                assertEquals(expected.getPercentiles().get(i).getQuantile(), actual.getPercentiles().get(i)
-                        .getQuantile(), 0.001, msg);
-                assertEquals(expected.getPercentiles().get(i).getValue(), actual.getPercentiles().get(i)
-                        .getValue(), 0.001, msg);
+                assertEquals(actual.getPercentiles().get(i).getOriginalQuantile(),
+                        expected.getPercentiles().get(i).getOriginalQuantile(),  msg);
+                assertEquals(actual.getPercentiles().get(i).getValue(), expected.getPercentiles().get(i).getValue(),
+                        0.001, msg);
             }
         }
     }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
@@ -49,6 +49,7 @@ import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.NumericBucketPoint;
+import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.Retention;
 import org.hawkular.metrics.model.Tenant;
 import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
@@ -201,7 +202,8 @@ public class CounterITest extends BaseMetricsITest {
             top.increment(i);
         }
 
-        List<Double> percentiles = asList(50.0, 90.0, 99.0, 99.9);
+        List<Percentile> percentiles = asList(new Percentile("50.0"), new Percentile("90.0"), new Percentile("99.0"),
+                new Percentile("99.9"));
 
         Metric<Long> counter = new Metric<>(new MetricId<>(tenantId, COUNTER, "C1"), counterList);
 

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/RatesITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/RatesITest.java
@@ -237,7 +237,7 @@ public class RatesITest extends BaseMetricsITest {
 
         List<NumericBucketPoint> actual = metricsService.findRateStats(counter.getMetricId(),
                 0, now().getMillis(), Buckets.fromStep(60_000, 60_000 * 8, 60_000),
-                asList(99.0)).toBlocking().single();
+                asList(new Percentile("99.0"))).toBlocking().single();
         List<NumericBucketPoint> expected = new ArrayList<>();
         for (int i = 1; i < 8; i++) {
             NumericBucketPoint.Builder builder = new NumericBucketPoint.Builder(60_000 * i, 60_000 * (i + 1));
@@ -246,22 +246,22 @@ public class RatesITest extends BaseMetricsITest {
                 case 1:
                     val = 400D;
                     builder.setAvg(val).setMax(val).setMedian(val).setMin(val)
-                            .setPercentiles(asList(new Percentile(0.99, val))).setSamples(1).setSum(val);
+                            .setPercentiles(asList(new Percentile("0.99", val))).setSamples(1).setSum(val);
                     break;
                 case 3:
                     val = 100D;
                     builder.setAvg(val).setMax(val).setMedian(val).setMin(val)
-                            .setPercentiles(asList(new Percentile(0.99, val))).setSamples(1).setSum(val);
+                            .setPercentiles(asList(new Percentile("0.99", val))).setSamples(1).setSum(val);
                     break;
                 case 5:
                     val = 100;
                     builder.setAvg(val).setMax(val).setMedian(val).setMin(val)
-                            .setPercentiles(asList(new Percentile(0.99, val))).setSamples(1).setSum(val);
+                            .setPercentiles(asList(new Percentile("0.99", val))).setSamples(1).setSum(val);
                 case 6:
                     break;
                 case 7:
                     builder.setAvg(150.0).setMax(200.0).setMin(100.0).setMedian(100.0).setPercentiles(
-                            asList(new Percentile(0.99, 100.0))).setSamples(2).setSum(300.0);
+                            asList(new Percentile("0.99", 100.0))).setSamples(2).setSum(300.0);
                 default:
                     break;
             }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
@@ -438,14 +438,15 @@ public class TagsITest extends BaseMetricsITest {
 
         List<NumericBucketPoint> actual = metricsService.findCounterStats(counter.getMetricId(),
                 0, now().getMillis(), Buckets.fromStep(60_000, 60_000 * 8, 60_000),
-                asList(95.0)).toBlocking().single();
+                asList(new Percentile("95.0"))).toBlocking().single();
+
         List<NumericBucketPoint> expected = new ArrayList<>();
         for (int i = 1; i < 8; i++) {
             NumericBucketPoint.Builder builder = new NumericBucketPoint.Builder(60_000 * i, 60_000 * (i + 1));
             switch (i) {
                 case 1:
                     builder.setAvg(100D).setMax(200D).setMedian(0D).setMin(0D)
-                            .setPercentiles(asList(new Percentile(0.95, 0D))).setSamples(2).setSum(200D);
+                            .setPercentiles(asList(new Percentile("95.0", 0D))).setSamples(2).setSum(200D);
                     break;
                 case 2:
                 case 4:
@@ -453,15 +454,15 @@ public class TagsITest extends BaseMetricsITest {
                     break;
                 case 3:
                     builder.setAvg(400D).setMax(400D).setMedian(400D).setMin(400D)
-                            .setPercentiles(asList(new Percentile(0.95, 400D))).setSamples(1).setSum(400D);
+                            .setPercentiles(asList(new Percentile("95.0", 400D))).setSamples(1).setSum(400D);
                     break;
                 case 5:
                     builder.setAvg(550D).setMax(550D).setMedian(550D).setMin(550D)
-                            .setPercentiles(asList(new Percentile(0.95, 550D))).setSamples(1).setSum(550D);
+                            .setPercentiles(asList(new Percentile("95.0", 550D))).setSamples(1).setSum(550D);
                     break;
                 case 7:
                     builder.setAvg(975D).setMax(1000D).setMedian(950D).setMin(950D)
-                            .setPercentiles(asList(new Percentile(0.95, 950D))).setSamples(2).setSum(1950D);
+                            .setPercentiles(asList(new Percentile("95.0", 950D))).setSamples(2).setSum(1950D);
                     break;
             }
             expected.add(builder.build());

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/Percentile.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/Percentile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,22 +22,25 @@ package org.hawkular.metrics.model;
 public class Percentile {
     private double target;
     private double value = 0.0;
+    private String originalQuantile;
 
-    public Percentile(double quantile) {
-        this.target = quantile;
+    public Percentile(String quantile) {
+        this.originalQuantile = quantile;
+        this.target = Double.valueOf(quantile);
     }
 
-    public Percentile(double quantile, double value) {
-        this.target = quantile;
+    public Percentile(String quantile, double value) {
+        this.originalQuantile = quantile;
         this.value = value;
+        this.target = Double.valueOf(quantile);
+    }
+
+    public String getOriginalQuantile() {
+        return originalQuantile;
     }
 
     public double getQuantile() {
         return target;
-    }
-
-    public void setQuantile(double target) {
-        this.target = target;
     }
 
     public double getValue() {

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/param/Percentiles.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/param/Percentiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,8 @@ package org.hawkular.metrics.model.param;
 
 import java.util.List;
 
+import org.hawkular.metrics.model.Percentile;
+
 /**
  * A wrapping class for List<Double> of percentile requests for JAX-RS
  *
@@ -25,17 +27,17 @@ import java.util.List;
  */
 public class Percentiles {
 
-    private List<Double> percentiles;
+    private List<Percentile> percentiles;
 
-    public Percentiles(List<Double> percentiles) {
+    public Percentiles(List<Percentile> percentiles) {
         this.percentiles = percentiles;
     }
 
-    public List<Double> getPercentiles() {
+    public List<Percentile> getPercentiles() {
         return percentiles;
     }
 
-    public void setPercentiles(List<Double> percentiles) {
+    public void setPercentiles(List<Percentile> percentiles) {
         this.percentiles = percentiles;
     }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -777,7 +777,7 @@ Actual:   ${response.data}
       assertEquals(1, response.data.size)
       assertEquals(3, response.data[0].percentiles.size)
 
-      assertEquals(0.5, response.data[0].percentiles[0].quantile, 0.01)
+      assertEquals(50.0, response.data[0].percentiles[0].quantile)
       assertEquals(400, response.data[0].percentiles[0].value, 0.1)
   }
 


### PR DESCRIPTION
Change percentile queries to return the original requested value instead of calculated value from PSPercentile (from apache.commons.math). This prevents client from having to deal with floating point imprecision in quantile keys.