### PR TITLE
[HWKMETRICS-424] Fetch stats from multiple metrics in a single request

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.metrics.api.jaxrs;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -25,7 +26,7 @@ import java.util.Objects;
  */
 public class StatsQueryRequest {
 
-    private Map<String, List<String>> metrics;
+    private Map<String, List<String>> metrics = new HashMap<>();
 
     private Long start;
 
@@ -36,6 +37,8 @@ public class StatsQueryRequest {
     private String bucketDuration;
 
     private String percentiles;
+
+    private String tags;
 
     public Map<String, List<String>> getMetrics() {
         return metrics;
@@ -85,12 +88,21 @@ public class StatsQueryRequest {
         this.percentiles = percentiles;
     }
 
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         StatsQueryRequest that = (StatsQueryRequest) o;
         return Objects.equals(metrics, that.metrics) &&
+                Objects.equals(tags, that.tags) &&
                 Objects.equals(start, that.start) &&
                 Objects.equals(end, that.end) &&
                 Objects.equals(buckets, that.buckets) &&
@@ -106,6 +118,7 @@ public class StatsQueryRequest {
     @Override public String toString() {
         return "StatsQueryRequest{" +
                 "metrics=" + metrics +
+                "tags=" +
                 ", start=" + start +
                 ", end=" + end +
                 ", buckets=" + buckets +

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
@@ -16,10 +16,13 @@
  */
 package org.hawkular.metrics.api.jaxrs;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
 
 /**
  * @author jsanda
@@ -39,6 +42,8 @@ public class StatsQueryRequest {
     private String percentiles;
 
     private String tags;
+
+    private List<String> types = new ArrayList<>();
 
     public Map<String, List<String>> getMetrics() {
         return metrics;
@@ -96,6 +101,14 @@ public class StatsQueryRequest {
         this.tags = tags;
     }
 
+    public List<String> getTypes() {
+        return types;
+    }
+
+    public void setTypes(List<String> types) {
+        this.types = types;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -107,23 +120,25 @@ public class StatsQueryRequest {
                 Objects.equals(end, that.end) &&
                 Objects.equals(buckets, that.buckets) &&
                 Objects.equals(bucketDuration, that.bucketDuration) &&
-                Objects.equals(percentiles, that.percentiles);
+                Objects.equals(percentiles, that.percentiles) &&
+                Objects.equals(types, that.types);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(metrics, start, end, buckets, bucketDuration, percentiles);
+        return Objects.hash(metrics, start, end, buckets, bucketDuration, percentiles, types);
     }
 
     @Override public String toString() {
-        return "StatsQueryRequest{" +
-                "metrics=" + metrics +
-                "tags=" +
-                ", start=" + start +
-                ", end=" + end +
-                ", buckets=" + buckets +
-                ", bucketDuration=" + bucketDuration +
-                ", percentiles=" + percentiles +
-                '}';
+        return MoreObjects.toStringHelper(this)
+                .add("metrics", metrics)
+                .add("tags", tags)
+                .add("start", start)
+                .add("end", end)
+                .add("buckets", buckets)
+                .add("bucketDuration", bucketDuration)
+                .add("percentiles", percentiles)
+                .add("types", types)
+                .toString();
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
@@ -35,7 +35,7 @@ public class StatsQueryRequest {
 
     private String bucketDuration;
 
-    private List<Double> percentiles;
+    private String percentiles;
 
     public Map<String, List<String>> getMetrics() {
         return metrics;
@@ -77,11 +77,11 @@ public class StatsQueryRequest {
         this.bucketDuration = bucketDuration;
     }
 
-    public List<Double> getPercentiles() {
+    public String getPercentiles() {
         return percentiles;
     }
 
-    public void setPercentiles(List<Double> percentiles) {
+    public void setPercentiles(String percentiles) {
         this.percentiles = percentiles;
     }
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/StatsQueryRequest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author jsanda
+ */
+public class StatsQueryRequest {
+
+    private Map<String, List<String>> metrics;
+
+    private Long start;
+
+    private Long end;
+
+    private Integer buckets;
+
+    private String bucketDuration;
+
+    private List<Double> percentiles;
+
+    public Map<String, List<String>> getMetrics() {
+        return metrics;
+    }
+
+    public void setMetrics(Map<String, List<String>> metrics) {
+        this.metrics = metrics;
+    }
+
+    public Long getStart() {
+        return start;
+    }
+
+    public void setStart(Long start) {
+        this.start = start;
+    }
+
+    public Long getEnd() {
+        return end;
+    }
+
+    public void setEnd(Long end) {
+        this.end = end;
+    }
+
+    public Integer getBuckets() {
+        return buckets;
+    }
+
+    public void setBuckets(Integer buckets) {
+        this.buckets = buckets;
+    }
+
+    public String getBucketDuration() {
+        return bucketDuration;
+    }
+
+    public void setBucketDuration(String bucketDuration) {
+        this.bucketDuration = bucketDuration;
+    }
+
+    public List<Double> getPercentiles() {
+        return percentiles;
+    }
+
+    public void setPercentiles(List<Double> percentiles) {
+        this.percentiles = percentiles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StatsQueryRequest that = (StatsQueryRequest) o;
+        return Objects.equals(metrics, that.metrics) &&
+                Objects.equals(start, that.start) &&
+                Objects.equals(end, that.end) &&
+                Objects.equals(buckets, that.buckets) &&
+                Objects.equals(bucketDuration, that.bucketDuration) &&
+                Objects.equals(percentiles, that.percentiles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(metrics, start, end, buckets, bucketDuration, percentiles);
+    }
+
+    @Override public String toString() {
+        return "StatsQueryRequest{" +
+                "metrics=" + metrics +
+                ", start=" + start +
+                ", end=" + end +
+                ", buckets=" + buckets +
+                ", bucketDuration=" + bucketDuration +
+                ", percentiles=" + percentiles +
+                '}';
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -31,7 +31,6 @@ import static org.hawkular.metrics.model.MetricType.GAUGE;
 import static org.hawkular.metrics.model.MetricType.STRING;
 
 import java.net.URI;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -73,7 +73,6 @@ import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.MixedMetricsRequest;
-import org.hawkular.metrics.model.NumericBucketPoint;
 import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/AvailabilityBucketPoint.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/AvailabilityBucketPoint.java
@@ -52,7 +52,7 @@ public final class AvailabilityBucketPoint extends BucketPoint {
     protected AvailabilityBucketPoint(long start, long end, long downtimeDuration, long lastDowntime, double
             uptimeRatio, long downtimeCount) {
         super(start, end);
-        this.durationMap = new HashMap<AvailabilityType, Long>();
+        this.durationMap = new HashMap<>();
         this.durationMap.put(AvailabilityType.DOWN, downtimeDuration);
         this.lastNotUptime = lastDowntime;
         this.uptimeRatio = getDoubleValue(uptimeRatio);

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
@@ -1772,6 +1772,555 @@ class MetricsITest extends RESTTest {
   }
 
   @Test
+  void fetchGaugeAndCounterRateStatsByTags() {
+    String tenantId = nextTenantId()
+    withDataPoints(tenantId, {
+      // now query by tags instead of ids
+      def response = hawkularMetrics.post(
+          path: 'metrics/stats/query',
+          headers: [(tenantHeaderName): tenantId],
+          body: [
+              buckets: 2,
+              start: 200,
+              end: 500,
+              tags: 'z:1',
+              types: ['gauge', 'counter_rate']
+          ]
+      )
+      assertEquals(200, response.status)
+
+      def expected = [
+          gauge: [
+              G1: [
+                  [
+                      start: 200,
+                      end: 350,
+                      samples: 2,
+                      max: 5.34,
+                      min: 3.45,
+                      avg: avg([3.45, 5.34]),
+                      sum: 3.45 + 5.34,
+                      median: median([3.45, 5.34]),
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 2.22,
+                      min: 2.22,
+                      avg: 2.22,
+                      median: 2.22,
+                      sum: 2.22,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              G3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 5.55,
+                      min: 4.44,
+                      avg: avg([5.55, 4.44]),
+                      median: median([5.55, 4.44]),
+                      sum: 5.55 + 4.44,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 3.33,
+                      min: 3.33,
+                      avg: 3.33,
+                      median: 3.33,
+                      sum: 3.33,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ],
+          counter_rate: [
+              C2: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 9000,
+                      avg: 9000,
+                      min: 9000,
+                      sum: 9000,
+                      median: 9000,
+                      samples: 1,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 4200,
+                      min: 4200,
+                      avg: 4200,
+                      sum: 4200,
+                      median: 4200,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              C3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 4200,
+                      min: 4200,
+                      avg: 4200,
+                      sum: 4200,
+                      median: 4200,
+                      samples: 1,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 4200,
+                      min: 4200,
+                      avg: 4200,
+                      sum: 4200,
+                      median: 4200,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ]
+      ]
+
+      assertEquals(expected.size(), response.data.size())
+      assertEquals(expected.gauge.size(), response.data.gauge.size())
+      assertEquals(expected.gauge.G1.size(), response.data.gauge.G1.size())
+      assertNumericBucketEquals('The data for G1[0] does not match', expected.gauge.G1[0], response.data.gauge.G1[0])
+      assertNumericBucketEquals('The data for G1[1] does not match', expected.gauge.G1[1], response.data.gauge.G1[1])
+      assertEquals(expected.gauge.G3.size(), response.data.gauge.G3.size())
+      assertNumericBucketEquals('The data for G3[0] does not match', expected.gauge.G3[0], response.data.gauge.G3[0])
+
+      assertEquals(expected.counter_rate.size(), response.data.counter_rate.size())
+      assertEquals(expected.counter_rate.C2.size(), response.data.counter_rate.C2.size())
+      assertNumericBucketEquals('The rate data for C2[0] does not match', expected.counter_rate.C2[0],
+          response.data.counter_rate.C2[0])
+      assertNumericBucketEquals('The rate data for C2[1] does not match', expected.counter_rate.C2[1],
+          response.data.counter_rate.C2[1])
+      assertEquals(expected.counter_rate.C3.size(), response.data.counter_rate.C3.size())
+      assertNumericBucketEquals('The rate data for C3[0] does not match', expected.counter_rate.C3[0],
+          response.data.counter_rate.C3[0])
+      assertNumericBucketEquals('The rate data for C3[1] does not match', expected.counter_rate.C3[1],
+          response.data.counter_rate.C3[1])
+    })
+  }
+
+  @Test
+  void fetchGaugeRateAndCounterStatsByTags() {
+    String tenantId = nextTenantId()
+    withDataPoints(tenantId, {
+      // now query by tags instead of ids
+      def response = hawkularMetrics.post(
+          path: 'metrics/stats/query',
+          headers: [(tenantHeaderName): tenantId],
+          body: [
+              buckets: 2,
+              start: 200,
+              end: 500,
+              tags: 'z:1',
+              types: ['gauge_rate', 'counter']
+          ]
+      )
+      assertEquals(200, response.status)
+
+      def expected = [
+          gauge_rate: [
+              G1: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 1134,
+                      min: 1134,
+                      avg: 1134,
+                      median: 1134,
+                      sum: 1134,
+                      samples: 1,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: -1872,
+                      min: -1872,
+                      avg: -1872,
+                      median: -1872,
+                      sum: -1872,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              G3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: -666,
+                      min: -666,
+                      avg: -666,
+                      median: -666,
+                      sum: -666,
+                      samples: 1,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: -666,
+                      min: -666,
+                      avg: -666,
+                      median: -666,
+                      sum: -666,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ],
+          counter: [
+              C2: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 64,
+                      min: 49,
+                      avg: avg([49, 64]),
+                      median: median([49, 64]),
+                      sum: 49 + 64,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 71,
+                      min: 71,
+                      avg: 71,
+                      median: 71,
+                      sum: 71,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              C3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 42,
+                      min: 35,
+                      avg: avg([35, 42]),
+                      median: median([35, 42]),
+                      sum: 35 + 42,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 49,
+                      min: 49,
+                      avg: 49,
+                      median: 49,
+                      sum: 49,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ]
+      ]
+
+      assertEquals(expected.size(), response.data.size())
+      assertEquals(expected.counter.size(), response.data.counter.size())
+      assertEquals(expected.counter.C2.size(), response.data.counter.C2.size())
+      assertNumericBucketEquals('The data for C2[0] does not match', expected.counter.C2[0],
+          response.data.counter.C2[0])
+      assertNumericBucketEquals('The data for C2[1] does not match', expected.counter.C2[1],
+          response.data.counter.C2[1])
+      assertEquals(expected.counter.C3.size(), response.data.counter.C3.size())
+      assertNumericBucketEquals('The data for C3[0] does not match', expected.counter.C3[0],
+          response.data.counter.C3[0])
+      assertNumericBucketEquals('The data for C3[1] does not match', expected.counter.C3[1],
+          response.data.counter.C3[1])
+
+      assertEquals(expected.gauge_rate.size(), response.data.gauge_rate.size())
+      assertEquals(expected.gauge_rate.G1.size(), response.data.gauge_rate.G1.size())
+      assertNumericBucketEquals('The rate data for G1[0] does not match', expected.gauge_rate.G1[0],
+          response.data.gauge_rate.G1[0])
+      assertNumericBucketEquals('The rate data for G1[1] does not match', expected.gauge_rate.G1[1],
+          response.data.gauge_rate.G1[1])
+    })
+  }
+
+  @Test
+  void fetchGaugeAndCounterStatsWithRatesByTags() {
+    String tenantId = nextTenantId()
+    withDataPoints(tenantId, {
+      // now query by tags instead of ids
+      def response = hawkularMetrics.post(
+          path: 'metrics/stats/query',
+          headers: [(tenantHeaderName): tenantId],
+          body: [
+              buckets: 2,
+              start: 200,
+              end: 500,
+              tags: 'z:1',
+              types: ['gauge', 'gauge_rate', 'counter', 'counter_rate']
+          ]
+      )
+      assertEquals(200, response.status)
+
+      def expected = [
+          gauge: [
+              G1: [
+                  [
+                      start: 200,
+                      end: 350,
+                      samples: 2,
+                      max: 5.34,
+                      min: 3.45,
+                      avg: avg([3.45, 5.34]),
+                      sum: 3.45 + 5.34,
+                      median: median([3.45, 5.34]),
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 2.22,
+                      min: 2.22,
+                      avg: 2.22,
+                      median: 2.22,
+                      sum: 2.22,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              G3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 5.55,
+                      min: 4.44,
+                      avg: avg([5.55, 4.44]),
+                      median: median([5.55, 4.44]),
+                      sum: 5.55 + 4.44,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 3.33,
+                      min: 3.33,
+                      avg: 3.33,
+                      median: 3.33,
+                      sum: 3.33,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ],
+          gauge_rate: [
+              G1: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 1134,
+                      min: 1134,
+                      avg: 1134,
+                      median: 1134,
+                      sum: 1134,
+                      samples: 1,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: -1872,
+                      min: -1872,
+                      avg: -1872,
+                      median: -1872,
+                      sum: -1872,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              G3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: -666,
+                      min: -666,
+                      avg: -666,
+                      median: -666,
+                      sum: -666,
+                      samples: 1,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: -666,
+                      min: -666,
+                      avg: -666,
+                      median: -666,
+                      sum: -666,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ],
+          counter: [
+              C2: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 64,
+                      min: 49,
+                      avg: avg([49, 64]),
+                      median: median([49, 64]),
+                      sum: 49 + 64,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 71,
+                      min: 71,
+                      avg: 71,
+                      median: 71,
+                      sum: 71,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              C3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 42,
+                      min: 35,
+                      avg: avg([35, 42]),
+                      median: median([35, 42]),
+                      sum: 35 + 42,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 49,
+                      min: 49,
+                      avg: 49,
+                      median: 49,
+                      sum: 49,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ],
+          counter_rate: [
+              C2: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 9000,
+                      avg: 9000,
+                      min: 9000,
+                      sum: 9000,
+                      median: 9000,
+                      samples: 1,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 4200,
+                      min: 4200,
+                      avg: 4200,
+                      sum: 4200,
+                      median: 4200,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              C3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 4200,
+                      min: 4200,
+                      avg: 4200,
+                      sum: 4200,
+                      median: 4200,
+                      samples: 1,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 4200,
+                      min: 4200,
+                      avg: 4200,
+                      sum: 4200,
+                      median: 4200,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ]
+      ]
+
+      assertEquals(expected.size(), response.data.size())
+      assertEquals(expected.gauge.size(), response.data.gauge.size())
+      assertEquals(expected.gauge.G1.size(), response.data.gauge.G1.size())
+      assertNumericBucketEquals('The data for G1[0] does not match', expected.gauge.G1[0], response.data.gauge.G1[0])
+      assertNumericBucketEquals('The data for G1[1] does not match', expected.gauge.G1[1], response.data.gauge.G1[1])
+      assertEquals(expected.gauge.G3.size(), response.data.gauge.G3.size())
+      assertNumericBucketEquals('The data for G3[0] does not match', expected.gauge.G3[0], response.data.gauge.G3[0])
+      assertNumericBucketEquals('The data for G3[1] does not match', expected.gauge.G3[1], response.data.gauge.G3[1])
+
+      assertEquals(expected.counter.size(), response.data.counter.size())
+      assertEquals(expected.counter.C2.size(), response.data.counter.C2.size())
+      assertNumericBucketEquals('The data for C2[0] does not match', expected.counter.C2[0],
+          response.data.counter.C2[0])
+      assertNumericBucketEquals('The data for C2[1] does not match', expected.counter.C2[1],
+          response.data.counter.C2[1])
+      assertEquals(expected.counter.C3.size(), response.data.counter.C3.size())
+      assertNumericBucketEquals('The data for C3[0] does not match', expected.counter.C3[0],
+          response.data.counter.C3[0])
+      assertNumericBucketEquals('The data for C3[1] does not match', expected.counter.C3[1],
+          response.data.counter.C3[1])
+
+      assertEquals(expected.gauge_rate.size(), response.data.gauge_rate.size())
+      assertEquals(expected.gauge_rate.G1.size(), response.data.gauge_rate.G1.size())
+      assertNumericBucketEquals('The rate data for G1[0] does not match', expected.gauge_rate.G1[0],
+          response.data.gauge_rate.G1[0])
+      assertNumericBucketEquals('The rate data for G1[1] does not match', expected.gauge_rate.G1[1],
+          response.data.gauge_rate.G1[1])
+
+      assertEquals(expected.counter_rate.size(), response.data.counter_rate.size())
+      assertEquals(expected.counter_rate.C2.size(), response.data.counter_rate.C2.size())
+      assertNumericBucketEquals('The rate data for C2[0] does not match', expected.counter_rate.C2[0],
+          response.data.counter_rate.C2[0])
+      assertNumericBucketEquals('The rate data for C2[1] does not match', expected.counter_rate.C2[1],
+          response.data.counter_rate.C2[1])
+      assertEquals(expected.counter_rate.C3.size(), response.data.counter_rate.C3.size())
+      assertNumericBucketEquals('The rate data for C3[0] does not match', expected.counter_rate.C3[0],
+          response.data.counter_rate.C3[0])
+      assertNumericBucketEquals('The rate data for C3[1] does not match', expected.counter_rate.C3[1],
+          response.data.counter_rate.C3[1])
+    })
+  }
+
+  @Test
   void shouldNotFetchStatsWithoutBucketParam() {
     String tenantId = nextTenantId()
 

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
@@ -16,10 +16,11 @@
  */
 package org.hawkular.metrics.rest
 
-import static org.junit.Assert.assertEquals
-
 import org.joda.time.DateTime
 import org.junit.Test
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
 
 /**
  * @author jsanda
@@ -392,6 +393,417 @@ class MetricsITest extends RESTTest {
         ],
         headers: [(tenantHeaderName): tenantId]) { exception ->
       // Missing type
+      assertEquals(400, exception.response.status)
+    }
+  }
+
+  def withGaugeAndCounterData(String tenantId, Closure callback) {
+    def response = hawkularMetrics.post(
+        path: "gauges/raw",
+        headers: [(tenantHeaderName): tenantId],
+        body: [
+            [
+                id: 'G1',
+                data: [
+                    [timestamp: 100, value: 1.23],
+                    [timestamp: 200, value: 3.45],
+                    [timestamp: 300, value: 5.34],
+                    [timestamp: 400, value: 2.22],
+                    [timestamp: 500, value: 5.22]
+                ]
+            ],
+            [
+                id: 'G2',
+                data: [
+                    [timestamp: 100, value: 1.45],
+                    [timestamp: 200, value: 2.36],
+                    [timestamp: 300, value: 3.62],
+                    [timestamp: 400, value: 2.63],
+                    [timestamp: 500, value: 3.99]
+                ]
+            ],
+            [
+                id: 'G3',
+                data: [
+                    [timestamp: 100, value: 4.45],
+                    [timestamp: 200, value: 5.55],
+                    [timestamp: 300, value: 4.44],
+                    [timestamp: 400, value: 3.33],
+                    [timestamp: 500, value: 3.77]
+                ]
+            ]
+        ]
+    )
+    response = hawkularMetrics.post(
+        path: "counters/raw",
+        headers: [(tenantHeaderName): tenantId],
+        body: [
+            [
+                id: 'C1',
+                data: [
+                    [timestamp: 100, value: 12],
+                    [timestamp: 200, value: 17],
+                    [timestamp: 300, value: 19],
+                    [timestamp: 400, value: 26],
+                    [timestamp: 500, value: 37]
+                ]
+            ],
+            [
+                id: 'C2',
+                data: [
+                    [timestamp: 100, value: 41],
+                    [timestamp: 200, value: 49],
+                    [timestamp: 300, value: 64],
+                    [timestamp: 400, value: 71],
+                    [timestamp: 500, value: 95]
+                ]
+            ],
+            [
+                id: 'C3',
+                data: [
+                    [timestamp: 100, value: 28],
+                    [timestamp: 200, value: 35],
+                    [timestamp: 300, value: 42],
+                    [timestamp: 400, value: 49],
+                    [timestamp: 500, value: 59]
+                ]
+            ]
+        ]
+    )
+    assertEquals(200, response.status)
+    callback()
+  }
+
+  @Test
+  void fetchStatsFromGaugesAndCounters() {
+    String tenantId = nextTenantId()
+
+    withGaugeAndCounterData(tenantId, {
+      def response = hawkularMetrics.post(
+          path: 'metrics/stats/query',
+          headers: [(tenantHeaderName): tenantId],
+          body: [
+              metrics: [
+                  gauge: ['G1', 'G3'],
+                  counter: ['C2', 'C3']
+              ],
+              buckets: 2,
+              start: 200,
+              end: 500
+          ]
+      )
+      assertEquals(200, response.status)
+
+      def expected = [
+          gauge: [
+              G1: [
+                  [
+                      start: 200,
+                      end: 350,
+                      samples: 2,
+                      max: 5.34,
+                      min: 3.45,
+                      avg: avg([3.45, 5.34]),
+                      sum: 3.45 + 5.34,
+                      median: median([3.45, 5.34]),
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 2.22,
+                      min: 2.22,
+                      avg: 2.22,
+                      median: 2.22,
+                      sum: 2.22,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              G3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 5.55,
+                      min: 4.44,
+                      avg: avg([5.55, 4.44]),
+                      median: median([5.55, 4.44]),
+                      sum: 5.55 + 4.44,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 3.33,
+                      min: 3.33,
+                      avg: 3.33,
+                      median: 3.33,
+                      sum: 3.33,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ],
+          counter: [
+              C2: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 64,
+                      min: 49,
+                      avg: avg([49, 64]),
+                      median: median([49, 64]),
+                      sum: 49 + 64,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 71,
+                      min: 71,
+                      avg: 71,
+                      median: 71,
+                      sum: 71,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              C3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 42,
+                      min: 35,
+                      avg: avg([35, 42]),
+                      median: median([35, 42]),
+                      sum: 35 + 42,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 49,
+                      min: 49,
+                      avg: 49,
+                      median: 49,
+                      sum: 49,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ]
+      ]
+      assertEquals(expected.size(), response.data.size())
+      assertEquals(expected.gauge.size(), response.data.gauge.size())
+      assertEquals(expected.gauge.G1.size(), response.data.gauge.G1.size())
+      assertNumericBucketEquals('The data for G1[0] does not match', expected.gauge.G1[0], response.data.gauge.G1[0])
+      assertNumericBucketEquals('The data for G1[1] does not match', expected.gauge.G1[1], response.data.gauge.G1[1])
+      assertEquals(expected.gauge.G3.size(), response.data.gauge.G3.size())
+      assertNumericBucketEquals('The data for G3[0] does not match', expected.gauge.G3[0], response.data.gauge.G3[0])
+      assertNumericBucketEquals('The data for G3[1] does not match', expected.gauge.G3[1], response.data.gauge.G3[1])
+
+
+      assertEquals(expected.counter.size(), response.data.counter.size())
+      assertEquals(expected.counter.C2.size(), response.data.counter.C2.size())
+      assertNumericBucketEquals('The data for C2[0] does not match', expected.counter.C2[0],
+          response.data.counter.C2[0])
+      assertNumericBucketEquals('The data for C2[1] does not match', expected.counter.C2[1],
+          response.data.counter.C2[1])
+      assertEquals(expected.counter.C3.size(), response.data.counter.C3.size())
+      assertNumericBucketEquals('The data for C3[0] does not match', expected.counter.C3[0],
+          response.data.counter.C3[0])
+      assertNumericBucketEquals('The data for C3[1] does not match', expected.counter.C3[1],
+          response.data.counter.C3[1])
+    })
+  }
+
+  @Test
+  void fetchStatsFromGauges() {
+    String tenantId = nextTenantId()
+    withGaugeAndCounterData(tenantId, {
+      def response = hawkularMetrics.post(
+          path: 'metrics/stats/query',
+          headers: [(tenantHeaderName): tenantId],
+          body: [
+              metrics: [
+                  gauge: ['G1', 'G3'],
+              ],
+              buckets: 2,
+              start: 200,
+              end: 500
+          ]
+      )
+      assertEquals(200, response.status)
+
+      def expected = [
+          gauge: [
+              G1: [
+                  [
+                      start: 200,
+                      end: 350,
+                      samples: 2,
+                      max: 5.34,
+                      min: 3.45,
+                      avg: avg([3.45, 5.34]),
+                      sum: 3.45 + 5.34,
+                      median: median([3.45, 5.34]),
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 2.22,
+                      min: 2.22,
+                      avg: 2.22,
+                      median: 2.22,
+                      sum: 2.22,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              G3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 5.55,
+                      min: 4.44,
+                      avg: avg([5.55, 4.44]),
+                      median: median([5.55, 4.44]),
+                      sum: 5.55 + 4.44,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 3.33,
+                      min: 3.33,
+                      avg: 3.33,
+                      median: 3.33,
+                      sum: 3.33,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ],
+          counter: []
+      ]
+      assertEquals(expected.size(), response.data.size())
+      assertTrue(response.data.counter.isEmpty())
+      assertEquals(expected.gauge.G1.size(), response.data.gauge.G1.size())
+      assertNumericBucketEquals('The data for G1[0] does not match', expected.gauge.G1[0], response.data.gauge.G1[0])
+      assertNumericBucketEquals('The data for G1[1] does not match', expected.gauge.G1[1], response.data.gauge.G1[1])
+      assertEquals(expected.gauge.G3.size(), response.data.gauge.G3.size())
+      assertNumericBucketEquals('The data for G3[0] does not match', expected.gauge.G3[0], response.data.gauge.G3[0])
+      assertNumericBucketEquals('The data for G3[1] does not match', expected.gauge.G3[1], response.data.gauge.G3[1])
+    })
+  }
+
+  @Test
+  void fetchStatsFromCounters() {
+    String tenantId = nextTenantId()
+    withGaugeAndCounterData(tenantId, {
+      def response = hawkularMetrics.post(
+          path: 'metrics/stats/query',
+          headers: [(tenantHeaderName): tenantId],
+          body: [
+              metrics: [
+                  counter: ['C2', 'C3'],
+              ],
+              buckets: 2,
+              start: 200,
+              end: 500
+          ]
+      )
+      assertEquals(200, response.status)
+
+      def expected = [
+          gauge: [],
+          counter: [
+              C2: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 64,
+                      min: 49,
+                      avg: avg([49, 64]),
+                      median: median([49, 64]),
+                      sum: 49 + 64,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 71,
+                      min: 71,
+                      avg: 71,
+                      median: 71,
+                      sum: 71,
+                      samples: 1,
+                      empty: false
+                  ]
+              ],
+              C3: [
+                  [
+                      start: 200,
+                      end: 350,
+                      max: 42,
+                      min: 35,
+                      avg: avg([35, 42]),
+                      median: median([35, 42]),
+                      sum: 35 + 42,
+                      samples: 2,
+                      empty: false
+                  ],
+                  [
+                      start: 350,
+                      end: 500,
+                      max: 49,
+                      min: 49,
+                      avg: 49,
+                      median: 49,
+                      sum: 49,
+                      samples: 1,
+                      empty: false
+                  ]
+              ]
+          ]
+      ]
+      printJson(response.data)
+      assertEquals(expected.size(), response.data.size())
+      assertEquals(expected.gauge.size(), response.data.gauge.size())
+
+      assertEquals(expected.counter.size(), response.data.counter.size())
+      assertEquals(expected.counter.C2.size(), response.data.counter.C2.size())
+      assertNumericBucketEquals('The data for C2[0] does not match', expected.counter.C2[0],
+          response.data.counter.C2[0])
+      assertNumericBucketEquals('The data for C2[1] does not match', expected.counter.C2[1],
+          response.data.counter.C2[1])
+      assertEquals(expected.counter.C3.size(), response.data.counter.C3.size())
+      assertNumericBucketEquals('The data for C3[0] does not match', expected.counter.C3[0],
+          response.data.counter.C3[0])
+      assertNumericBucketEquals('The data for C3[1] does not match', expected.counter.C3[1],
+          response.data.counter.C3[1])
+    })
+  }
+
+  @Test
+  void shouldNotFetchStatsWithoutBucketParam() {
+    String tenantId = nextTenantId()
+
+    badPost( path: "metrics/stats/query",
+        body: [
+            metrics: [
+                counter: ['C2', 'C3'],
+            ],
+            start: 200,
+            end: 500
+        ],
+        headers: [(tenantHeaderName): tenantId]) { exception ->
       assertEquals(400, exception.response.status)
     }
   }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
@@ -1636,7 +1636,7 @@ class MetricsITest extends RESTTest {
               ]
           ]
       ]
-      printJson(response.data)
+
       assertEquals(expected.size(), response.data.size())
       assertEquals(expected.gauge_rate.size(), response.data.gauge_rate.size())
       assertEquals(expected.gauge_rate.G1.size(), response.data.gauge_rate.G1.size())

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -30,8 +30,10 @@ import org.junit.BeforeClass
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import static junit.framework.Assert.assertNull
 import static org.hawkular.metrics.core.service.transformers.BatchStatementTransformer.MAX_BATCH_SIZE
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
 
 class RESTTest {
@@ -188,6 +190,20 @@ Actual: ${actual}
       assertDoubleEquals(msg, expected.median, actual.median)
       assertDoubleEquals(msg, expected.max, actual.max)
       assertDoubleEquals(msg, expected.sum, actual.sum)
+      assertPercentilesEquals(expected.percentiles, actual.percentiles)
+    }
+  }
+
+  static void assertPercentilesEquals(def expected, def actual) {
+    if (expected == null) {
+      assertNull(actual)
+    } else {
+      assertEquals(expected.size(), actual.size())
+      expected.each { expectedP ->
+        def actualP = actual.find { it.quantile == expectedP.quantile }
+        assertNotNull(actualP)
+        assertDoubleEquals(expectedP.value, actualP.value)
+      }
     }
   }
 
@@ -201,6 +217,12 @@ Actual: ${actual}
     PSquarePercentile median = new PSquarePercentile(50.0)
     values.each { median.increment(it as double) }
     return median.result
+  }
+
+  static double percentile(double p, List values) {
+    PSquarePercentile percentile = new PSquarePercentile(p)
+    values.each { percentile.increment(it as double) }
+    return percentile.result
   }
 
   static double rate(Map dataPointX, Map dataPointY) {

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -16,26 +16,23 @@
  */
 package org.hawkular.metrics.rest
 
-import groovy.json.JsonOutput
-
-import static org.hawkular.metrics.core.service.transformers.BatchStatementTransformer.MAX_BATCH_SIZE
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertTrue
-
-
-import java.util.concurrent.atomic.AtomicInteger
-
-import org.apache.commons.math3.stat.descriptive.moment.Mean
-import org.joda.time.DateTime
-import org.junit.BeforeClass
-
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-
+import groovy.json.JsonOutput
 import groovyx.net.http.ContentType
 import groovyx.net.http.HttpResponseDecorator
 import groovyx.net.http.HttpResponseException
 import groovyx.net.http.RESTClient
+import org.apache.commons.math3.stat.descriptive.moment.Mean
+import org.apache.commons.math3.stat.descriptive.rank.PSquarePercentile
+import org.joda.time.DateTime
+import org.junit.BeforeClass
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import static org.hawkular.metrics.core.service.transformers.BatchStatementTransformer.MAX_BATCH_SIZE
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
 
 class RESTTest {
 
@@ -198,6 +195,12 @@ Actual: ${actual}
     Mean mean = new Mean()
     values.each { mean.increment(it as double) }
     return mean.result
+  }
+
+  static double median(List values) {
+    PSquarePercentile median = new PSquarePercentile(50.0)
+    values.each { median.increment(it as double) }
+    return median.result
   }
 
   static double rate(Map dataPointX, Map dataPointY) {

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -201,9 +201,26 @@ Actual: ${actual}
       assertEquals(expected.size(), actual.size())
       expected.each { expectedP ->
         def actualP = actual.find { it.quantile == expectedP.quantile }
-        assertNotNull(actualP)
-        assertDoubleEquals(expectedP.value, actualP.value)
+        assertNotNull("Expected to find $expectedP in $actual", actualP)
+        assertDoubleEquals("The percentile value is wrong", expectedP.value, actualP.value)
       }
+    }
+  }
+
+  static void assertAvailablityBucketEquals(String msg, def expected, def actual) {
+    assertEquals(msg, expected.start, actual.start)
+    assertEquals(msg, expected.end, actual.end)
+    assertEquals(msg, expected.empty, actual.empty)
+    if (!expected.empty) {
+      assertEquals(msg, expected.lastNotUptime, actual.lastNotUptime)
+      assertDoubleEquals(msg, expected.uptimeRatio, actual.uptimeRatio)
+      assertEquals(msg, expected.notUpCount, actual.notUpCount)
+      assertEquals(msg, expected.downtimeDuration, actual.downtimeDuration)
+      assertEquals(msg, expected.lastDowntime, actual.lastDowntime)
+      assertEquals(msg, expected.adminDuration, actual.adminDuration)
+      assertEquals(msg, expected.unknownDuration, actual.unknownDuration)
+      assertEquals(msg, expected.upDuration, actual.upDuration)
+      assertEquals(msg, expected.notUpDuration, actual.notUpDuration)
     }
   }
 


### PR DESCRIPTION
This PR adds an endpoint for fetching stats (i.e., bucket data points) from multiple metrics in a single request. Right now it only supports gauges and counter. I will update the endpoint to also support gauge and counter rate stats as well. I wanted to go ahead submit the PR for review though because adding support for rates is mostly boiler plate along with additional integration tests.

@lucasponce would it make sense to include availability stats as well?