### PR TITLE
ETL compression process based on Gorilla algorithms

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -407,6 +407,7 @@ public class MetricsServiceLifecycle {
         RxSession rxSession = new RxSessionImpl(session);
         jobsService = new JobsServiceImpl();
         jobsService.setMetricsService(metricsService);
+        jobsService.setConfigurationService(configurationService);
         jobsService.setSession(rxSession);
         scheduler = new JobSchedulerFactory().getJobScheduler(rxSession);
         jobsService.setScheduler(scheduler);

--- a/core/datetime-service/src/main/java/org/hawkular/metrics/datetime/DateTimeService.java
+++ b/core/datetime-service/src/main/java/org/hawkular/metrics/datetime/DateTimeService.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.metrics.datetime;
 
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjuster;
 import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
@@ -98,5 +101,14 @@ public class DateTimeService {
         return dt.millisOfSecond().roundCeilingCopy().minusMillis(dt.getMillisOfSecond() % p.getMillis());
     }
 
+    public static TemporalAdjuster startOfNextOddHour() {
+        return temporal -> {
+            int currentHour = temporal.get(ChronoField.HOUR_OF_DAY);
+            return temporal.plus((currentHour % 2 == 0) ? 1 : 2, ChronoUnit.HOURS)
+                    .with(ChronoField.MINUTE_OF_HOUR, 0)
+                    .with(ChronoField.SECOND_OF_MINUTE, 0)
+                    .with(ChronoField.NANO_OF_SECOND, 0);
+        };
+    }
 
 }

--- a/core/metrics-core-service/pom.xml
+++ b/core/metrics-core-service/pom.xml
@@ -87,6 +87,11 @@
       <artifactId>rxjava-math</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>fi.iki.yak</groupId>
