### PR TITLE
[HWKMETRICS-461] Fix the regexp split

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -177,9 +177,8 @@ public class MetricHandler {
             @ApiParam(value = "Queried metric type", required = false, allowableValues = "gauge, availability, counter")
             @QueryParam("type") MetricType<T> metricType,
             @ApiParam(value = "List of tags filters", required = false) @QueryParam("tags") Tags tags,
-            @ApiParam(value = "Regexp to match metricId, requires tags filtering", required = false) @QueryParam("id")
-            String id
-    ) {
+            @ApiParam(value = "Regexp to match metricId if tags filtering is used, otherwise exact matching",
+                    required = false) @QueryParam("id") String id) {
         if (metricType != null && !metricType.isUserType()) {
             asyncResponse.resume(badRequest(new ApiError("Incorrect type param " + metricType.toString())));
             return;
@@ -190,7 +189,7 @@ public class MetricHandler {
         if(tags == null) {
             if(!Strings.isNullOrEmpty(id)) {
                 // HWKMETRICS-461
-                String[] ids = id.split("|");
+                String[] ids = id.split("\\|");
                 metricObservable = Observable.from(ids)
                         .map(idPart -> new MetricId(getTenant(), metricType, idPart))
                         .flatMap(mId -> (Observable<Metric<T>>) metricsService.findMetric(mId));

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -399,7 +399,14 @@ class TagsITest extends RESTTest {
       ], headers: [(tenantHeaderName): tenantId])
       assertEquals(201, response.status)
 
-      response = hawkularMetrics.get(path: it.path,
+      response = hawkularMetrics.post(path: it.path, body: [
+          id  : '91c171ed-0294-44b3-bcdb-42253b58aa5a',
+          tags: ['c1': 'C'],
+          dataRetention: 7
+      ], headers: [(tenantHeaderName): tenantId])
+      assertEquals(201, response.status)
+
+      response = hawkularMetrics.get(path: 'metrics',
           query: [id: 'N1|N2', type: it.type],
           headers: [(tenantHeaderName): tenantId])
 
@@ -422,6 +429,30 @@ class TagsITest extends RESTTest {
             type: it.type
         ]))
       }
+
+      // Create metric with uuid, detect issue with regexp |
+      response = hawkularMetrics.get(path: 'metrics',
+          query: [id: '91c171ed-0294-44b3-bcdb-42253b58aa5a', type: it.type],
+          headers: [(tenantHeaderName): tenantId])
+
+        assertEquals(response.data, [[
+            dataRetention: 7,
+            tenantId: tenantId,
+            id      : '91c171ed-0294-44b3-bcdb-42253b58aa5a',
+            tags    : ['c1': 'C'],
+            type: it.type
+        ]])
+
+        assertEquals(200, response.status)
+        assertTrue(response.data instanceof List)
+        assertEquals(1, response.data.size())
+        assertTrue((response.data ?: []).contains([
+            dataRetention: 7,
+            tenantId: tenantId,
+            id      : '91c171ed-0294-44b3-bcdb-42253b58aa5a',
+            tags    : ['c1': 'C'],
+            type: it.type
+        ]))
     }
   }
 }


### PR DESCRIPTION
The regexp was missing double quotation for the regexp character "|", that's why it returned incorrect information. Also the tests used the wrong endpoint and just happened to work.