### PR TITLE
[HWKMETRICS-453] add retry policy for non-repeating jobs

### DIFF
--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/RetryPolicy.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/RetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/RetryPolicy.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/RetryPolicy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.scheduler.api;
+
+/**
+ * A retry policy specifies when a job should be executed again in the event of a failure. Retry policies take effect
+ * only for non-repeating jobs.
+ *
+ * @author jsanda
+ */
+public interface RetryPolicy {
+
+    RetryPolicy NONE = () -> -1;
+
+    RetryPolicy NOW = () -> 0;
+
+    long getDelay();
+
+}

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/Scheduler.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/Scheduler.java
@@ -21,18 +21,54 @@ import java.util.Map;
 import rx.Completable;
 import rx.Single;
 import rx.functions.Func1;
+import rx.functions.Func2;
 
 /**
  * @author jsanda
  */
 public interface Scheduler {
 
+    /**
+     * Schedules a job for execution. A unique id is created and is persisted along with the specified job details.
+     * If the execution time has already passed, the job details will not be persisted, and the returned Single
+     * will call subscribers onError method.
+     *
+     * @param type
+     * @param name
+     * @param parameters
+     * @param trigger
+     * @return A Single that emits the job details
+     */
     Single<JobDetails> scheduleJob(String type, String name, Map<String, String> parameters, Trigger trigger);
 
-    void registerJobFactory(String jobType, Func1<JobDetails, Completable> factory);
+    /**
+     * Register a function that produces a job of the specified type. This method should be called prior to scheduling
+     * any jobs of the specified type.
+     *
+     * @param jobType
+     * @param jobProducer
+     */
+    void register(String jobType, Func1<JobDetails, Completable> jobProducer);
 
+    /**
+     * Registers two functions. The first produces a job of the specfied type. The second function returns a retry
+     * policy that is used with non-repeating jobs when the fail.
+     *
+     * @param jobType
+     * @param jobProducer
+     * @param retryFunction
+     */
+    void register(String jobType, Func1<JobDetails, Completable> jobProducer,
+            Func2<JobDetails, Throwable, RetryPolicy> retryFunction);
+
+    /**
+     * Start executing jobs.
+     */
     void start();
 
+    /**
+     * Shut down thread pools and stop executing jobs. Jobs that are running may be interrupted and might not finish.
+     */
     void shutdown();
 
 }

--- a/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
+++ b/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
@@ -44,10 +44,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.hawkular.metrics.datetime.DateTimeService;
 import org.hawkular.metrics.scheduler.api.JobDetails;
 import org.hawkular.metrics.scheduler.api.RepeatingTrigger;
+import org.hawkular.metrics.scheduler.api.RetryPolicy;
 import org.hawkular.metrics.scheduler.api.SingleExecutionTrigger;
 import org.hawkular.metrics.scheduler.api.Trigger;
 import org.jboss.logging.Logger;
 import org.joda.time.DateTime;
+import org.joda.time.Minutes;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -63,6 +65,8 @@ import rx.Observable;
 import rx.Scheduler;
 import rx.Subscription;
 import rx.functions.Action1;
+import rx.functions.Func1;
+import rx.functions.Func2;
 import rx.internal.schedulers.SchedulerLifecycle;
 import rx.schedulers.Schedulers;
 import rx.schedulers.TestScheduler;