+      <artifactId>compression-gorilla</artifactId>
+    </dependency>
+
     <!-- JBoss Logging Annotations Processor -->
 
     <dependency>

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/CompressData.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/CompressData.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.jobs;
+
+import static org.hawkular.metrics.model.MetricType.AVAILABILITY;
+import static org.hawkular.metrics.model.MetricType.COUNTER;
+import static org.hawkular.metrics.model.MetricType.GAUGE;
+
+import org.hawkular.metrics.core.service.MetricsService;
+import org.hawkular.metrics.datetime.DateTimeService;
+import org.hawkular.metrics.model.Metric;
+import org.hawkular.metrics.model.MetricId;
+import org.hawkular.metrics.scheduler.api.JobDetails;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+
+import rx.Completable;
+import rx.Observable;
+import rx.functions.Func1;
+
+/**
+ * @author Michael Burman
+ */
+public class CompressData implements Func1<JobDetails, Completable> {
+
+    public static final String JOB_NAME = "COMPRESS_DATA";
+    public static final String ENABLED_CONFIG = "compression.enabled";
+    public static final String BLOCK_SIZE = "compression.block.size";
+
+    private MetricsService metricsService;
+
+    public CompressData(MetricsService service) {
+        metricsService = service;
+    }
+
+    @Override
+    public Completable call(JobDetails jobDetails) {
+        // Rewind to previous timeslice
+        long previousBlock = DateTimeService.getTimeSlice(new DateTime(jobDetails.getTrigger().getTriggerTime(),
+                DateTimeZone.UTC).minusHours(2), Duration.standardHours(2)).getMillis();
+
+        Observable<? extends MetricId<?>> metricIds = metricsService.findAllMetrics()
+                .map(Metric::getMetricId)
+                .filter(m -> (m.getType() == GAUGE || m.getType() == COUNTER || m.getType() == AVAILABILITY));
+
+        // Fetch all partition keys and compress the previous timeSlice
+        return Completable.fromObservable(metricsService.compressBlock(metricIds, previousBlock));
+
+        // TODO Optimization - new worker per token - use parallelism in Cassandra
+        // Configure the amount of parallelism?
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsService.java
@@ -18,6 +18,7 @@ package org.hawkular.metrics.core.jobs;
 
 import org.hawkular.metrics.scheduler.api.JobDetails;
 
+import rx.Observable;
 import rx.Single;
 
 /**
@@ -30,4 +31,8 @@ public interface JobsService {
     void shutdown();
 
     Single<JobDetails> submitDeleteTenantJob(String tenantId, String jobName);
+
+    Single<JobDetails> submitCompressDataJob();
+
+    Observable<JobDetails> getJobDetails();
 }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -20,6 +20,7 @@ package org.hawkular.metrics.core.service;
 import java.util.Map;
 import java.util.Set;
 
+import org.hawkular.metrics.core.service.compress.CompressedPointContainer;
 import org.hawkular.metrics.model.AvailabilityType;
 import org.hawkular.metrics.model.Interval;
 import org.hawkular.metrics.model.Metric;
@@ -76,6 +77,9 @@ public interface DataAccess {
 
     Observable<Row> findCounterData(MetricId<Long> id, long startTime, long endTime, int limit, Order order);
 
+    Observable<Row> findCompressedData(MetricId<?> id, long startTime, long endTime, int limit, Order
+            order);
+
     Observable<Row> findGaugeData(MetricId<Double> id, long startTime, long endTime, int limit, Order order);
 
     Observable<Row> findStringData(MetricId<String> id, long startTime, long endTime, int limit, Order order);
@@ -84,7 +88,6 @@ public interface DataAccess {
             Order order);
 
     Observable<Row> findAvailabilityData(MetricId<AvailabilityType> id, long timestamp);
-
 
     Observable<ResultSet> deleteGaugeMetric(String tenantId, String metric, Interval interval, long dpart);
 
@@ -106,4 +109,8 @@ public interface DataAccess {
     Observable<Row> findMetricsByTagName(String tenantId, String tag);
 
     Observable<Row> findMetricsByTagNameValue(String tenantId, String tag, String tvalue);
+
+    <T> Observable<ResultSet> deleteAndInsertCompressedGauge(MetricId<T> id, long timeslice,
+                                                             CompressedPointContainer cpc,
+                                                             long sliceStart, long sliceEnd, int ttl);
 }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -96,6 +96,8 @@ public interface MetricsService {
      */
     Observable<Void> createMetric(Metric<?> metric, boolean overwrite);
 
+    Observable<Metric<?>> findAllMetrics();
+
     <T> Observable<Metric<T>> findMetric(MetricId<T> id);
 
     /**
@@ -163,8 +165,12 @@ public interface MetricsService {
      */
     <T> Observable<DataPoint<T>> findDataPoints(MetricId<T> id, long start, long end, int limit, Order order);
 
+    Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long timeSlice);
+
+//    <T> Observable<Void> compressBlock(Observable<MetricId<T>> metrics, long timeSlice);
+
     <T> Observable<NamedDataPoint<T>> findDataPoints(List<MetricId<T>> ids, long start, long end, int limit,
-            Order order);
+                                                     Order order);
 
     /**
      * Fetch data points for multiple metrics searched by tag.

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/compress/CompressedPointContainer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/compress/CompressedPointContainer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.service.compress;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Holds references to the row's byteBuffers. If only value is set, then that should include all the necessary
+ * information for both tags as well as timestamps.
+ *
+ * @author Michael Burman
+ */
+public class CompressedPointContainer {
+
+    private ByteBuffer valueBuffer = null;
+    private ByteBuffer timestampBuffer = null;
+    private ByteBuffer tagsBuffer = null;
+
+    public ByteBuffer getValueBuffer() {
+        return valueBuffer;
+    }
+
+    public void setValueBuffer(ByteBuffer valueBuffer) {
+        this.valueBuffer = valueBuffer;
+    }
+
+    public ByteBuffer getTimestampBuffer() {
+        return timestampBuffer;
+    }
+
+    public void setTimestampBuffer(ByteBuffer timestampBuffer) {
+        this.timestampBuffer = timestampBuffer;
+    }
+
+    public ByteBuffer getTagsBuffer() {
+        return tagsBuffer;
+    }
+
+    public void setTagsBuffer(ByteBuffer tagsBuffer) {
+        this.tagsBuffer = tagsBuffer;
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/compress/CompressorHeader.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/compress/CompressorHeader.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.service.compress;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * CompressionHeader for compression details, stored as the first byte in every c_value ByteBuffer
+ *
+ * First 4 bits are reserved for compressor type
+ * Next 4 bits are reserved for compressor's properties
+ *
+ * @author Michael Burman
+ */
+public class CompressorHeader {
+
+    public interface CompressorSetting {
+        byte getByteValue();
+    }
+
+    public enum Compressor {
+        GORILLA((byte) 0x10, GorillaSettings.class);
+
+        private byte value;
+        private Class enumClass;
+
+        Compressor(byte value, Class enumClass) {
+            this.value = value;
+            this.enumClass = enumClass;
+        }
+
+        public byte getByteValue() {
+            return this.value;
+        }
+
+        public <E extends Enum<E> & CompressorSetting> Class getSettingsClass() {
+            return enumClass;
+        }
+    }
+
+    public enum GorillaSettings implements CompressorSetting {
+        SECOND_PRECISION((byte) 0x01);
+
+        private byte value;
+
+        GorillaSettings(byte value) {
+            this.value = value;
+        }
+
+        public byte getByteValue() {
+            return this.value;
+        }
+    }
+
+    public static byte getHeader(Compressor compressor, EnumSet<? extends CompressorSetting> settings) {
+        byte b = (byte) (compressor.getByteValue() & 0xF0);
+        for (CompressorSetting setting : settings) {
+            b ^= setting.getByteValue();
+        }
+
+        return b;
+    }
+
+    public static Compressor getCompressor(byte b) {
+        byte d = (byte) (b & 0xF0);
+
+        for (Compressor compressor : Compressor.values()) {
+            if(compressor.value == d) {
+                return compressor;
+            }
+        }
+
+        throw new RuntimeException("Invalid compression method " + Integer.toBinaryString((d & 0xFF) + 0x100)
+                .substring(1));
+
+    }
+
+    public static <E extends Enum<E> & CompressorSetting> EnumSet getSettings(Class<E> e, byte b) {
+        List<E> enumList = new ArrayList<>(4); // There's only 4 bits reserved
+        EnumSet<E> enumSet = EnumSet.allOf(e);
+        for (E setting : enumSet) {
+            if((b & setting.getByteValue()) == setting.getByteValue()) {
+                enumList.add(setting);
+            }
+        }
+
+        return EnumSet.copyOf(enumList);
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/compress/TagsDeserializer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/compress/TagsDeserializer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.service.compress;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Deserializes the data_compressed table tags map
+ *
+ * @author Michael Burman
+ */
+public class TagsDeserializer {
+    private long blockStart;
+
+    public TagsDeserializer(long blockStart) {
+        this.blockStart = blockStart;
+    }
+
+    public Map<Long, Map<String, String>> deserialize(ByteBuffer bb) {
+        Map<Long, Map<String, String>> tagsMap = new HashMap<>();
+
+        if(bb.hasRemaining()) {
+            if(TagsSerializer.SIMPLE_SERIALIZER == bb.get()) {
+                while(bb.hasRemaining()) {
+                    int delta = bb.getInt();
+                    long timestamp = blockStart + delta;
+
+                    int tagsSize = bb.get() & 0xFF;
+
+                    Map<String, String> entryMap = new HashMap<>();
+
+                    for(byte i = 0; i < tagsSize; i++) {
+                        int keyLength = bb.get() & 0xFF;
+                        int valueLength = bb.get() & 0xFF;
+
+                        byte[] key = new byte[keyLength];
+                        byte[] value = new byte[valueLength];
+
+                        bb.get(key);
+                        bb.get(value);
+
+                        String mapKey = new String(key, StandardCharsets.UTF_8);
+                        String mapValue = new String(value, StandardCharsets.UTF_8);
+
+                        entryMap.put(mapKey, mapValue);
+                    }
+
+                    tagsMap.put(Long.valueOf(timestamp), entryMap);
+                }
+            } else {
+                // Return back to start position, let something else handle it
+                bb.rewind();
+            }
+        }
+
+        return tagsMap;
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/compress/TagsSerializer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/compress/TagsSerializer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.service.compress;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Serializes multiple rows of tags to a single blob. For compression, we rely on the Cassandra's block compression.
+ *
+ * @author Michael Burman
+ */
+public class TagsSerializer {
+
+    private ByteBuffer bb;
+    private int MAX_SIZE = 255;
+    private long blockStart;
+    public static byte SIMPLE_SERIALIZER = 0x10;
+
+    public TagsSerializer(long blockStart) {
+        // Max byteAmount is 510 bytes per key/value + 4 bytes for delta + 1 byte for
+
+        bb = ByteBuffer.allocate(33*4096);
+        bb.put(SIMPLE_SERIALIZER);
+        this.blockStart = blockStart; // No need to encode blockStart as we have that stored on the row already
+    }
+
+    public void addDataPointTags(long timestamp, Map<String, String> tags) {
+        if(tags.entrySet().size() > MAX_SIZE) {
+            throw new RuntimeException("Single datapoint can only store max of " + MAX_SIZE + " tags");
+        }
+
+        // Store delta of block timestamp.. 23 bits is enough to represent any delta value
+        long delta = timestamp - blockStart;
+
+        bb.putInt((int) delta);
+        bb.put((byte) tags.entrySet().size()); // MAX of 255 tags per datapoint?
+
+        // Now write the values
+        for (Map.Entry<String, String> tagEntry : tags.entrySet()) {
+            byte[] key = tagEntry.getKey().getBytes(StandardCharsets.UTF_8);
+            byte[] value = tagEntry.getValue().getBytes(StandardCharsets.UTF_8);
+
+            if(key.length > MAX_SIZE || value.length > MAX_SIZE) {
+                throw new RuntimeException("Could not store pair key->" + tagEntry.getKey() + ", value->" + tagEntry
+                        .getValue() + ", they exceed max length of " + MAX_SIZE + " bytes");
+            }
+
+            bb.put((byte) key.length);
+            bb.put((byte) value.length);
+            bb.put(key);
+            bb.put(value);
+        }
+    }
+
+    public ByteBuffer getByteBuffer() {
+        return bb;
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/BatchStatementTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/BatchStatementTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,6 @@
 package org.hawkular.metrics.core.service.transformers;
 
 import static com.datastax.driver.core.BatchStatement.Type.UNLOGGED;
-import static com.google.common.base.Preconditions.checkArgument;
 
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.Statement;
@@ -32,7 +31,7 @@ import rx.functions.Func0;
  * @author Thomas Segismont
  */
 public class BatchStatementTransformer implements Transformer<Statement, BatchStatement> {
-    public static final int MAX_BATCH_SIZE = 10;
+    public static final int DEFAULT_BATCH_SIZE = 10;
 
     /**
      * Creates {@link com.datastax.driver.core.BatchStatement.Type#UNLOGGED} batch statements.
@@ -46,7 +45,7 @@ public class BatchStatementTransformer implements Transformer<Statement, BatchSt
      * Creates a new transformer using the {@link #DEFAULT_BATCH_STATEMENT_FACTORY}.
      */
     public BatchStatementTransformer() {
-        this(DEFAULT_BATCH_STATEMENT_FACTORY, MAX_BATCH_SIZE);
+        this(DEFAULT_BATCH_STATEMENT_FACTORY, DEFAULT_BATCH_SIZE);
     }
 
     /**
@@ -55,7 +54,7 @@ public class BatchStatementTransformer implements Transformer<Statement, BatchSt
      */
     public BatchStatementTransformer(Func0<BatchStatement> batchStatementFactory, int batchSize) {
         this.batchSize = batchSize;
-        checkArgument(batchSize <= MAX_BATCH_SIZE, "batchSize exceeds limit");
+//        checkArgument(batchSize <= DEFAULT_BATCH_SIZE, "batchSize exceeds limit");
         this.batchStatementFactory = batchStatementFactory;
     }
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/DataPointCompressTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/DataPointCompressTransformer.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.service.transformers;
+
+import java.nio.ByteBuffer;
+import java.util.EnumSet;
+
+import org.hawkular.metrics.core.service.compress.CompressedPointContainer;
+import org.hawkular.metrics.core.service.compress.CompressorHeader;
+import org.hawkular.metrics.core.service.compress.TagsSerializer;
+import org.hawkular.metrics.model.AvailabilityType;
+import org.hawkular.metrics.model.DataPoint;
+import org.hawkular.metrics.model.MetricType;
+
+import fi.iki.yak.ts.compression.gorilla.ByteBufferBitOutput;
+import fi.iki.yak.ts.compression.gorilla.Compressor;
+import rx.Observable;
+
+/**
+ * DataPointCompressor for the type 01 (plain Gorilla)
+ *
+ * @author Michael Burman
+ */
+public class DataPointCompressTransformer<T> implements Observable.Transformer<DataPoint<T>, CompressedPointContainer> {
+
+    private ByteBufferBitOutput out;
+    private long sliceTimestamp;
+    private MetricType<T> metricType;
+    private Compressor compressor;
+    private TagsSerializer tagsSerializer;
+
+    public DataPointCompressTransformer(MetricType<T> metricType, long timeslice) {
+        out = new ByteBufferBitOutput();
+        this.metricType = metricType;
+
+        // Write the appropriate header, at first we're stuck to Gorilla only
+        byte gorillaHeader = CompressorHeader.getHeader(CompressorHeader.Compressor.GORILLA, EnumSet.noneOf
+                (CompressorHeader.GorillaSettings.class));
+        out.getByteBuffer().put(gorillaHeader);
+
+        this.sliceTimestamp = timeslice;
+        this.compressor = new Compressor(timeslice, out);
+        this.tagsSerializer = new TagsSerializer(timeslice);
+    }
+
+    @Override
+    public Observable<CompressedPointContainer> call(Observable<DataPoint<T>> datapoints) {
+        return datapoints.collect(CompressedPointContainer::new,
+                (container, d) -> {
+                    switch(metricType.getCode()) {
+                        case 0: // GAUGE
+                            compressor.addValue(d.getTimestamp(), (Double) d.getValue());
+                            break;
+                        case 1: // AVAILABILITY
+                            compressor.addValue(d.getTimestamp(), ((AvailabilityType) d.getValue()).getCode());
+                            break;
+                        case 2: // COUNTER
+                            compressor.addValue(d.getTimestamp(), (Long) d.getValue());
+                            break;
+                        default:
+                            // Not supported yet
+                            throw new RuntimeException("Metric of type " + metricType.getText() + " is not supported " +
+                                    "in compression");
+                    }
+
+                    if(d.getTags() != null && !d.getTags().isEmpty()) {
+                        tagsSerializer.addDataPointTags(d.getTimestamp(), d.getTags());
+                    }
+                })
+                .doOnNext(cpc -> {
+                    compressor.close();
+                    ByteBuffer valueBuffer = (ByteBuffer) out.getByteBuffer().flip();
+                    ByteBuffer tagsBuffer = (ByteBuffer) tagsSerializer.getByteBuffer().flip();
+                    cpc.setValueBuffer(valueBuffer);
+                    if(tagsBuffer.limit() > 1) {
+                        // Exclude header
+                        cpc.setTagsBuffer(tagsBuffer);
+                    }
+                });
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/DataPointDecompressTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/DataPointDecompressTransformer.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.service.transformers;
+
+import static org.hawkular.metrics.core.service.Order.ASC;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.hawkular.metrics.core.service.Order;
+import org.hawkular.metrics.core.service.compress.TagsDeserializer;
+import org.hawkular.metrics.model.AvailabilityType;
+import org.hawkular.metrics.model.DataPoint;
+import org.hawkular.metrics.model.MetricType;
+
+import com.datastax.driver.core.Row;
+
+import fi.iki.yak.ts.compression.gorilla.BitInput;
+import fi.iki.yak.ts.compression.gorilla.ByteBufferBitInput;
+import fi.iki.yak.ts.compression.gorilla.Decompressor;
+import fi.iki.yak.ts.compression.gorilla.Pair;
+import rx.Observable;
+
+/**
+ * Transforms input rows from compressed format back to DataPoints.
+ *
+ * @author Michael Burman
+ */
+public class DataPointDecompressTransformer<T> implements Observable.Transformer<Row, DataPoint<T>> {
+
+    private Order order;
+    private int limit;
+    private long start;
+    private long end;
+    private MetricType<T> metricType;
+
+    public DataPointDecompressTransformer(MetricType<T> metricType, Order order, int limit, long start, long end) {
+        this.order = order;
+        this.limit = limit;
+        this.start = start;
+        this.end = end;
+        this.metricType = metricType;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Observable<DataPoint<T>> call(Observable<Row> rows) {
+
+        Observable<DataPoint<T>> datapoints =
+                rows.flatMap(r -> {
+                    Stream.Builder<DataPoint<T>> dataPointStreamBuilder = Stream.builder();
+
+                    ByteBuffer tagsBuffer = r.getBytes("tags");
+                    ByteBuffer compressedValue = r.getBytes("c_value");
+
+                    if (compressedValue != null) {
+                        // Read the HWKMETRICS internal header here, but don't process as of now
+                        compressedValue.get();
+
+                        BitInput in = new ByteBufferBitInput(compressedValue);
+
+                        Map<Long, Map<String, String>> tagMap = null;
+                        if(tagsBuffer != null) {
+                            long blockStart = r.getTimestamp("time").toInstant().toEpochMilli();
+                            TagsDeserializer deserializer = new TagsDeserializer(blockStart);
+                            tagMap = deserializer.deserialize(tagsBuffer);
+                        }
+
+                        Decompressor d = new Decompressor(in);
+                        Pair pair;
+                        while ((pair = d.readPair()) != null) {
+                            if (pair.getTimestamp() >= start && pair.getTimestamp() < end) {
+                                DataPoint<T> dataPoint = null;
+
+                                switch(metricType.getCode()) {
+                                    case 0: // GAUGE
+                                        dataPoint = new DataPoint(pair.getTimestamp(), pair.getDoubleValue());
+                                        break;
+                                    case 1: // AVAILABILITY
+                                        dataPoint = new DataPoint(pair.getTimestamp(), AvailabilityType.fromByte((byte)
+                                            pair.getLongValue()));
+                                        break;
+                                    case 2: // COUNTER
+                                        dataPoint = new DataPoint(pair.getTimestamp(), pair.getLongValue());
+                                        break;
+                                    default:
+                                        // Not supported yet
+                                        throw new RuntimeException(
+                                                "Metric of type " + metricType.getText() + " is not supported " +
+                                                        "in decompression");
+                                }
+
+                                // Add tags from the serialized tags
+                                if(tagMap != null) {
+                                    Long key = pair.getTimestamp();
+
+                                    if (tagMap.containsKey(key)) {
+                                        Map<String, String> dpTags = tagMap.get(key);
+                                        dataPoint = new DataPoint(dataPoint.getTimestamp(), dataPoint
+                                                .getValue(), dpTags);
+                                    }
+                                }
+
+                                dataPointStreamBuilder.add(dataPoint);
+                            }
+                        }
+                    }
+                    return Observable.from(dataPointStreamBuilder.build()
+                            .sorted((d1, d2) -> {
+                                if (order == ASC) {
+                                    return (d1.getTimestamp() > d2.getTimestamp()) ? 1 : -1;
+                                }
+                                return (d1.getTimestamp() < d2.getTimestamp()) ? 1 : -1;
+                            })
+                            .collect(Collectors.toList()));
+                });
+        if(limit > 0) {
+            // TODO What about the min-max timestamp case when requesting metric info (MiQ)? Should we store it on
+            //      the row as aggregate? No need to fetch c_value and calculate from there
+            datapoints = datapoints.take(limit);
+        }
+
+        return datapoints;
+    }
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricFromDataRowTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricFromDataRowTransformer.java
@@ -47,7 +47,7 @@ public class MetricFromDataRowTransformer<T> implements Transformer<Row, Metric<
     @Override
     public Observable<Metric<T>> call(Observable<Row> rows) {
         return rows.map(row -> {
-            MetricId<T> metricId = new MetricId<>(tenantId, type, row.getString(1));
+            MetricId<T> metricId = new MetricId<>(tenantId, type, row.getString(2));
             return new Metric<>(metricId, defaultDataRetention);
         });
     }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricFromFullDataRowTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricFromFullDataRowTransformer.java
@@ -43,8 +43,8 @@ public class MetricFromFullDataRowTransformer implements Transformer<Row, Metric
     @Override
     public Observable<Metric<?>> call(Observable<Row> rows) {
         return rows.map(row -> {
-            MetricId<?> metricId = new MetricId<>(row.getString(0), MetricType.fromCode(row.getByte(2)),
-                    row.getString(1));
+            MetricId<?> metricId = new MetricId<>(row.getString(0), MetricType.fromCode(row.getByte(1)),
+                    row.getString(2));
             return new Metric<>(metricId, defaultDataRetention);
         });
     }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/compress/CompressorHeaderTest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/compress/CompressorHeaderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.compress;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.EnumSet;
+
+import org.hawkular.metrics.core.service.compress.CompressorHeader;
+import org.junit.Test;
+
+/**
+ * @author Michael Burman
+ */
+public class CompressorHeaderTest {
+
+    @Test
+    public void testHeader() {
+        EnumSet<CompressorHeader.GorillaSettings> settings =
+                EnumSet.of(CompressorHeader.GorillaSettings.SECOND_PRECISION);
+
+        byte gorillaHeader = CompressorHeader.getHeader(CompressorHeader.Compressor.GORILLA, settings);
+
+        assertEquals(gorillaHeader, (byte) 0x11);
+
+        CompressorHeader.Compressor compressor = CompressorHeader.getCompressor(gorillaHeader);
+        assertEquals(CompressorHeader.Compressor.GORILLA, compressor);
+
+        EnumSet<CompressorHeader.GorillaSettings> compressorSettings
+                = CompressorHeader.getSettings(compressor.getSettingsClass(), gorillaHeader);
+
+        assertEquals(1, compressorSettings.size());
+        assertTrue(compressorSettings.contains(CompressorHeader.GorillaSettings.SECOND_PRECISION));
+    }
+}

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/compress/TagsMapSerializingTest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/compress/TagsMapSerializingTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.compress;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import org.hawkular.metrics.core.service.compress.TagsDeserializer;
+import org.hawkular.metrics.core.service.compress.TagsSerializer;
+import org.hawkular.metrics.datetime.DateTimeService;
+import org.joda.time.Duration;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Test that data_compressed table's tags serialization works
+ *
+ * @author Michael Burman
+ */
+public class TagsMapSerializingTest {
+
+    @Test
+    public void singleValueMapTest() {
+        long timeSlice = DateTimeService.getTimeSlice(DateTimeService.now.get().getMillis(), Duration.standardHours(2));
+
+        TagsSerializer serializer = new TagsSerializer(timeSlice);
+
+        serializer.addDataPointTags(timeSlice + 20, ImmutableMap.of("a", "b"));
+
+        ByteBuffer serializedTags = serializer.getByteBuffer();
+
+        serializedTags.flip();
+
+        TagsDeserializer deserializer = new TagsDeserializer(timeSlice);
+        Map<Long, Map<String, String>> deTags = deserializer.deserialize(serializedTags);
+
+        Long key = Long.valueOf(timeSlice + 20);
+
+        assertEquals(1, deTags.size());
+        assertEquals(1, deTags.get(key).size());
+
+        Map<String, String> abMap = deTags.get(key);
+        assertEquals("b", abMap.get("a"));
+    }
+
+    @Test
+    public void multiValueMapTest() {
+        long timeSlice = DateTimeService.getTimeSlice(DateTimeService.now.get().getMillis(), Duration.standardHours(2));
+
+        TagsSerializer serializer = new TagsSerializer(timeSlice);
+
+        serializer.addDataPointTags(timeSlice + 20, ImmutableMap.of("a", "b", "c", "d"));
+        serializer.addDataPointTags(timeSlice + 32, ImmutableMap.of("a2", "b2", "c2", "d2", "e2", "f2"));
+
+        ByteBuffer serializedTags = serializer.getByteBuffer();
+
+        serializedTags.flip();
+
+        TagsDeserializer deserializer = new TagsDeserializer(timeSlice);
+        Map<Long, Map<String, String>> deTags = deserializer.deserialize(serializedTags);
+
+        Long key = Long.valueOf(timeSlice + 20);
+        Long key2 = Long.valueOf(timeSlice + 32);
+
+        assertEquals(2, deTags.size());
+        assertEquals(3, deTags.get(key2).size());
+
+        Map<String, String> abMap = deTags.get(key);
+        assertEquals("b", abMap.get("a"));
+        assertEquals("d", abMap.get("c"));
+    }
+}

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/CompressDataJobITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/CompressDataJobITest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.jobs;
+
+import static java.util.Arrays.asList;
+
+import static org.hawkular.metrics.model.MetricType.AVAILABILITY;
+import static org.hawkular.metrics.model.MetricType.COUNTER;
+import static org.hawkular.metrics.model.MetricType.GAUGE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hawkular.metrics.core.service.BaseITest;
+import org.hawkular.metrics.core.service.DataAccess;
+import org.hawkular.metrics.core.service.DataAccessImpl;
+import org.hawkular.metrics.core.service.MetricsServiceImpl;
+import org.hawkular.metrics.core.service.Order;
+import org.hawkular.metrics.core.service.transformers.DataPointDecompressTransformer;
+import org.hawkular.metrics.datetime.DateTimeService;
+import org.hawkular.metrics.model.AvailabilityType;
+import org.hawkular.metrics.model.DataPoint;
+import org.hawkular.metrics.model.Metric;
+import org.hawkular.metrics.model.MetricId;
+import org.hawkular.metrics.model.MetricType;
+import org.hawkular.metrics.model.Tenant;
+import org.hawkular.metrics.scheduler.api.JobDetails;
+import org.hawkular.metrics.scheduler.impl.TestScheduler;
+import org.hawkular.metrics.sysconfig.ConfigurationService;
+import org.jboss.logging.Logger;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.MetricRegistry;
+import com.datastax.driver.core.Row;
+import com.google.common.collect.ImmutableMap;
+
+import rx.Observable;
+import rx.observers.TestSubscriber;
+
+/**
+ * Test the compression ETL jobs
+ *
+ * @author Michael Burman
+ */
+public class CompressDataJobITest extends BaseITest {
+
+    private static Logger logger = Logger.getLogger(CompressDataJobITest.class);
+
+    private static AtomicInteger tenantCounter = new AtomicInteger();
+    private MetricsServiceImpl metricsService;
+    private DataAccess dataAccess;
+    private JobsServiceImpl jobsService;
+    private ConfigurationService configurationService;
+    private TestScheduler jobScheduler;
+
+    @BeforeClass
+    public void initClass() {
+        dataAccess = new DataAccessImpl(session);
+
+        configurationService = new ConfigurationService() ;
+        configurationService.init(rxSession);
+
+        metricsService = new MetricsServiceImpl();
+        metricsService.setDataAccess(dataAccess);
+        metricsService.setConfigurationService(configurationService);
+        metricsService.startUp(session, getKeyspace(), true, new MetricRegistry());
+    }
+
+    @BeforeMethod
+    public void initTest(Method method) {
+        logger.debug("Starting [" + method.getName() + "]");
+
+        jobScheduler = new TestScheduler(rxSession);
+        long nextStart = LocalDateTime.now(ZoneOffset.UTC)
+                .with(DateTimeService.startOfNextOddHour())
+                .toInstant(ZoneOffset.UTC).toEpochMilli() - 60000;
+        jobScheduler.advanceTimeTo(nextStart);
+        jobScheduler.truncateTables(getKeyspace());
+
+        jobsService = new JobsServiceImpl();
+        jobsService.setSession(rxSession);
+        jobsService.setScheduler(jobScheduler);
+        jobsService.setMetricsService(metricsService);
+        jobsService.setConfigurationService(configurationService);
+        jobsService.start();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        jobsService.shutdown();
+    }
+
+    @Test
+    public void testCompressJob() throws Exception {
+        long now = jobScheduler.now();
+
+        DateTime start = DateTimeService.getTimeSlice(new DateTime(now, DateTimeZone.UTC).minusHours(2),
+                Duration.standardHours(2)).plusMinutes(30);
+        DateTime end = start.plusMinutes(20);
+        String tenantId = nextTenantId() + now;
+
+        MetricId<Double> mId = new MetricId<>(tenantId, GAUGE, "m1");
+
+        doAction(() -> metricsService.createTenant(new Tenant(tenantId), false));
+
+        Metric<Double> m1 = new Metric<>(mId, asList(
+                new DataPoint<>(start.getMillis(), 1.1),
+                new DataPoint<>(start.plusMinutes(2).getMillis(), 2.2),
+                new DataPoint<>(start.plusMinutes(4).getMillis(), 3.3),
+                new DataPoint<>(end.getMillis(), 4.4)));
+
+        doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m1)));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        jobScheduler.onJobFinished(jobDetails -> {
+            latch.countDown();
+        });
+
+        for (JobDetails jobDetails : jobsService.getJobDetails().toBlocking().toIterable()) {
+            if(CompressData.JOB_NAME.equals(jobDetails.getJobName())) {
+                jobScheduler.advanceTimeTo(jobDetails.getTrigger().getTriggerTime());
+                jobScheduler.advanceTimeBy(1);
+                break;
+            }
+        }
+
+        assertTrue(latch.await(25, TimeUnit.SECONDS));
+        long startSlice = DateTimeService.getTimeSlice(start.getMillis(), Duration.standardHours(2));
+        long endSlice = DateTimeService.getTimeSlice(DateTime.now().getMillis(), Duration.standardHours(2));
+
+        Observable<Row> compressedRows = dataAccess.findCompressedData(mId, startSlice, endSlice, 0, Order.ASC);
+
+        TestSubscriber<Row> testSubscriber = new TestSubscriber<>();
+        compressedRows.subscribe(testSubscriber);
+
+        testSubscriber.awaitTerminalEvent(5, TimeUnit.SECONDS);
+
+        testSubscriber.assertNoErrors();
+        List<Row> rows = testSubscriber.getOnNextEvents();
+        assertEquals(1, rows.size());
+        ByteBuffer c_value = rows.get(0).getBytes("c_value");
+        ByteBuffer tags = rows.get(0).getBytes("tags");
+
+        assertNotNull(c_value);
+        assertNull(tags);
+        testSubscriber.assertCompleted();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> void testCompressResults(MetricType<T> type, Metric<T> metric, DateTime start) throws
+            Exception {
+        doAction(() -> metricsService.addDataPoints(type, Observable.just(metric)));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        jobScheduler.onJobFinished(jobDetails -> {
+            latch.countDown();
+        });
+
+        for (JobDetails jobDetails : jobsService.getJobDetails().toBlocking().toIterable()) {
+            if(CompressData.JOB_NAME.equals(jobDetails.getJobName())) {
+                jobScheduler.advanceTimeTo(jobDetails.getTrigger().getTriggerTime());
+                break;
+            }
+        }
+
+        assertTrue(latch.await(25, TimeUnit.SECONDS));
+        long startSlice = DateTimeService.getTimeSlice(start.getMillis(), Duration.standardHours(2));
+        long endSlice = DateTimeService.getTimeSlice(DateTime.now().getMillis(), Duration.standardHours(2));
+
+        DataPointDecompressTransformer decompressor = new DataPointDecompressTransformer(type, Order.ASC, 0, start
+                .getMillis(), start.plusMinutes(30).getMillis());
+
+        Observable<DataPoint<T>> dataPoints = dataAccess.findCompressedData(metric.getMetricId(), startSlice, endSlice,
+                0, Order.ASC).compose(decompressor);
+
+        TestSubscriber<DataPoint<T>> pointTestSubscriber = new TestSubscriber<>();
+        dataPoints.subscribe(pointTestSubscriber);
+        pointTestSubscriber.awaitTerminalEvent(3, TimeUnit.SECONDS);
+        pointTestSubscriber.assertCompleted();
+        List<DataPoint<T>> compressedPoints = pointTestSubscriber.getOnNextEvents();
+
+        assertEquals(metric.getDataPoints(), compressedPoints);
+    }
+
+    @Test
+    public void testGaugeCompress() throws Exception {
+        long now = jobScheduler.now();
+
+        System.out.println(new DateTime(now).toString());
+
+        DateTime start = DateTimeService.getTimeSlice(new DateTime(now, DateTimeZone.UTC).minusHours(2),
+                Duration.standardHours(2)).plusMinutes(30);
+
+        DateTime end = start.plusMinutes(20);
+        String tenantId = nextTenantId() + now;
+
+        MetricId<Double> mId = new MetricId<>(tenantId, GAUGE, "m1");
+
+        doAction(() -> metricsService.createTenant(new Tenant(tenantId), false));
+
+        Metric<Double> m1 = new Metric<>(mId, asList(
+                new DataPoint<>(start.getMillis(), 1.1),
+                new DataPoint<>(start.plusMinutes(2).getMillis(), 2.2),
+                new DataPoint<>(start.plusMinutes(4).getMillis(), 3.3),
+                new DataPoint<>(end.getMillis(), 4.4)));
+
+        testCompressResults(GAUGE, m1, start);
+    }
+
+    @Test
+    public void testCounterCompress() throws Exception {
+        long now = jobScheduler.now();
+
+        DateTime start = DateTimeService.getTimeSlice(new DateTime(now, DateTimeZone.UTC).minusHours(2),
+                Duration.standardHours(2)).plusMinutes(30);
+        DateTime end = start.plusMinutes(20);
+        String tenantId = nextTenantId() + now;
+
+        MetricId<Long> mId = new MetricId<>(tenantId, COUNTER, "m2");
+
+        doAction(() -> metricsService.createTenant(new Tenant(tenantId), false));
+
+        Metric<Long> m1 = new Metric<>(mId, asList(
+                new DataPoint<>(start.getMillis(), 1L),
+                new DataPoint<>(start.plusMinutes(2).getMillis(), 2L),
+                new DataPoint<>(start.plusMinutes(4).getMillis(), 3L),
+                new DataPoint<>(end.getMillis(), 4L)));
+
+        testCompressResults(COUNTER, m1, start);
+    }
+
+    @Test
+    public void testAvailabilityCompress() throws Exception {
+        long now = jobScheduler.now();
+
+        DateTime start = DateTimeService.getTimeSlice(new DateTime(now, DateTimeZone.UTC).minusHours(2),
+                Duration.standardHours(2)).plusMinutes(30);
+        DateTime end = start.plusMinutes(20);
+        String tenantId = nextTenantId() + now;
+
+        MetricId<AvailabilityType> mId = new MetricId<>(tenantId, AVAILABILITY, "m3");
+
+        doAction(() -> metricsService.createTenant(new Tenant(tenantId), false));
+
+        Metric<AvailabilityType> m1 = new Metric<>(mId, asList(
+                new DataPoint<>(start.getMillis(), AvailabilityType.UP),
+                new DataPoint<>(start.plusMinutes(2).getMillis(), AvailabilityType.DOWN),
+                new DataPoint<>(start.plusMinutes(4).getMillis(), AvailabilityType.DOWN),
+                new DataPoint<>(end.getMillis(), AvailabilityType.UP)));
+
+        testCompressResults(AVAILABILITY, m1, start);
+    }
+
+    @Test
+    public void testGaugeWithTags() throws Exception {
+        long now = jobScheduler.now();
+
+        System.out.println(new DateTime(now).toString());
+
+        DateTime start = DateTimeService.getTimeSlice(new DateTime(now, DateTimeZone.UTC).minusHours(2),
+                Duration.standardHours(2)).plusMinutes(30);
+
+        DateTime end = start.plusMinutes(20);
+        String tenantId = nextTenantId() + now;
+
+        MetricId<Double> mId = new MetricId<>(tenantId, GAUGE, "m1");
+
+        doAction(() -> metricsService.createTenant(new Tenant(tenantId), false));
+
+        Metric<Double> m1 = new Metric<>(mId, asList(
+                new DataPoint<>(start.getMillis(), 1.1, ImmutableMap.of("a", "b")),
+                new DataPoint<>(start.plusMinutes(2).getMillis(), 2.2),
+                new DataPoint<>(start.plusMinutes(4).getMillis(), 3.3, ImmutableMap.of("d", "e")),
+                new DataPoint<>(end.getMillis(), 4.4)));
+
+        testCompressResults(GAUGE, m1, start);
+    }
+
+    private String nextTenantId() {
+        return "T" + tenantCounter.getAndIncrement();
+    }
+}

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/DeleteTenantITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/DeleteTenantITest.java
@@ -114,6 +114,7 @@ public class DeleteTenantITest extends BaseITest {
         jobsService.setSession(rxSession);
         jobsService.setScheduler(jobScheduler);
         jobsService.setMetricsService(metricsService);
+        jobsService.setConfigurationService(configurationService);
 
         jobName = method.getName();
         jobsService.start();

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -20,6 +20,7 @@ package org.hawkular.metrics.core.service;
 import java.util.Map;
 import java.util.Set;
 
+import org.hawkular.metrics.core.service.compress.CompressedPointContainer;
 import org.hawkular.metrics.model.AvailabilityType;
 import org.hawkular.metrics.model.Interval;
 import org.hawkular.metrics.model.Metric;
@@ -126,8 +127,13 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
+    public Observable<Row> findCompressedData(MetricId<?> id, long startTime, long endTime, int limit, Order order) {
+        return delegate.findCompressedData(id, startTime, endTime, limit, order);
+    }
+
+    @Override
     public Observable<Row> findGaugeData(MetricId<Double> id, long startTime, long endTime, int limit, Order order) {
-        return delegate.findGaugeData(id, startTime, endTime, 0, order);
+        return delegate.findGaugeData(id, startTime, endTime, limit, order);
     }
 
     @Override
@@ -210,5 +216,12 @@ public class DelegatingDataAccess implements DataAccess {
     @Override
     public Observable<Row> findAvailabilityData(MetricId<AvailabilityType> id, long timestamp) {
         return delegate.findAvailabilityData(id, timestamp);
+    }
+
+    @Override
+    public <T> Observable<ResultSet> deleteAndInsertCompressedGauge(MetricId<T> id, long timeslice,
+                                                                    CompressedPointContainer cpc,
+                                                              long sliceStart, long sliceEnd, int ttl) {
+        return delegate.deleteAndInsertCompressedGauge(id, timeslice, cpc, sliceStart, sliceEnd, ttl);
     }
 }

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/AvailabilityType.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/AvailabilityType.java
@@ -75,4 +75,19 @@ public enum AvailabilityType {
         default: throw new IllegalArgumentException(bytes.array()[0] + " is not a recognized availability type");
         }
     }
+
+    public static AvailabilityType fromByte(byte value) {
+        switch (value) {
+            case 0:
+                return UP;
+            case 1:
+                return DOWN;
+            case 2:
+                return UNKNOWN;
+            case 3:
+                return ADMIN;
+            default:
+                throw new IllegalArgumentException(value + " is not a recognized availability type");
+        }
+    }
 }

--- a/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
+++ b/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
@@ -55,7 +55,7 @@ public class SchemaService {
         // For now, I am just hard coding the version tag, but a more robust solution would be
         // to calculate the tags using the current version stored in the sys_config table
         // and the new version which we can extract from any of our JAR manifest files.
-        List<String> tags = asList("0.15.x", "0.18.x", "0.19.x");
+        List<String> tags = asList("0.15.x", "0.18.x", "0.19.x", "0.20.x");
         URI script = getScript();
         cassalog.execute(script, tags, vars);
 

--- a/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.20.0.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.20.0.groovy
@@ -1,4 +1,3 @@
-package org.hawkular.schema
 /*
  * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
@@ -16,11 +15,32 @@ package org.hawkular.schema
  * limitations under the License.
  */
 
-include '/org/hawkular/schema/bootstrap.groovy'
-
 setKeyspace keyspace
 
-include '/org/hawkular/schema/updates/schema-0.15.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.18.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.19.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.20.0.groovy'
+schemaChange {
+  version '4.0'
+  author 'burmanm'
+  tags '0.20.x'
+  cql """
+CREATE TABLE data_compressed (
+    tenant_id text,
+    type tinyint,
+    metric text,
+    dpart bigint,
+    time timestamp,
+    c_value blob,
+    ts_value blob,
+    tags blob,
+    PRIMARY KEY ((tenant_id, type, metric, dpart), time)
+) WITH CLUSTERING ORDER BY (time DESC)
+"""
+}
+
+schemaChange {
+  version '4.1'
+  author 'burmanm'
+  tags '0.20.x'
+  cql """
+ALTER TABLE data WITH COMPRESSION = {'sstable_compression': 'LZ4Compressor'};
+"""
+}

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -31,7 +31,7 @@ import org.junit.BeforeClass
 import java.util.concurrent.atomic.AtomicInteger
 
 import static junit.framework.Assert.assertNull
-import static org.hawkular.metrics.core.service.transformers.BatchStatementTransformer.MAX_BATCH_SIZE
+import static org.hawkular.metrics.core.service.transformers.BatchStatementTransformer.DEFAULT_BATCH_SIZE
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
@@ -42,7 +42,7 @@ class RESTTest {
   static final double DELTA = 0.001
   static final String TENANT_PREFIX = UUID.randomUUID().toString()
   static final AtomicInteger TENANT_ID_COUNTER = new AtomicInteger(0)
-  static final int LARGE_PAYLOAD_SIZE = MAX_BATCH_SIZE
+  static final int LARGE_PAYLOAD_SIZE = DEFAULT_BATCH_SIZE
   static ObjectMapper objectMapper = new ObjectMapper()
   static RESTClient hawkularMetrics
 

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/Scheduler.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/Scheduler.java
@@ -19,6 +19,7 @@ package org.hawkular.metrics.scheduler.api;
 import java.util.Map;
 
 import rx.Completable;
+import rx.Observable;
 import rx.Single;
 import rx.functions.Func1;
 import rx.functions.Func2;
@@ -71,4 +72,5 @@ public interface Scheduler {
      */
     void shutdown();
 
+    Observable<JobDetails> getAllJobs();
 }

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/TestScheduler.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/TestScheduler.java
@@ -150,6 +150,11 @@ public class TestScheduler implements Scheduler {
         scheduler.shutdown();
     }
 
+    @Override
+    public Observable<JobDetails> getAllJobs() {
+        return scheduler.getAllJobs();
+    }
+
     public void onTimeSliceFinished(Action1<DateTime> callback) {
         finishedTimeSlicesSubscriptions.add(finishedTimeSlices.subscribe(timeSlice ->
                 callback.call(new DateTime(timeSlice))));

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
     <version.org.codehaus.mojo.dashboard-maven-plugin>1.0.0-beta-1</version.org.codehaus.mojo.dashboard-maven-plugin>
     <version.org.jmxtrans.embedded.embedded-jmxtrans>1.0.15</version.org.jmxtrans.embedded.embedded-jmxtrans>
     <version.com.squareup.okhttp>2.0.0</version.com.squareup.okhttp>
+    <version.fi.iki.yak.compression-gorilla>1.1.0</version.fi.iki.yak.compression-gorilla>
   </properties>
 
   <dependencyManagement>
@@ -211,6 +212,11 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${version.com.google.guava}</version>
+      </dependency>
+      <dependency>
+        <groupId>fi.iki.yak</groupId>
+        <artifactId>compression-gorilla</artifactId>
+        <version>${version.fi.iki.yak.compression-gorilla}</version>
       </dependency>
       <!-- Other -->
       <dependency>


### PR DESCRIPTION
Adds ETL based compression methods in the core for Gauge data (for now, I will later in the PR add support for counters & availabilities also).

After this PR is merged, I recommend replacing Deflate with LZ4 again (since we need speed due to the ETL processing)

This PR for now is missing the job scheduler stuff, that is coming later to this same PR.