### PR TITLE
[HWKMETRICS-422] Avoid writing to the metrics index on data point inserts

### DIFF
--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -46,7 +46,9 @@ public interface DataAccess {
 
     <T> ResultSetFuture insertMetricInMetricsIndex(Metric<T> metric, boolean overwrite);
 
-    <T> Observable<Row> findMetric(MetricId<T> id);
+    <T> Observable<Row> findMetricInData(MetricId<T> id);
+
+    <T> Observable<Row> findMetricInMetricsIndex(MetricId<T> id);
 
     <T> Observable<ResultSet> addDataRetention(Metric<T> metric);
 
@@ -59,6 +61,8 @@ public interface DataAccess {
     <T> Observable<Integer> updateMetricsIndex(Observable<Metric<T>> metrics);
 
     <T> Observable<Row> findMetricsInMetricsIndex(String tenantId, MetricType<T> type);
+
+    Observable<Row> findAllMetricsInData();
 
     Observable<Integer> insertGaugeData(Metric<Double> metric);
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -243,11 +243,6 @@ public interface MetricsService {
             int limit, Order order);
 
     /**
-     * Check if a metric has been stored in the sysconfig.
-     */
-    Observable<Boolean> idExists(MetricId<?> metric);
-
-    /**
      * Computes stats on a counter.
      *
      * @param id      counter metric id

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -963,11 +963,7 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     public Observable<Boolean> idExists(final MetricId<?> metricId) {
-        return this.findMetrics(metricId.getTenantId(), metricId.getType())
-                .filter(m -> {
-                    return metricId.getName().equals(m.getMetricId().getName());
-                })
-                .take(1)
+        return this.findMetric(metricId)
                 .map(m -> Boolean.TRUE)
                 .defaultIfEmpty(Boolean.FALSE);
     }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -880,32 +880,31 @@ public class MetricsServiceImpl implements MetricsService {
         if (!stacked) {
             if (COUNTER == metricType || GAUGE == metricType) {
                 return Observable.from(metrics)
-                        .flatMap(metricName -> findMetric(new MetricId<>(tenantId, metricType, metricName)))
-                        .flatMap(metric -> findDataPoints(metric.getMetricId(), start, end, 0, Order.DESC))
+                        .flatMap(metricName -> findDataPoints(new MetricId<>(tenantId, metricType, metricName), start,
+                                end, 0, Order.DESC))
                         .compose(new NumericBucketPointTransformer(buckets, percentiles));
             } else {
                 MetricType<? extends Number> mtype = metricType == GAUGE_RATE ? GAUGE : COUNTER;
                 return Observable.from(metrics)
-                        .flatMap(metricName -> findMetric(new MetricId<>(tenantId, mtype, metricName)))
-                        .flatMap(metric -> findRateData(metric.getMetricId(), start, end, 0, ASC))
+                        .flatMap(metricName -> findRateData(new MetricId<>(tenantId, mtype, metricName), start, end, 0,
+                                ASC))
                         .compose(new NumericBucketPointTransformer(buckets, percentiles));
             }
         } else {
             Observable<Observable<NumericBucketPoint>> individualStats;
             if (COUNTER == metricType || GAUGE == metricType) {
                 individualStats = Observable.from(metrics)
-                        .flatMap(metricName -> findMetric(new MetricId<>(tenantId, metricType, metricName)))
-                        .map(metric -> {
-                            return findDataPoints(metric.getMetricId(), start, end, 0, Order.DESC)
+                        .map(metricName -> {
+                            return findDataPoints(new MetricId<>(tenantId, metricType, metricName), start, end, 0,
+                                    Order.DESC)
                                     .compose(new NumericBucketPointTransformer(buckets, percentiles))
                                     .flatMap(Observable::from);
                         });
             } else {
                 MetricType<? extends Number> mtype = metricType == GAUGE_RATE ? GAUGE : COUNTER;
                 individualStats = Observable.from(metrics)
-                        .flatMap(metricName -> findMetric(new MetricId<>(tenantId, mtype, metricName)))
-                        .map(metric -> {
-                            return findRateData(metric.getMetricId(), start, end, 0, ASC)
+                        .map(metricName -> {
+                            return findRateData(new MetricId<>(tenantId, mtype, metricName), start, end, 0, ASC)
                                     .compose(new NumericBucketPointTransformer(buckets, percentiles))
                                     .flatMap(Observable::from);
                         });

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -962,13 +962,6 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    public Observable<Boolean> idExists(final MetricId<?> metricId) {
-        return this.findMetric(metricId)
-                .map(m -> Boolean.TRUE)
-                .defaultIfEmpty(Boolean.FALSE);
-    }
-
-    @Override
     public Observable<List<NumericBucketPoint>> findCounterStats(MetricId<Long> id, long start, long end,
             Buckets buckets, List<Percentile> percentiles) {
         checkArgument(isValidTimeRange(start, end), "Invalid time range");

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricFromDataRowTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricFromDataRowTransformer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.core.service.transformers;
+
+import org.hawkular.metrics.model.Metric;
+import org.hawkular.metrics.model.MetricId;
+import org.hawkular.metrics.model.MetricType;
+import org.joda.time.Duration;
+
+import com.datastax.driver.core.Row;
+
+import rx.Observable;
+import rx.Observable.Transformer;
+
+/**
+ * Transforms {@link Row}s from data table to a {@link Metric}. Requires the following order on select:
+ * {@code metric_id}.
+ *
+ * @author Thomas Segismont
+ */
+public class MetricFromDataRowTransformer<T> implements Transformer<Row, Metric<T>> {
+    private final MetricType<T> type;
+    private final String tenantId;
+    private final int defaultDataRetention;
+
+    public MetricFromDataRowTransformer(String tenantId, MetricType<T> type, int defaultTTL) {
+        this.type = type;
+        this.tenantId = tenantId;
+        this.defaultDataRetention = (int) Duration.standardSeconds(defaultTTL).getStandardDays();
+    }
+
+    @Override
+    public Observable<Metric<T>> call(Observable<Row> rows) {
+        return rows.map(row -> {
+            MetricId<T> metricId = new MetricId<>(tenantId, type, row.getString(1));
+            return new Metric<>(metricId, defaultDataRetention);
+        });
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricFromFullDataRowTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricFromFullDataRowTransformer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.metrics.core.service.transformers;
+
+import org.hawkular.metrics.model.Metric;
+import org.hawkular.metrics.model.MetricId;
+import org.hawkular.metrics.model.MetricType;
+import org.joda.time.Duration;
+
+import com.datastax.driver.core.Row;
+
+import rx.Observable;
+import rx.Observable.Transformer;
+
+/**
+ * Transforms {@link Row}s from data table to a {@link Metric}. Requires the following order on select:
+ * {@code tenant_id, type, metric_id}.
+ *
+ * @author Thomas Segismont
+ */
+public class MetricFromFullDataRowTransformer implements Transformer<Row, Metric<?>> {
+    private final int defaultDataRetention;
+
+    public MetricFromFullDataRowTransformer(int defaultTTL) {
+        this.defaultDataRetention = (int) Duration.standardSeconds(defaultTTL).getStandardDays();
+    }
+
+    @Override
+    public Observable<Metric<?>> call(Observable<Row> rows) {
+        return rows.map(row -> {
+            MetricId<?> metricId = new MetricId<>(row.getString(0), MetricType.fromCode(row.getByte(2)),
+                    row.getString(1));
+            return new Metric<>(metricId, defaultDataRetention);
+        });
+    }
+}

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -65,8 +65,13 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public <T> Observable<Row> findMetric(MetricId<T> id) {
-        return delegate.findMetric(id);
+    public <T> Observable<Row> findMetricInData(MetricId<T> id) {
+        return delegate.findMetricInData(id);
+    }
+
+    @Override
+    public <T> Observable<Row> findMetricInMetricsIndex(MetricId<T> id) {
+        return delegate.findMetricInMetricsIndex(id);
     }
 
     @Override
@@ -97,6 +102,11 @@ public class DelegatingDataAccess implements DataAccess {
     @Override
     public <T> Observable<Row> findMetricsInMetricsIndex(String tenantId, MetricType<T> type) {
         return delegate.findMetricsInMetricsIndex(tenantId, type);
+    }
+
+    @Override
+    public Observable<Row> findAllMetricsInData() {
+        return delegate.findAllMetricsInData();
     }
 
     @Override

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/AvailabilityITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/AvailabilityITest.java
@@ -113,10 +113,9 @@ public class AvailabilityITest extends BaseMetricsITest {
         assertEquals(actual, expected.getDataPoints(), "The availability data does not match expected values");
 
         assertMetricIndexMatches(tenantId, AVAILABILITY, asList(
-                new Metric<>(m1.getMetricId(), m1.getDataPoints(), 7),
-                new Metric<>(m2.getMetricId(), m2.getDataPoints(), 7),
-                new Metric<>(m3.getMetricId(), 7),
-                m4));
+                new Metric<>(m1.getMetricId(), 7),
+                new Metric<>(m2.getMetricId(), 7),
+                new Metric<>(m4.getMetricId(), 24)));
     }
 
     @Test

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
@@ -51,7 +51,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -164,9 +164,9 @@ public abstract class BaseMetricsITest extends BaseITest {
 
     protected void assertMetricIndexMatches(String tenantId, MetricType<?> type, List<Metric<?>> expected)
         throws Exception {
-        List<Metric<?>> actualIndex = ImmutableList.copyOf(metricsService.findMetrics(tenantId, type).toBlocking()
-                .toIterable());
-        assertEquals(actualIndex, expected, "The metrics index results do not match");
+        Set<Metric<?>> actualIndex = Sets
+                .newHashSet(metricsService.findMetrics(tenantId, type).toBlocking().toIterable());
+        assertEquals(actualIndex, Sets.newHashSet(expected), "The metrics index results do not match");
     }
 
     protected class MetricsTagsIndexEntry {

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
@@ -134,7 +134,6 @@ public class GaugeITest extends BaseMetricsITest {
         assertMetricIndexMatches(tenantId, GAUGE, asList(
                 new Metric<>(m1.getMetricId(), m1.getDataPoints(), 7),
                 new Metric<>(m2.getMetricId(), m2.getDataPoints(), 7),
-                new Metric<>(m3.getMetricId(), 7),
                 m4));
     }
 


### PR DESCRIPTION
Avoid writing to the metrics index on data point inserts. However, keep all the other writes to the metrics index in place.

Here are the changes to query metrics:
1) When requesting info about a single metric
  a) query the metrics index first, if found then return the info (just like before this change)
  b) if no result there, query the data table for a single data point, if found then the metric exists just not in the metrics index
  c) if no result in either metrics index or data table then there is no such metric

2) When requesting a list of all metrics for a tenant
  a) query the metrics index first
  b) query the data table for all metrics and filter by tenant and type if needed
  c) concat the two lists
  d) return only distinct values; note that the results from metrics index take precendence since they contain info about data retention and tags.

Note: After this change the metrics index will still contain metrics that have tags, non-default retention values, or have been explicitly created by the user. Metrics that just have data points will not have an entry in the metrics index table.