### PR TITLE
[HWKMETRICS-465] New POST endpoints gauges/stats/query and counters/stats/query

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AggregatedStatsQueryRequest.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AggregatedStatsQueryRequest.java
@@ -16,20 +16,18 @@
  */
 package org.hawkular.metrics.api.jaxrs;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
 /**
- * @author jsanda
+ * Request object used to provide stats on multiple metrics that are aggregated
+ * @author Joel Takvorian
  */
-public class StatsQueryRequest {
+public class AggregatedStatsQueryRequest {
 
-    private Map<String, List<String>> metrics = new HashMap<>();
+    private List<String> metrics;
 
     private String start;
 
@@ -43,13 +41,13 @@ public class StatsQueryRequest {
 
     private String tags;
 
-    private List<String> types = new ArrayList<>();
+    private boolean stacked;
 
-    public Map<String, List<String>> getMetrics() {
+    public List<String> getMetrics() {
         return metrics;
     }
 
-    public void setMetrics(Map<String, List<String>> metrics) {
+    public void setMetrics(List<String> metrics) {
         this.metrics = metrics;
     }
 
@@ -101,19 +99,19 @@ public class StatsQueryRequest {
         this.tags = tags;
     }
 
-    public List<String> getTypes() {
-        return types;
+    public boolean isStacked() {
+        return stacked;
     }
 
-    public void setTypes(List<String> types) {
-        this.types = types;
+    public void setStacked(boolean stacked) {
+        this.stacked = stacked;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        StatsQueryRequest that = (StatsQueryRequest) o;
+        AggregatedStatsQueryRequest that = (AggregatedStatsQueryRequest) o;
         return Objects.equals(metrics, that.metrics) &&
                 Objects.equals(tags, that.tags) &&
                 Objects.equals(start, that.start) &&
@@ -121,12 +119,12 @@ public class StatsQueryRequest {
                 Objects.equals(buckets, that.buckets) &&
                 Objects.equals(bucketDuration, that.bucketDuration) &&
                 Objects.equals(percentiles, that.percentiles) &&
-                Objects.equals(types, that.types);
+                Objects.equals(stacked, that.stacked);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(metrics, tags, start, end, buckets, bucketDuration, percentiles, types);
+        return Objects.hash(metrics, tags, start, end, buckets, bucketDuration, percentiles, stacked);
     }
 
     @Override public String toString() {
@@ -138,7 +136,7 @@ public class StatsQueryRequest {
                 .add("buckets", buckets)
                 .add("bucketDuration", bucketDuration)
                 .add("percentiles", percentiles)
-                .add("types", types)
+                .add("stacked", stacked)
                 .toString();
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -47,6 +47,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import org.hawkular.metrics.api.jaxrs.AggregatedStatsQueryRequest;
 import org.hawkular.metrics.api.jaxrs.QueryRequest;
 import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
@@ -795,6 +796,26 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
         }
+    }
+
+    @POST
+    @Path("/stats/query")
+    @ApiOperation(value = "Find stats for multiple metrics. These metrics are aggregated into a single statistics " +
+            "series.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully fetched metric data."),
+            @ApiResponse(code = 204, message = "Query was successful, but no data was found."),
+            @ApiResponse(code = 400, message = "Either tags or metric ids is required but not both. Either the " +
+                    "buckets or the bucketDuration parameter is required but not both.", response = ApiError.class),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
+                    response = ApiError.class)
+    })
+    public void getStats(
+            @Suspended AsyncResponse asyncResponse,
+            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids. " +
+                    "The standard start, end, order, and limit query parameters are supported as well.")
+                    AggregatedStatsQueryRequest query) {
+        findStatsForAggregatedMetrics(asyncResponse, query, MetricType.COUNTER);
     }
 
     @Deprecated


### PR DESCRIPTION
It's a kind of duplication of the GET endpoints "gauges/stats" and "counters/stats".
The reason is the same as the one explained here: https://issues.jboss.org/browse/HWKMETRICS-410 and which ended up in duplicating GET "gauges/raw" endpoint to POST "gauges/raw/query" in a similar way.

Also added integration tests