### PR TITLE
[HWKMETRICS-440] Create Interface for JAXRS Handlers

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -49,6 +49,7 @@ import javax.ws.rs.core.UriInfo;
 import org.hawkular.metrics.api.jaxrs.QueryRequest;
 import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
+import org.hawkular.metrics.api.jaxrs.handler.template.IMetricsHandler;
 import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransformer;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.service.Functions;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -84,7 +84,7 @@ import rx.Observable;
 @Produces(APPLICATION_JSON)
 @Api(tags = "Availability")
 @ApplicationScoped
-public class AvailabilityHandler extends MetricsServiceHandler {
+public class AvailabilityHandler extends MetricsServiceHandler implements IMetricsHandler<AvailabilityType> {
 
     @POST
     @Path("/")
@@ -97,7 +97,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
-    public void createAvailabilityMetric(
+    public void createMetric(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(required = true) Metric<AvailabilityType> metric,
             @ApiParam(value = "Overwrite previously created metric configuration if it exists. "
@@ -130,7 +130,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Failed to retrieve metrics due to unexpected error.",
                     response = ApiError.class)
     })
-    public void findAvailabilityMetrics(
+    public void getMetrics(
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(value = "List of tags filters", required = false) @QueryParam("tags") Tags tags) {
 
@@ -159,7 +159,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @ApiResponse(code = 204, message = "Query was successful, but no metrics definition is set."),
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric's definition.",
                          response = ApiError.class) })
-    public void getAvailabilityMetric(@Suspended final AsyncResponse asyncResponse, @PathParam("id") String id) {
+    public void getMetric(@Suspended final AsyncResponse asyncResponse, @PathParam("id") String id) {
         metricsService.findMetric(new MetricId<>(getTenant(), AVAILABILITY, id))
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
                 .map(metric -> Response.ok(metric).build())
@@ -244,7 +244,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data",
                     response = ApiError.class)
     })
-    public void addAvailabilityForMetric(
+    public void addMetricData(
             @Suspended final AsyncResponse asyncResponse, @PathParam("id") String id,
             @ApiParam(value = "List of availability datapoints", required = true) List<DataPoint<AvailabilityType>> data
     ) {
@@ -262,7 +262,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @Suspended final AsyncResponse asyncResponse, @PathParam("id") String id,
             @ApiParam(value = "List of availability datapoints", required = true)
                     List<DataPoint<AvailabilityType>> data) {
-        addAvailabilityForMetric(asyncResponse, id, data);
+        addMetricData(asyncResponse, id, data);
     }
 
     @POST
@@ -274,7 +274,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data",
                     response = ApiError.class)
     })