@@ -204,7 +208,7 @@ public class JobExecutionTest extends JobSchedulerTest {
         JobDetails jobDetails = new JobDetails(randomUUID(), "Test Type", "Test Job 1", emptyMap(), trigger);
         AtomicInteger executionCountRef = new AtomicInteger();
 
-        jobScheduler.registerJobFactory(jobDetails.getJobType(), details -> Completable.fromAction(() -> {
+        jobScheduler.register(jobDetails.getJobType(), details -> Completable.fromAction(() -> {
             logger.debug("Executing " + details);
             executionCountRef.incrementAndGet();
         }));
@@ -255,7 +259,7 @@ public class JobExecutionTest extends JobSchedulerTest {
             session.execute(updateJobQueue.bind(timeSlice.toDate(), details.getJobId()));
         }
 
-        jobScheduler.registerJobFactory(jobType, details -> Completable.fromAction(() -> {
+        jobScheduler.register(jobType, details -> Completable.fromAction(() -> {
             logger.debug("Executing " + details);
             Integer count = executionCounts.get(details.getJobName());
             executionCounts.put(details.getJobName(), ++count);
@@ -292,7 +296,7 @@ public class JobExecutionTest extends JobSchedulerTest {
         CountDownLatch job1Running = new CountDownLatch(1);
         CountDownLatch job2Finished = new CountDownLatch(1);
 
-        jobScheduler.registerJobFactory(job1.getJobType(), details -> Completable.fromAction(() -> {
+        jobScheduler.register(job1.getJobType(), details -> Completable.fromAction(() -> {
             try {
                 logger.debug("First time slice finished!");
                 // This is to let the test know that this job has started executing and the clock can be advanced
@@ -311,7 +315,7 @@ public class JobExecutionTest extends JobSchedulerTest {
         JobDetails job2 = new JobDetails(randomUUID(), "Test Type", "Test Job", emptyMap(),
                 new SingleExecutionTrigger.Builder().withTriggerTime(timeSlice.plusMinutes(1).getMillis()).build());
 
-        jobScheduler.registerJobFactory(job2.getJobType(), details -> Completable.fromAction(() ->
+        jobScheduler.register(job2.getJobType(), details -> Completable.fromAction(() ->
                 logger.debug("Executing " + details)));
 
         scheduleJob(job1);
@@ -359,7 +363,7 @@ public class JobExecutionTest extends JobSchedulerTest {
         JobDetails jobDetails = new JobDetails(randomUUID(), "Repeat Test", "Repeat Test", emptyMap(), trigger);
         TestJob job = new TestJob();
 
-        jobScheduler.registerJobFactory(jobDetails.getJobType(), details -> Completable.fromAction(() -> {
+        jobScheduler.register(jobDetails.getJobType(), details -> Completable.fromAction(() -> {
             job.call(details);
         }));
 
@@ -392,6 +396,162 @@ public class JobExecutionTest extends JobSchedulerTest {
         assertEquals(getFinishedJobs(timeSlice.plusMinutes(1)), emptySet());
     }
 
+    @Test
+    public void executeSingleExecutionJobThatFailsAndHasNoRetryPolicy() throws Exception {
+        Trigger repeatingTrigger = new RepeatingTrigger.Builder()
+                .withDelay(1, TimeUnit.MINUTES)
+                .withInterval(1, TimeUnit.MINUTES)
+                .build();
+        DateTime timeSlice = new DateTime(repeatingTrigger.getTriggerTime());
+        JobDetails repeating = new JobDetails(randomUUID(), "Repeating Job", "Repeating Job", emptyMap(),
+                repeatingTrigger);
+
+        Trigger singleFireTrigger = new SingleExecutionTrigger.Builder().withDelay(1, TimeUnit.MINUTES).build();
+        JobDetails failed = new JobDetails(randomUUID(), "Failed Job", "Failed Job", emptyMap(), singleFireTrigger);
+
+        jobScheduler.register(repeating.getJobType(), details -> Completable.complete());
+        jobScheduler.register(failed.getJobType(), details -> Completable.error(new Exception()));
+
+        scheduleJob(repeating);
+        scheduleJob(failed);
+
+        CountDownLatch firstTimeSliceFinished = new CountDownLatch(1);
+        CountDownLatch secondTimeSliceFinished = new CountDownLatch(1);
+        AtomicInteger executions = new AtomicInteger();
+
+        onTimeSliceFinished(finishedTimeSlice -> {
+            if (timeSlice.equals(finishedTimeSlice)) {
+                firstTimeSliceFinished.countDown();
+            }
+        });
+        onTimeSliceFinished(finishedTimeSlice -> {
+            if (timeSlice.plusMinutes(1).equals(finishedTimeSlice)) {
+                secondTimeSliceFinished.countDown();
+            }
+        });
+        onJobFinished(details -> {
+            if (details.getJobType().equals(repeating.getJobType())) {
+                executions.incrementAndGet();
+            }
+        });
+
+        tickScheduler.advanceTimeTo(timeSlice.getMillis(), TimeUnit.MILLISECONDS);
+        assertTrue(firstTimeSliceFinished.await(10, TimeUnit.SECONDS));
+
+        tickScheduler.advanceTimeBy(1, TimeUnit.MINUTES);
+        assertTrue(secondTimeSliceFinished.await(10, TimeUnit.SECONDS));
+
+        assertEquals(executions.get(), 2);
+    }
+
+    @Test
+    public void executeJobThatFailsAndRetrysImmediately() throws Exception {
+        Trigger trigger = new SingleExecutionTrigger.Builder().withDelay(1, TimeUnit.MINUTES).build();
+        DateTime timeSlice = new DateTime(trigger.getTriggerTime());
+        JobDetails jobDetails = new JobDetails(randomUUID(), "Failed Job", "Failed Job", emptyMap(), trigger);
+
+        AtomicInteger attempts = new AtomicInteger();
+        Func1<JobDetails, Completable> job = details -> {
+            if (attempts.getAndIncrement() == 0) {
+                return Completable.error(new Exception());
+            }
+            return Completable.complete();
+        };
+        Func2<JobDetails, Throwable, RetryPolicy> retry = (details, throwable) -> RetryPolicy.NOW;
+
+        jobScheduler.register(jobDetails.getJobType(), job, retry);
+
+        scheduleJob(jobDetails);
+
+        CountDownLatch timeSliceFinished = new CountDownLatch(1);
+        onTimeSliceFinished(finishedTimeSlice -> {
+            if (finishedTimeSlice.equals(timeSlice)) {
+                timeSliceFinished.countDown();
+            }
+        });
+
+        tickScheduler.advanceTimeTo(timeSlice.getMillis(), TimeUnit.MILLISECONDS);
+        assertTrue(timeSliceFinished.await(10, TimeUnit.SECONDS));
+        assertEquals(attempts.get(), 2);
+    }
+
+    @Test
+    public void executeJobThatFailsAndRetriesAfterDelay() throws Exception {
+        Trigger trigger = new SingleExecutionTrigger.Builder().withDelay(1, TimeUnit.MINUTES).build();
+        DateTime timeSlice = new DateTime(trigger.getTriggerTime());
+        JobDetails jobDetails = new JobDetails(randomUUID(), "Failed Job", "Failed Job", emptyMap(), trigger);
+
+        AtomicInteger attempts = new AtomicInteger();
+        Func1<JobDetails, Completable> job = details -> {
+            if (attempts.getAndIncrement() == 0) {
+                return Completable.error(new Exception());
+            }
+            return Completable.complete();
+        };
+        Func2<JobDetails, Throwable, RetryPolicy> retry = (details, throwable) ->
+                () -> Minutes.ONE.toStandardDuration().getMillis();
+
+        jobScheduler.register(jobDetails.getJobType(), job, retry);
+
+        scheduleJob(jobDetails);
+
+        CountDownLatch firstTimeSliceFinished = new CountDownLatch(1);
+        CountDownLatch secondTimeSliceFinished = new CountDownLatch(1);
+        onTimeSliceFinished(finishedTimeSlice -> {
+            if (finishedTimeSlice.equals(timeSlice)) {
+                firstTimeSliceFinished.countDown();
+            } else if (finishedTimeSlice.equals(timeSlice.plusMinutes(1))) {
+                secondTimeSliceFinished.countDown();
+            }
+        });
+
+        tickScheduler.advanceTimeTo(timeSlice.getMillis(), TimeUnit.MILLISECONDS);
+        assertTrue(firstTimeSliceFinished.await(10, TimeUnit.SECONDS));
+
+        tickScheduler.advanceTimeBy(1, TimeUnit.MINUTES);
+        assertTrue(secondTimeSliceFinished.await(10, TimeUnit.SECONDS));
+        assertEquals(attempts.get(), 2);
+    }
+
+    @Test
+    public void executeRepeatingJobThatFails() throws Exception {
+        Trigger trigger = new RepeatingTrigger.Builder()
+                .withDelay(1, TimeUnit.MINUTES)
+                .withInterval(1, TimeUnit.MINUTES)
+                .build();
+        DateTime timeSlice = new DateTime(trigger.getTriggerTime());
+        JobDetails jobDetails = new JobDetails(randomUUID(), "Failed Repeating Job", "Failed Repeating Job", emptyMap(),
+                trigger);
+
+        AtomicInteger attempts = new AtomicInteger();
+
+        jobScheduler.register(jobDetails.getJobType(), details -> {
+            if (attempts.getAndIncrement() == 0) {
+                return Completable.error(new Exception());
+            }
+            return Completable.complete();
+        });
+
+        scheduleJob(jobDetails);
+
+        CountDownLatch firstTimeSliceFinished = new CountDownLatch(1);
+        CountDownLatch secondTimeSliceFinished = new CountDownLatch(1);
+        onTimeSliceFinished(finishedTimeSlice -> {
+            if (finishedTimeSlice.equals(timeSlice)) {
+                firstTimeSliceFinished.countDown();
+            } else if (finishedTimeSlice.equals(timeSlice.plusMinutes(1))) {
+                secondTimeSliceFinished.countDown();
+            }
+        });
+
+        tickScheduler.advanceTimeTo(timeSlice.getMillis(), TimeUnit.MILLISECONDS);
+        assertTrue(firstTimeSliceFinished.await(10, TimeUnit.SECONDS));
+
+        tickScheduler.advanceTimeBy(1, TimeUnit.MINUTES);
+        assertTrue(secondTimeSliceFinished.await(10, TimeUnit.SECONDS));
+        assertEquals(attempts.get(), 2);
+    }
+
     /**
      * This test executes multiple repeating jobs multiple times.
      */
@@ -412,7 +572,7 @@ public class JobExecutionTest extends JobSchedulerTest {
             scheduleJob(details);
         }
 
-        jobScheduler.registerJobFactory(jobType, details -> Completable.fromAction(() -> {
+        jobScheduler.register(jobType, details -> Completable.fromAction(() -> {
             logger.debug("Executing " + details);
             List<DateTime> executionTimes = executions.get(details.getJobName());
             executionTimes.add(currentMinute());
@@ -488,7 +648,7 @@ public class JobExecutionTest extends JobSchedulerTest {
             shortJobExecutions.offer(new TestLatch(1, timeSlice.plusMinutes(i).toDate()));
         }
 
-        jobScheduler.registerJobFactory(longJob.getJobType(), details -> Completable.fromAction(() -> {
+        jobScheduler.register(longJob.getJobType(), details -> Completable.fromAction(() -> {
             try {
                 longJobExecutionCount.incrementAndGet();
                 logger.debug("LONG wait...");
@@ -500,7 +660,7 @@ public class JobExecutionTest extends JobSchedulerTest {
             }
         }));
 
-        jobScheduler.registerJobFactory(shortJob.getJobType(), details -> Completable.fromAction(() -> {
+        jobScheduler.register(shortJob.getJobType(), details -> Completable.fromAction(() -> {
             try {
                 shortJobExecutionTimes.add(new Date(details.getTrigger().getTriggerTime()));
                 logger.debug("Executing " + details + " " + shortJobExecutionTimes.size() + " times");
@@ -581,7 +741,7 @@ public class JobExecutionTest extends JobSchedulerTest {
         CountDownLatch secondTimeSliceFinished = new CountDownLatch(1);
         CountDownLatch thirdTimeSliceFinished = new CountDownLatch(1);
 
-        jobScheduler.registerJobFactory(jobType, details -> Completable.fromAction(() -> {
+        jobScheduler.register(jobType, details -> Completable.fromAction(() -> {
             logger.debug("Executing " + details);
             long timeout = Math.abs(random.nextLong() % 100);
             DateTime time = new DateTime(details.getTrigger().getTriggerTime());


### PR DESCRIPTION
A retry policy specifies if and when a job should be retried in the event of a
failure. Retry policies are effective only for non-repeating jobs. If a
repating job fails, its trigger determines when it executes again. By default,
failed jobs will not be retried.