### PR TITLE
[HWKMETRICS-466] Add query by tags capability to /query endpoints

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/QueryRequest.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/QueryRequest.java
@@ -33,6 +33,8 @@ public class QueryRequest {
 
     private String order;
 
+    private String tags;
+
     public List<String> getIds() {
         return ids;
     }
@@ -73,6 +75,14 @@ public class QueryRequest {
         this.order = order;
     }
 
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+
     @Override public String toString() {
         return "QueryRequest{" +
                 "ids=" + ids +
@@ -80,6 +90,7 @@ public class QueryRequest {
                 ", end=" + end +
                 ", limit=" + limit +
                 ", order=" + order +
+                ", tags=" + tags +
                 '}';
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -301,8 +301,8 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
     })
     public void getData(
             @Suspended AsyncResponse asyncResponse,
-            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids. " +
-                    "The standard start, end, order, and limit query parameters are supported as well.")
+            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
+                    "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
         findRawDataPointsForMetrics(asyncResponse, query, AVAILABILITY);
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -271,8 +271,8 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
     })
     public void getData(
             @Suspended AsyncResponse asyncResponse,
-            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids. " +
-                    "The standard start, end, order, and limit query parameters are supported as well.")
+            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
+                    "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
         findRawDataPointsForMetrics(asyncResponse, query, COUNTER);
     }
@@ -290,8 +290,8 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
     })
     public void getRateData(
             @Suspended AsyncResponse asyncResponse,
-            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids. " +
-                    "The standard start, end, order, and limit query parameters are supported as well.")
+            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
+                    "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
         findRateDataPointsForMetrics(asyncResponse, query, COUNTER);
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -304,8 +304,8 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
     })
     public void getData(
             @Suspended AsyncResponse asyncResponse,
-            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids. " +
-                    "The standard start, end, order, and limit query parameters are supported as well.")
+            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
+                    "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
         findRawDataPointsForMetrics(asyncResponse, query, GAUGE);
     }