-    public void addAvailabilityData(
+    public void addData(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(value = "List of availability metrics", required = true)
             @JsonDeserialize()
@@ -297,7 +297,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
-    public Response findRawData(@ApiParam(required = true, value = "Query parameters that minimally must include a " +
+    public Response getData(@ApiParam(required = true, value = "Query parameters that minimally must include a " +
             "list of metric ids. The standard start, end, order, and limit query parameters are supported as well.")
             QueryRequest query) {
         return findRawDataPointsForMetrics(query, AVAILABILITY);
@@ -312,7 +312,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @ApiParam(value = "List of availability metrics", required = true)
             @JsonDeserialize() List<Metric<AvailabilityType>> availabilities
     ) {
-        addAvailabilityData(asyncResponse, availabilities);
+        addData(asyncResponse, availabilities);
     }
 
     @Deprecated
@@ -320,7 +320,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
     @Path("/{id}/data")
     @ApiOperation(value = "Deprecated. Please use /raw or /stats endpoints.", response = DataPoint.class,
             responseContainer = "List")
-    public void findAvailabilityData(
+    public void deprecatedFindAvailabilityData(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
@@ -382,7 +382,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching availability data.",
                     response = ApiError.class)
     })
-    public void findRawAvailabilityData(
+    public void getMetricData(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
@@ -429,7 +429,7 @@ public class AvailabilityHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching availability data.",
                     response = ApiError.class)
     })
-    public void findStatsAvailabilityData(
+    public void getMetricStats(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -50,6 +50,7 @@ import javax.ws.rs.core.UriInfo;
 import org.hawkular.metrics.api.jaxrs.QueryRequest;
 import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
+import org.hawkular.metrics.api.jaxrs.handler.template.IMetricsHandler;
 import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransformer;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.service.Functions;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -86,7 +86,7 @@ import rx.Observable;
 @Produces(APPLICATION_JSON)
 @Api(tags = "Counter")
 @ApplicationScoped
-public class CounterHandler extends MetricsServiceHandler {
+public class CounterHandler extends MetricsServiceHandler implements IMetricsHandler<Long> {
 
     @POST
     @Path("/")
@@ -103,7 +103,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Metric creation failed due to an unexpected error",
                     response = ApiError.class)
     })
-    public void createCounter(
+    public void createMetric(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(required = true) Metric<Long> metric,
             @ApiParam(value = "Overwrite previously created metric configuration if it exists. "
@@ -136,7 +136,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Failed to retrieve metrics due to unexpected error.",
                     response = ApiError.class)
     })
-    public void findCounterMetrics(
+    public void getMetrics(
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(value = "List of tags filters", required = false) @QueryParam("tags") Tags tags) {
 
@@ -165,7 +165,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 204, message = "Query was successful, but no metrics definition is set."),
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric's definition.",
                          response = ApiError.class) })
-    public void getCounter(@Suspended final AsyncResponse asyncResponse, @PathParam("id") String id) {
+    public void getMetric(@Suspended final AsyncResponse asyncResponse, @PathParam("id") String id) {
 
         metricsService.findMetric(new MetricId<>(getTenant(), COUNTER, id))
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
@@ -268,7 +268,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
-    public Response findRawData(@ApiParam(required = true, value = "Query parameters that minimally must include a " +
+    public Response getData(@ApiParam(required = true, value = "Query parameters that minimally must include a " +
             "list of metric ids. The standard start, end, order, and limit query parameters are supported as well.")
             QueryRequest query) {
         return findRawDataPointsForMetrics(query, COUNTER);
@@ -285,7 +285,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
-    public Response findRateData(@ApiParam(required = true, value = "Query parameters that minimally must include a " +
+    public Response getRateData(@ApiParam(required = true, value = "Query parameters that minimally must include a " +
             "list of metric ids. The standard start, end, order, and limit query parameters are supported as well.")
             QueryRequest query) {
         return findRateDataPointsForMetrics(query, COUNTER);
@@ -311,7 +311,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data",
                     response = ApiError.class),
     })
-    public void addData(
+    public void addMetricData(
             @Suspended final AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "List of data points containing timestamp and value", required = true)
@@ -331,7 +331,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @PathParam("id") String id,
             @ApiParam(value = "List of data points containing timestamp and value", required = true)
                 List<DataPoint<Long>> data) {
-        addData(asyncResponse, id, data);
+        addMetricData(asyncResponse, id, data);
     }
 
     @Deprecated
@@ -339,7 +339,7 @@ public class CounterHandler extends MetricsServiceHandler {
     @Path("/{id}/data")
     @ApiOperation(value = "Deprecated. Please use /raw or /stats endpoints",
                     response = DataPoint.class, responseContainer = "List")
-    public void findCounterData(
+    public void deprecatedFindCounterData(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
@@ -451,11 +451,13 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
-    public void findRawCounterData(
+    public void getMetricData(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
             @ApiParam(value = "Defaults to now") @QueryParam("end") Long end,
+            @ApiParam(value = "Use data from earliest received, subject to retention period")
+                @QueryParam("fromEarliest") Boolean fromEarliest,
             @ApiParam(value = "Limit the number of data points returned") @QueryParam("limit") Integer limit,
             @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
     ) {
@@ -494,7 +496,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
-    public void findStatsCounterData(
+    public void getMetricStats(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
@@ -589,7 +591,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
-    public void findRate(
+    public void getMetricRate(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
@@ -660,7 +662,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
-    public void findStatsRate(
+    public void getMetricStatsRate(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,
@@ -714,7 +716,7 @@ public class CounterHandler extends MetricsServiceHandler {
                     "bucketDuration parameter is required but not both.", response = ApiError.class),
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                 response = ApiError.class) })
-    public void findCounterDataStats(
+    public void getStats(
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") final Long start,
             @ApiParam(value = "Defaults to now") @QueryParam("end") final Long end,
@@ -783,7 +785,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiParam(value = "List of metric names", required = false) @QueryParam("metrics") List<String> metricNames,
             @ApiParam(value = "Downsample method (if true then sum of stacked individual stats; defaults to false)",
                 required = false) @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-        findCounterDataStats(asyncResponse, start, end,
+        getStats(asyncResponse, start, end,
                 bucketsCount, bucketDuration, percentiles, tags, metricNames, stacked);
     }
 
@@ -801,7 +803,7 @@ public class CounterHandler extends MetricsServiceHandler {
                     "bucketDuration parameter is required but not both.", response = ApiError.class),
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                 response = ApiError.class) })
-    public void findCounterRateDataStats(
+    public void getRateStats(
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") final Long start,
             @ApiParam(value = "Defaults to now") @QueryParam("end") final Long end,
@@ -870,7 +872,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiParam(value = "List of metric names", required = false) @QueryParam("metrics") List<String> metricNames,
             @ApiParam(value = "Downsample method (if true then sum of stacked individual stats; defaults to false)",
                     required = false) @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-        findCounterDataStats(asyncResponse, start, end, bucketsCount, bucketDuration, percentiles, tags, metricNames,
+        getStats(asyncResponse, start, end, bucketsCount, bucketDuration, percentiles, tags, metricNames,
                 stacked);
     }
 
@@ -887,7 +889,7 @@ public class CounterHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
-    public void findStatsByTags(
+    public void getMetricStatsByTags(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -52,6 +52,7 @@ import javax.ws.rs.core.UriInfo;
 import org.hawkular.metrics.api.jaxrs.QueryRequest;
 import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
+import org.hawkular.metrics.api.jaxrs.handler.template.IMetricsHandler;
 import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransformer;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.service.Functions;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/IMetricsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/IMetricsHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.handler;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.hawkular.metrics.api.jaxrs.QueryRequest;
+import org.hawkular.metrics.core.service.Order;
+import org.hawkular.metrics.model.DataPoint;
+import org.hawkular.metrics.model.Metric;
+import org.hawkular.metrics.model.param.TagNames;
+import org.hawkular.metrics.model.param.Tags;
+
+/**
+ * @author Stefan Negrea
+ *
+ */
+public interface IMetricsHandler<V> {
+
+    //Metric
+    void getMetrics(AsyncResponse asyncResponse, Tags tags);
+
+    void createMetric(AsyncResponse asyncResponse, Metric<V> metric, Boolean overwrite, UriInfo uriInfo);
+
+    void getMetric(AsyncResponse asyncResponse, String id);
+
+    //Tags
+    void getTags(AsyncResponse asyncResponse, Tags tags);
+
+    void getMetricTags(AsyncResponse asyncResponse, String id);
+
+    void updateMetricTags(AsyncResponse asyncResponse, String id, Map<String, String> tags);
+
+    void deleteMetricTags(AsyncResponse asyncResponse, String id, TagNames tags);
+
+    //Data
+    void addData(AsyncResponse asyncResponse, List<Metric<V>> metrics);
+
+    Response getData(QueryRequest query);
+
+    void addMetricData(AsyncResponse asyncResponse, String id, List<DataPoint<V>> data);
+
+    void getMetricData(AsyncResponse asyncResponse, String id, Long start, Long end, Boolean flag, Integer limit,
+            Order order);
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.UriInfo;
 import org.hawkular.metrics.api.jaxrs.QueryRequest;
 import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
+import org.hawkular.metrics.api.jaxrs.handler.template.IMetricsHandler;
 import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransformer;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.service.Functions;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
@@ -78,7 +78,7 @@ import rx.Observable;
 @Api(tags = "String", description = "This resource is experimental and changes may be made to it in subsequent " +
         "releases that are not backwards compatible.")
 @ApplicationScoped
-public class StringHandler extends MetricsServiceHandler {
+public class StringHandler extends MetricsServiceHandler implements IMetricsHandler<String> {
 
     @POST
     @Path("/")
@@ -121,7 +121,7 @@ public class StringHandler extends MetricsServiceHandler {
             @ApiResponse(code = 400, message = "Invalid type parameter type.", response = ApiError.class),
             @ApiResponse(code = 500, message = "Failed to retrieve metrics due to unexpected error.", response = ApiError.class)
     })
-    public void findMetrics(
+    public void getMetrics(
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(value = "List of tags filters") @QueryParam("tags") Tags tags) {
 
@@ -225,7 +225,7 @@ public class StringHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data",
                     response = ApiError.class)
     })
-    public void addStringForMetric(
+    public void addMetricData(
             @Suspended final AsyncResponse asyncResponse, @PathParam("id") String id,
             @ApiParam(value = "List of string datapoints", required = true) List<DataPoint<String>> data
     ) {
@@ -244,7 +244,7 @@ public class StringHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error happened while storing the data",
                     response = ApiError.class)
     })
-    public void addStringData(
+    public void addData(
             @Suspended final AsyncResponse asyncResponse,
             @ApiParam(value = "List of string metrics", required = true)
             @JsonDeserialize()
@@ -267,7 +267,7 @@ public class StringHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
-    public Response findRawData(@ApiParam(required = true, value = "Query parameters that minimally must include a " +
+    public Response getData(@ApiParam(required = true, value = "Query parameters that minimally must include a " +
             "list of metric ids. The standard start, end, order, and limit query parameters are supported as well.")
             QueryRequest query) {
         return findRawDataPointsForMetrics(query, STRING);
@@ -282,7 +282,7 @@ public class StringHandler extends MetricsServiceHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching string data.",
                     response = ApiError.class)
     })
-    public void findRawStringData(
+    public void getMetricData(
             @Suspended AsyncResponse asyncResponse,
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") Long start,

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/template/IMetricsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/template/IMetricsHandler.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.metrics.api.jaxrs.handler;
+package org.hawkular.metrics.api.jaxrs.handler.template;
 
 import java.util.List;
 import java.util.Map;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/template/IMetricsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/template/IMetricsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.hawkular.metrics.api.jaxrs.handler.template;
 
 import java.util.List;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/template/IMetricsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/template/IMetricsHandler.java
@@ -35,12 +35,12 @@ import org.hawkular.metrics.model.param.Tags;
  * @author Stefan Negrea
  *
  */
-public interface IMetricsHandler<V> {
+public interface IMetricsHandler<T> {
 
     //Metric
     void getMetrics(AsyncResponse asyncResponse, Tags tags);
 
-    void createMetric(AsyncResponse asyncResponse, Metric<V> metric, Boolean overwrite, UriInfo uriInfo);
+    void createMetric(AsyncResponse asyncResponse, Metric<T> metric, Boolean overwrite, UriInfo uriInfo);
 
     void getMetric(AsyncResponse asyncResponse, String id);
 
@@ -54,11 +54,11 @@ public interface IMetricsHandler<V> {
     void deleteMetricTags(AsyncResponse asyncResponse, String id, TagNames tags);
 
     //Data
-    void addData(AsyncResponse asyncResponse, List<Metric<V>> metrics);
+    void addData(AsyncResponse asyncResponse, List<Metric<T>> metrics);
 
     Response getData(QueryRequest query);
 
-    void addMetricData(AsyncResponse asyncResponse, String id, List<DataPoint<V>> data);
+    void addMetricData(AsyncResponse asyncResponse, String id, List<DataPoint<T>> data);
 
     void getMetricData(AsyncResponse asyncResponse, String id, Long start, Long end, Boolean flag, Integer limit,
             Order order);


### PR DESCRIPTION
Create a basic interface for JAXRS handlers for methods like creating, listing, and adding data to metrics.

I created [HWKMETRICS-435](https://issues.jboss.org/browse/HWKMETRICS-435) to track implementing 'fromEarliest' for `/raw` endpoints for gauge and counter. Somehow this was missed during the migration away from `/data`.