### PR TITLE
Use singleton JAX-RS handlers

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/BaseHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/BaseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -42,6 +43,7 @@ import io.swagger.annotations.ApiOperation;
  * @author Matt Wringe
  */
 @Path(BaseHandler.PATH)
+@ApplicationScoped
 public class BaseHandler {
     public static final String PATH = "/";
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -95,10 +95,6 @@ public class MetricHandler {
         return httpHeaders.getRequestHeaders().getFirst(TENANT_HEADER_NAME);
     }
 
-    public MetricHandler() {
-        System.out.println("MetricHandler.MetricHandler");
-    }
-
     @POST
     @Path("/")
     @ApiOperation(value = "Create metric.", notes = "Clients are not required to explicitly create "

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/PingHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/PingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,9 +21,9 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import java.util.Date;
 import java.util.Map;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
@@ -38,10 +38,10 @@ import io.swagger.annotations.ApiOperation;
 @Path("/ping")
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
+@ApplicationScoped
 public class PingHandler {
 
     @GET
-    @POST
     @ApiOperation(value = "Returns the current time and serves to check for the availability of the api.", response =
             Map.class)
     public Response ping() {

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StatusHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StatusHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.ServletContext;
 import javax.ws.rs.Consumes;
@@ -42,6 +43,7 @@ import io.swagger.annotations.ApiOperation;
 @Path(StatusHandler.PATH)
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
+@ApplicationScoped
 public class StatusHandler {
     public static final String PATH = "/status";
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/TenantsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/TenantsHandler.java
@@ -23,6 +23,7 @@ import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.serverError;
 
 import java.net.URI;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
@@ -54,6 +55,7 @@ import io.swagger.annotations.ApiResponses;
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
 @Api(tags = "Tenant")
+@ApplicationScoped
 public class TenantsHandler {
 
     @Inject


### PR DESCRIPTION
Please do not merge yet.

Thinking about performance, using singleton JAX-RS handlers will reduce GC pressure.
Currently, a handler class instance is created for every request.

I would like to see if this as an impact on Filip's tests.

I had to remove @HeaderParam annotation as they are not available in singleton handlers.