@@ -323,8 +323,8 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
     })
     public void getRateData(
             @Suspended AsyncResponse asyncResponse,
-            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids. " +
-                    "The standard start, end, order, and limit query parameters are supported as well.")
+            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
+                    "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
         findRateDataPointsForMetrics(asyncResponse, query, GAUGE);
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
@@ -270,8 +270,8 @@ public class StringHandler extends MetricsServiceHandler implements IMetricsHand
     })
     public void getData(
             @Suspended AsyncResponse asyncResponse,
-            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids. " +
-                    "The standard start, end, order, and limit query parameters are supported as well.")
+            @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
+                    "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
         findRawDataPointsForMetrics(asyncResponse, query, STRING);
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagsConverter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TagsConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +43,17 @@ public class TagsConverter implements ParamConverter<Tags> {
 
     @Override
     public Tags fromString(String value) {
+        return convert(value);
+    }
+
+    public static Tags fromNullable(String value) {
+        if (value == null) {
+            return new Tags(Collections.emptyMap());
+        }
+        return convert(value);
+    }
+
+    private static Tags convert(String value) {
         if (value.isEmpty()) {
             return new Tags(Collections.emptyMap());
         }
@@ -74,7 +85,7 @@ public class TagsConverter implements ParamConverter<Tags> {
         return new Tags(tags);
     }
 
-    private boolean hasExpectedForm(String token, int colonIndex) {
+    private static boolean hasExpectedForm(String token, int colonIndex) {
         return colonIndex > 0 && colonIndex < token.length();
     }
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -167,6 +167,22 @@ public interface MetricsService {
             Order order);
 
     /**
+     * Fetch data points for multiple metrics searched by tag.
+     *
+     * @param tenantId The id of the tenant to which the metrics belong
+     * @param metricType The type of the metrics
+     * @param tagFilters The metric tag filter used to query for metrics
+     * @param start      start time inclusive as a Unix timestamp in milliseconds
+     * @param end        end time exclusive as a Unix timestamp in milliseconds
+     * @param limit      limit the number of data points
+     * @param order      the sort order for the results
+     *
+     * @return an {@link Observable} that emits {@link NamedDataPoint named data points}
+     */
+    <T> Observable<NamedDataPoint<T>> findDataPoints(String tenantId, MetricType<T> metricType,
+         Map<String, String> tagFilters, long start, long end, int limit, Order order);
+
+    /**
      * This method applies one or more functions to an Observable that emits data points of a gauge metric. The data
      * points Observable is asynchronous. The functions however, are applied serially in the order specified.
      *
@@ -290,6 +306,22 @@ public interface MetricsService {
 
     Observable<NamedDataPoint<Double>> findRateData(List<MetricId<? extends Number>> ids, long start, long end,
             int limit, Order order);
+
+    /**
+     * Fetches gauge or counter data points for multiple metrics searched by tag and calculates per-minute rates.
+     *
+     * @param tenantId The id of the tenant to which the metrics belong
+     * @param metricType The type of the metrics
+     * @param tagFilters The metric tag filter used to query for metrics
+     * @param start      start time inclusive as a Unix timestamp in milliseconds
+     * @param end        end time exclusive as a Unix timestamp in milliseconds
+     * @param limit      limit the number of data points
+     * @param order      the sort order for the results
+     *
+     * @return an {@link Observable} that emits {@link NamedDataPoint named data points}
+     */
+    Observable<NamedDataPoint<Double>> findRateData(String tenantId, MetricType<? extends Number> metricType,
+            Map<String, String> tagFilters, long start, long end, int limit, Order order);
 
     /**
      * Computes stats on a counter or gauge rate.

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -723,6 +723,15 @@ public class MetricsServiceImpl implements MetricsService {
                         .map(dataPoint -> new NamedDataPoint<>(id.getName(), dataPoint)));
     }
 
+    @Override
+    public <T> Observable<NamedDataPoint<T>> findDataPoints(String tenantId, MetricType<T> metricType,
+            Map<String, String> tagFilters, long start, long end, int limit, Order order) {
+        return findMetricsWithFilters(tenantId, metricType, tagFilters)
+                .map(Metric::getMetricId)
+                .concatMap(id -> findDataPoints(id, start, end, limit, order)
+                        .map(dataPoint -> new NamedDataPoint<>(id.getName(), dataPoint)));
+    }
+
     private <T> Timer getDataPointFindTimer(MetricType<T> metricType) {
         Timer timer = dataPointReadTimers.get(metricType);
         if (timer == null) {
@@ -780,10 +789,20 @@ public class MetricsServiceImpl implements MetricsService {
         return limit <= 0 ? dataPoints : dataPoints.take(limit);
     }
 
+    @Override
     public Observable<NamedDataPoint<Double>> findRateData(List<MetricId<? extends Number>> ids, long start,
-            long end, int limit, Order order) {
+                                                                     long end, int limit, Order order) {
         return Observable.from(ids).concatMap(id -> findRateData(id, start, end, limit, order)
                 .map(dataPoint -> new NamedDataPoint<>(id.getName(), dataPoint)));
+    }
+
+    @Override
+    public Observable<NamedDataPoint<Double>> findRateData(String tenantId, MetricType<? extends Number> metricType,
+            Map<String, String> tagFilters, long start, long end, int limit, Order order) {
+        return findMetricsWithFilters(tenantId, metricType, tagFilters)
+                .map(Metric::getMetricId)
+                .concatMap(id -> findRateData(id, start, end, limit, order)
+                        .map(dataPoint -> new NamedDataPoint<>(id.getName(), dataPoint)));
     }
 
     @Override

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -2010,4 +2010,100 @@ Actual:   ${response.data}
     }
   }
 
+  @Test
+  void fetchMRawDataFromMultipleCountersByTag() {
+    String tenantId = nextTenantId()
+    DateTime start = now().minusHours(4)
+
+    // Define tags
+    def response = hawkularMetrics.post(path: 'counters', body: [id: 'A1', tags: [letter: 'A', number: '1']],
+            headers: [(tenantHeaderName): tenantId])
+    assertEquals(201, response.status)
+    response = hawkularMetrics.post(path: 'counters', body: [id: 'A2', tags: [letter: 'A', number: '2']],
+            headers: [(tenantHeaderName): tenantId])
+    assertEquals(201, response.status)
+
+    response = hawkularMetrics.post(
+            path: "counters/raw",
+            headers: [(tenantHeaderName): tenantId],
+            body: [
+                    [
+                            id: 'A1',
+                            data: [
+                                    [timestamp: start.millis, value: 10],
+                                    [timestamp: start.plusHours(1).millis, value: 20],
+                                    [timestamp: start.plusHours(2).millis, value: 30],
+                                    [timestamp: start.plusHours(3).millis, value: 20],
+                                    [timestamp: start.plusHours(4).millis, value: 10]
+                            ]
+                    ],
+                    [
+                            id: 'A2',
+                            data: [
+                                    [timestamp: start.millis, value: 1],
+                                    [timestamp: start.plusHours(1).millis, value: 0],
+                                    [timestamp: start.plusHours(2).millis, value: 1],
+                                    [timestamp: start.plusHours(3).millis, value: 0],
+                                    [timestamp: start.plusHours(4).millis, value: 1]
+                            ]
+                    ]
+            ]
+    )
+    assertEquals(200, response.status)
+
+    response = hawkularMetrics.post(
+            path: "counters/raw/query",
+            headers: [(tenantHeaderName): tenantId],
+            body: [
+                    tags: "letter:A",
+                    start: start.plusHours(1).millis,
+                    end: start.plusHours(4).millis,
+                    limit: 2,
+                    order: 'desc'
+            ]
+    )
+
+    assertEquals(200, response.status)
+    assertEquals(2, response.data.size)
+
+    assertTrue(response.data.contains([
+            id: 'A1',
+            data: [
+                    [timestamp: start.plusHours(3).millis, value: 20],
+                    [timestamp: start.plusHours(2).millis, value: 30]
+            ]
+    ]))
+
+    assertTrue(response.data.contains([
+            id: 'A2',
+            data: [
+                    [timestamp: start.plusHours(3).millis, value: 0],
+                    [timestamp: start.plusHours(2).millis, value: 1]
+            ]
+    ]))
+
+    response = hawkularMetrics.post(
+            path: "counters/raw/query",
+            headers: [(tenantHeaderName): tenantId],
+            body: [
+                    tags: "letter:A,number:1",
+                    start: start.plusHours(1).millis,
+                    end: start.plusHours(4).millis,
+                    limit: 2,
+                    order: 'desc'
+            ]
+    )
+
+    assertEquals(200, response.status)
+    assertEquals(1, response.data.size)
+
+    assertTrue(response.data.contains([
+            id: 'A1',
+            data: [
+                    [timestamp: start.plusHours(3).millis, value: 20],
+                    [timestamp: start.plusHours(2).millis, value: 30]
+            ]
+    ]))
+  }
+
 }


### PR DESCRIPTION
Following discussion "[Hawkular-dev] metrics: REST API evolution when querying for multiple metrics" on the mailing list
See also https://issues.jboss.org/browse/HWKMETRICS-466
