### PR TITLE
Updated swagger return types to match actual return types

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -55,6 +55,7 @@ import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.service.Functions;
 import org.hawkular.metrics.core.service.Order;
 import org.hawkular.metrics.model.ApiError;
+import org.hawkular.metrics.model.AvailabilityBucketPoint;
 import org.hawkular.metrics.model.AvailabilityType;
 import org.hawkular.metrics.model.Buckets;
 import org.hawkular.metrics.model.DataPoint;
@@ -422,7 +423,7 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
     @Path("/{id}/stats")
     @ApiOperation(value = "Retrieve availability data.", notes = "Based on buckets or bucketDuration query parameter" +
             ", the time range between start and end will be divided in buckets of equal duration, and " +
-            "availability statistics will be computed for each bucket.", response = DataPoint.class,
+            "availability statistics will be computed for each bucket.", response = AvailabilityBucketPoint.class,
             responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched availability data."),

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -514,7 +514,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
     @Path("/{id}/stats")
     @ApiOperation(value = "Retrieve counter data points.", notes = "When buckets or bucketDuration query parameter " +
             "is used, the time range between start and end will be divided in buckets of equal duration, and metric " +
-            "statistics will be computed for each bucket.", response = DataPoint.class, responseContainer =
+            "statistics will be computed for each bucket.", response = NumericBucketPoint.class, responseContainer =
             "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched metric data."),
@@ -610,7 +610,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             "used, the time range between start and end will be divided in buckets of equal duration, and metric " +
             "statistics will be computed for each bucket. Reset events are detected and data points that immediately " +
             "follow such events are filtered out prior to calculating the rates. This avoid misleading or inaccurate " +
-            "rates when resets occur.", response = DataPoint.class, responseContainer = "List")
+            "rates when resets occur.", response = NumericBucketPoint.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched metric data."),
             @ApiResponse(code = 204, message = "No metric data was found."),
@@ -681,7 +681,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             "will be divided in buckets of equal duration, and metric " +
             "statistics will be computed for each bucket. Reset events are detected and data points that immediately " +
             "follow such events are filtered out prior to calculating the rates. This avoid misleading or inaccurate " +
-            "rates when resets occur.", response = DataPoint.class, responseContainer = "List")
+            "rates when resets occur.", response = NumericBucketPoint.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched metric data."),
             @ApiResponse(code = 204, message = "No metric data was found."),

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -64,6 +64,7 @@ import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.NumericBucketPoint;
 import org.hawkular.metrics.model.Percentile;
+import org.hawkular.metrics.model.TaggedBucketPoint;
 import org.hawkular.metrics.model.exception.RuntimeApiError;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
@@ -518,7 +519,7 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
     @Path("/{id}/stats")
     @ApiOperation(value = "Retrieve gauge data.", notes = "The time range between start and end will be divided "
             + "in buckets of equal duration, and metric statistics will be computed for each bucket.",
-                    response = DataPoint.class, responseContainer = "List")
+                    response = NumericBucketPoint.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched metric data."),
             @ApiResponse(code = 204, message = "No metric data was found."),
@@ -670,7 +671,7 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
     @Path("/{id}/stats/tags/{tags}")
     @ApiOperation(value = "Fetches data points and groups them into buckets based on one or more tag filters. The " +
             "data points in each bucket are then transformed into aggregated (i.e., bucket) data points.",
-            response = DataPoint.class, responseContainer = "Map")
+            response = TaggedBucketPoint.class, responseContainer = "Map")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched metric data."),
             @ApiResponse(code = 204, message = "No metric data was found."),
@@ -831,7 +832,7 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
     @ApiOperation(
             value = "Retrieve stats for gauge rate data points.", notes = "The time range between start and end " +
             "will be divided in buckets of equal duration, and metric statistics will be computed for each bucket.",
-            response = DataPoint.class, responseContainer = "List")
+            response = NumericBucketPoint.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched metric data."),
             @ApiResponse(code = 204, message = "No metric data was found."),


### PR DESCRIPTION
Swagger annotations dont match what is actually returned, which is confusing when parsing back to objects via jackson