### PR TITLE
HWKMETRICS-432 Status page cannot be displayed when status is not "STARTED"

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/MetricsServiceStateFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/MetricsServiceStateFilter.java
@@ -31,6 +31,7 @@ import javax.ws.rs.ext.Provider;
 
 import org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle;
 import org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle.State;
+import org.hawkular.metrics.api.jaxrs.handler.BaseHandler;
 import org.hawkular.metrics.api.jaxrs.handler.StatusHandler;
 import org.hawkular.metrics.model.ApiError;
 
@@ -53,7 +54,7 @@ public class MetricsServiceStateFilter implements ContainerRequestFilter {
         UriInfo uriInfo = containerRequestContext.getUriInfo();
         String path = uriInfo.getPath();
 
-        if (path.startsWith(StatusHandler.PATH)) {
+        if (path.startsWith(StatusHandler.PATH) || path.startsWith(BaseHandler.PATH)) {
             // The status page does not require the MetricsService to be up and running.
             return;
         }


### PR DESCRIPTION
Do not abort status page request if status is not "STARTED"