### PR TITLE
[HWKMETRICS-477] reschedule job for immediate execution if it falls behind

### DIFF
--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/SchedulerImpl.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/SchedulerImpl.java
@@ -183,7 +183,7 @@ public class SchedulerImpl implements Scheduler {
 
     // TODO make configurable
     private int getQueryThreadPoolSize() {
-        return Math.min(Runtime.getRuntime().availableProcessors() / 2, 1);
+        return Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);
     }
 
     /**

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/SchedulerImpl.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/SchedulerImpl.java
@@ -18,6 +18,7 @@ package org.hawkular.metrics.scheduler.impl;
 
 import static org.hawkular.metrics.datetime.DateTimeService.currentMinute;
 import static org.hawkular.metrics.datetime.DateTimeService.getTimeSlice;
+import static org.hawkular.metrics.datetime.DateTimeService.now;
 import static org.joda.time.Minutes.minutes;
 
 import java.util.Date;
@@ -37,6 +38,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.hawkular.metrics.scheduler.api.JobDetails;
@@ -64,6 +66,7 @@ import rx.functions.Func1;
 import rx.functions.Func2;
 import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
+import rx.subscriptions.BooleanSubscription;
 
 /**
  * @author jsanda
@@ -118,6 +121,18 @@ public class SchedulerImpl implements Scheduler {
 
     static final String QUEUE_LOCK_PREFIX = "org.hawkular.metrics.scheduler.queue.";
 
+    static final String SCHEDULING_LOCK = "scheduling";
+
+    static final String TIME_SLICE_EXECUTION_LOCK = "executing";
+
+    static final String JOB_EXECUTION_LOCK = "locked";
+
+    // TODO We probably want this to be configurable
+    static final int SCHEDULING_LOCK_TIMEOUT_IN_SEC = 5;
+
+    // TODO We probably want this to be configurable
+    static final int JOB_EXECUTION_LOCK_TIMEOUT_IN_SEC = 3600;
+
     /**
      * Test hook. See {@link #setTimeSlicesSubject(PublishSubject)}.
      */
@@ -136,8 +151,9 @@ public class SchedulerImpl implements Scheduler {
         tickScheduler = Schedulers.from(tickExecutor);
 
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("query-thread-pool-%d").build();
-        queryExecutor = new ThreadPoolExecutor(4, 4, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(),
-                threadFactory, new ThreadPoolExecutor.DiscardPolicy());
+        queryExecutor = new ThreadPoolExecutor(getQueryThreadPoolSize(), getQueryThreadPoolSize(), 0,
+                TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), threadFactory,
+                new ThreadPoolExecutor.DiscardPolicy());
         queryScheduler = Schedulers.from(queryExecutor);
 
         lockManager = new LockManager(session);
@@ -163,6 +179,11 @@ public class SchedulerImpl implements Scheduler {
 
         finishedTimeSlices = Optional.empty();
         jobFinished = Optional.empty();
+    }
+
+    // TODO make configurable
+    private int getQueryThreadPoolSize() {
+        return Runtime.getRuntime().availableProcessors() / 2;
     }
 
     /**
@@ -201,11 +222,11 @@ public class SchedulerImpl implements Scheduler {
 
     @Override
     public Single<JobDetails> scheduleJob(String type, String name, Map<String, String> parameter, Trigger trigger) {
-        if (System.currentTimeMillis() >= trigger.getTriggerTime()) {
+        if (now.get().getMillis() >= trigger.getTriggerTime()) {
             return Single.error(new RuntimeException("Trigger time has already passed"));
         }
         String lockName = QUEUE_LOCK_PREFIX + trigger.getTriggerTime();
-        return lockManager.acquireLock(lockName, "scheduling", 5)
+        return lockManager.acquireLock(lockName, SCHEDULING_LOCK, SCHEDULING_LOCK_TIMEOUT_IN_SEC)
                 .map(acquired -> {
                     if (acquired) {
                         UUID jobId = UUID.randomUUID();
@@ -286,7 +307,7 @@ public class SchedulerImpl implements Scheduler {
         String lockName = QUEUE_LOCK_PREFIX + timeSlice.getTime();
         int delay = 5;
         Observable<TimeSliceLock> observable = Observable.create(subscriber -> {
-            lockManager.acquireLock(lockName, "executing", 3600)
+            lockManager.acquireLock(lockName, TIME_SLICE_EXECUTION_LOCK, JOB_EXECUTION_LOCK_TIMEOUT_IN_SEC)
                     .map(acquired -> {
                         if (!acquired) {
                             logger.debug("Failed to acquire time slice lock for ["  + timeSlice + "]. Will attempt " +
@@ -307,14 +328,14 @@ public class SchedulerImpl implements Scheduler {
 
     private Observable<JobLock> acquireJobLock(UUID jobId) {
         String jobLock = "org.hawkular.metrics.scheduler.job." + jobId;
-        return lockManager.acquireLock(jobLock, "locked", 3600).map(acquired -> new JobLock(jobId, acquired));
+        return lockManager.acquireLock(jobLock, JOB_EXECUTION_LOCK, JOB_EXECUTION_LOCK_TIMEOUT_IN_SEC)
+                .map(acquired -> new JobLock(jobId, acquired));
     }
 
     private Completable doJobExecution(JobDetails details, Set<UUID> activeJobs) {
         logger.debug("Starting execution for " + details);
         Func1<JobDetails, Completable> factory = jobFactories.get(details.getJobType());
         Completable job = factory.call(details);
-        logger.debug("Preparing to execute " + details);
         Date timeSlice = new Date(details.getTrigger().getTriggerTime());
         return Completable.concat(
                 job.onErrorResumeNext(t -> {
@@ -345,14 +366,28 @@ public class SchedulerImpl implements Scheduler {
                     };
                     JobDetails newDetails = new JobDetails(details.getJobId(), details.getJobType(),
                             details.getJobName(), details.getParameters(), newTrigger);
-                    return rescheduleJob(newDetails);
+                    return rescheduleJob(newDetails, activeJobs);
                 }),
                 setJobFinished(timeSlice, details),
-                rescheduleJob(details),
-                deactivateJob(activeJobs, details),
+                rescheduleAndDeactivateJob(details, activeJobs),
                 Completable.fromAction(() ->
                         jobFinished.ifPresent(subject -> subject.onNext(details)))
         ).subscribeOn(Schedulers.io());
+    }
+
+    private Completable rescheduleAndDeactivateJob(JobDetails details, Set<UUID> activeJobs) {
+        return Completable.create(subscriber -> {
+            Completable c;
+            Trigger nextTrigger = details.getTrigger().nextTrigger();
+            if (nextTrigger == null) {
+                c = deactivateJob(activeJobs, details);
+            } else if (nextTrigger.getTriggerTime() <= now.get().getMillis()) {
+                c = rescheduleJob(details, activeJobs);
+            } else {
+                c = rescheduleJob(details, activeJobs).concatWith(deactivateJob(activeJobs, details));
+            }
+            c.subscribe(subscriber::onCompleted, subscriber::onError);
+        });
     }
 
     private Trigger getNextTrigger(Date timeSlice, Trigger trigger) {
@@ -364,13 +399,22 @@ public class SchedulerImpl implements Scheduler {
     }
 
     private Completable setJobFinished(Date timeSlice, JobDetails details) {
-        return session.execute(updateJobToFinished.bind(timeSlice, details.getJobId()), queryScheduler)
-                .doOnCompleted(() -> logger.debug("Updating " + details + " status to finished for time slice [" +
-                        timeSlice + "]"))
-                .toCompletable();
+        return Completable.create(subscriber -> {
+            session.execute(updateJobToFinished.bind(timeSlice, details.getJobId()), queryScheduler).subscribe(
+                    resultSet -> {},
+                    t -> {
+                        logger.warn("Failed to set " + details + " finished for time slice [" + timeSlice + "]");
+                        subscriber.onError(t);
+                    },
+                    () -> {
+                        logger.debug("Updating " + details + " status to finished for time slice [" + timeSlice + "]");
+                        subscriber.onCompleted();
+                    }
+            );
+        });
     }
 
-    private Completable rescheduleJob(JobDetails details) {
+    private Completable rescheduleJob(JobDetails details, Set<UUID> activeJobs) {
         Trigger nextTrigger = details.getTrigger().nextTrigger();
         if (nextTrigger == null) {
             return Completable.fromAction(() -> logger.debug("No more scheduled executions for " + details));
@@ -378,15 +422,48 @@ public class SchedulerImpl implements Scheduler {
 
         JobDetails newDetails = new JobDetails(details.getJobId(), details.getJobType(), details.getJobName(),
                 details.getParameters(), nextTrigger);
-        // TODO Make sure we do not end with an orphaned job.
-        // We need to obtain the lock here just like we do when scheduling a job. And of course, if we have already
-        // reached or passed the next execution time, we need to go ahead and just execute the job again.
+
+        if (nextTrigger.getTriggerTime() <= now.get().getMillis()) {
+            logger.info(details + " missed its next execution at " + nextTrigger.getTriggerTime() +
+                    ". It will scheduled for immediate execution.");
+            AtomicLong nextTimeSlice = new AtomicLong(currentMinute().getMillis());
+            Observable<Boolean> scheduled = Observable.defer(() ->
+                    lockManager.acquireLock(QUEUE_LOCK_PREFIX + nextTimeSlice.addAndGet(60000L), SCHEDULING_LOCK,
+                            SCHEDULING_LOCK_TIMEOUT_IN_SEC))
+                    .map(acquired -> {
+                        if (!acquired) {
+                            throw new RuntimeException();
+                        }
+                        return acquired;
+                    })
+                    .retry();
+            return Completable.concat(
+                    scheduled.toCompletable(),
+                    updateScheduledJobsIndex(nextTimeSlice.get(), details.getJobId()),
+                    insertIntoJobsTable(newDetails),
+                    scheduleImmediateJobExecution(newDetails, activeJobs));
+        }
+
         return Completable.concat(
                 Completable.fromAction(() -> logger.debug("Scheduling " + newDetails + " for next execution at " +
                         new Date(nextTrigger.getTriggerTime()))),
                 updateScheduledJobsIndex(newDetails),
                 insertIntoJobsTable(newDetails)
         );
+    }
+
+    private Completable scheduleImmediateJobExecution(JobDetails details, Set<UUID> activeJobs) {
+        rx.Scheduler.Worker worker = Schedulers.io().createWorker();
+        worker.schedule(() -> {
+            try {
+                String jobLock = "org.hawkular.metrics.scheduler.job." + details.getJobId();
+                lockManager.renewLock(jobLock, JOB_EXECUTION_LOCK, JOB_EXECUTION_LOCK_TIMEOUT_IN_SEC).toCompletable()
+                        .concatWith(doJobExecution(details, activeJobs)).await();
+            } catch (Exception e) {
+                logger.warn("Exceution of " + details + " was interrupted", e);
+            }
+        });
+        return Completable.complete();
     }
 
     private Completable deactivateJob(Set<UUID> activeJobs, JobDetails details) {
@@ -396,9 +473,29 @@ public class SchedulerImpl implements Scheduler {
             activeJobs.remove(details.getJobId());
         });
 
-        Completable releaseLock = lockManager.releaseLock(jobLock, "locked")
-                .doOnNext(released -> logger.debug("Released job lock [" + jobLock + "]? " + released))
-                .toCompletable();
+        Completable releaseLock = Completable.create(subscriber -> {
+            BooleanSubscription cancel = new BooleanSubscription();
+            subscriber.onSubscribe(cancel);
+
+            lockManager.releaseLock(jobLock, JOB_EXECUTION_LOCK).subscribe(
+                    released -> {
+                        if (!released) {
+                            logger.warn("Failed to release job lock for " + details);
+                            subscriber.onError(new RuntimeException("Failed to release job lock for " + details));
+                        }
+                    },
+                    t -> {
+                        logger.warn("Failed to release job lock for " + details, t);
+                        subscriber.onError(t);
+                    },
+                    () -> {
+                        if (!cancel.isUnsubscribed()) {
+                            cancel.unsubscribe();
+                            subscriber.onCompleted();
+                        }
+                    }
+            );
+        });
 
         return removeActiveJobId.concatWith(releaseLock);
     }
@@ -441,7 +538,7 @@ public class SchedulerImpl implements Scheduler {
         shutdown();
         jobFactories = new HashMap<>();
         this.tickScheduler = tickScheduler;
-        queryExecutor = Executors.newFixedThreadPool(2,
+        queryExecutor = Executors.newFixedThreadPool(getQueryThreadPoolSize(),
                 new ThreadFactoryBuilder().setNameFormat("query-thread-pool-%d").build());
         queryScheduler = Schedulers.from(queryExecutor);
     }
@@ -490,14 +587,35 @@ public class SchedulerImpl implements Scheduler {
     }
 
     private Completable insertIntoJobsTable(JobDetails details) {
-        return session.execute(insertJob.bind(details.getJobId(), details.getJobType(), details.getJobName(),
-                details.getParameters(), getTriggerValue(session, details.getTrigger())), queryScheduler)
-                .toCompletable();
+        return Completable.create(subscriber -> {
+            session.execute(insertJob.bind(details.getJobId(), details.getJobType(), details.getJobName(),
+                    details.getParameters(), getTriggerValue(session, details.getTrigger())), queryScheduler)
+                    .subscribe(
+                            resultSet -> {},
+                            t -> {
+                                logger.warn("Failed to insert " + details + " in jobs tables");
+                                subscriber.onError(t);
+                            },
+                            subscriber::onCompleted
+                    );
+        });
     }
 
     private Completable updateScheduledJobsIndex(JobDetails details) {
-        return session.execute(insertScheduledJob.bind(new Date(details.getTrigger().getTriggerTime()),
-                details.getJobId()), queryScheduler).toCompletable();
+        return updateScheduledJobsIndex(details.getTrigger().getTriggerTime(), details.getJobId());
+    }
+
+    private Completable updateScheduledJobsIndex(long timeSlice, UUID jobId) {
+        return Completable.create(subscriber -> {
+            session.execute(insertScheduledJob.bind(new Date(timeSlice), jobId), queryScheduler).subscribe(
+                    resultSet -> {},
+                    t -> {
+                        logger.warn("Failed to update scheduled jobs index for job id " + jobId);
+                        subscriber.onError(t);
+                    },
+                    subscriber::onCompleted
+            );
+        });
     }
 
     private void doOnTick(Action0 action) {
@@ -543,8 +661,7 @@ public class SchedulerImpl implements Scheduler {
                 .flatMap(Observable::from)
                 .map(row -> row.getTimestamp(0))
                 .toSortedList()
-                .flatMap(Observable::from)
-                .doOnNext(d -> logger.debug("Time slice [" + d + "]"));
+                .flatMap(Observable::from);
     }
 
     private Observable<JobDetails> findJob(UUID jobId) {

--- a/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
+++ b/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
@@ -332,6 +332,8 @@ public class JobExecutionTest extends JobSchedulerTest {
         jobRunning.countDown();
         assertTrue(firstTimeSliceFinished.await(10, TimeUnit.SECONDS));
 
+        logger.debug("All executions for " + job.getJobType() + " should be done");
+
         List<Date> expectedExecutions = asList(timeSlice.toDate(), timeSlice.plusMinutes(1).toDate(),
                 timeSlice.plusMinutes(2).toDate());
         assertEquals(executions, expectedExecutions);

--- a/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
+++ b/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
@@ -286,6 +286,7 @@ public class JobExecutionTest extends JobSchedulerTest {
         CountDownLatch firstTimeSliceFinished = new CountDownLatch(1);
         CountDownLatch secondTimeSliceFinished = new CountDownLatch(1);
         CountDownLatch thirdTimeSliceFinished = new CountDownLatch(1);
+        CountDownLatch jobExecutions = new CountDownLatch(3);
 
         List<Date> executions = new ArrayList<>();
 
@@ -298,6 +299,7 @@ public class JobExecutionTest extends JobSchedulerTest {
                     jobRunning.await();
                 }
                 logger.debug("Finished job execution for " + details);
+                jobExecutions.countDown();
             } catch (InterruptedException e) {
                 logger.warn(details + " was interrupted");
             } catch (Exception e) {
@@ -331,7 +333,8 @@ public class JobExecutionTest extends JobSchedulerTest {
 
         jobRunning.countDown();
         assertTrue(firstTimeSliceFinished.await(10, TimeUnit.SECONDS));
-
+        assertTrue(jobExecutions.await(10, TimeUnit.SECONDS));
+        
         logger.debug("All executions for " + job.getJobType() + " should be done");
 
         List<Date> expectedExecutions = asList(timeSlice.toDate(), timeSlice.plusMinutes(1).toDate(),

--- a/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
+++ b/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
@@ -274,6 +274,69 @@ public class JobExecutionTest extends JobSchedulerTest {
         assertEquals(getFinishedJobs(timeSlice.plusMinutes(1)), emptySet());
     }
 
+    @Test
+    public void executeLongRunningRepeatingJob() throws Exception {
+        final DateTime timeSlice = new DateTime(jobScheduler.now()).plusMinutes(1);
+        JobDetails job = new JobDetails(randomUUID(), "Long Repeating Job", "Long Repeating Job", emptyMap(),
+                new RepeatingTrigger.Builder().withInterval(1, TimeUnit.MINUTES).build());
+
+        CountDownLatch jobStarted = new CountDownLatch(1);
+        CountDownLatch jobRunning = new CountDownLatch(1);
+
+        CountDownLatch firstTimeSliceFinished = new CountDownLatch(1);
+        CountDownLatch secondTimeSliceFinished = new CountDownLatch(1);
+        CountDownLatch thirdTimeSliceFinished = new CountDownLatch(1);
+
+        List<Date> executions = new ArrayList<>();
+
+        jobScheduler.register(job.getJobType(), details -> Completable.fromAction(() -> {
+            try {
+                logger.debug("Executing " + details);
+                executions.add(new Date(details.getTrigger().getTriggerTime()));
+                if (details.getTrigger().getTriggerTime() == job.getTrigger().getTriggerTime()) {
+                    jobStarted.countDown();
+                    jobRunning.await();
+                }
+                logger.debug("Finished job execution for " + details);
+            } catch (InterruptedException e) {
+                logger.warn(details + " was interrupted");
+            } catch (Exception e) {
+                logger.warn("Job execution for " + details + " failed", e);
+            }
+        }));
+
+        scheduleJob(job);
+
+        jobScheduler.onTimeSliceFinished(finishedTimeSlice -> {
+            if (finishedTimeSlice.equals(timeSlice)) {
+                firstTimeSliceFinished.countDown();
+            } else if (finishedTimeSlice.equals(timeSlice.plusMinutes(1))) {
+                secondTimeSliceFinished.countDown();
+            } else if (finishedTimeSlice.equals(timeSlice.plusMinutes(2))) {
+                thirdTimeSliceFinished.countDown();
+            }
+        });
+
+        jobScheduler.advanceTimeTo(job.getTrigger().getTriggerTime());
+        assertTrue(jobStarted.await(10, TimeUnit.SECONDS));
+
+        // At this point the job is running. We advance the clock ahead by two minutes to
+        // simulate a long running job.
+
+        jobScheduler.advanceTimeTo(timeSlice.plusMinutes(1).getMillis());
+        assertTrue(secondTimeSliceFinished.await(10, TimeUnit.SECONDS));
+
+        jobScheduler.advanceTimeTo(timeSlice.plusMinutes(2).getMillis());
+        assertTrue(thirdTimeSliceFinished.await(10, TimeUnit.SECONDS));
+
+        jobRunning.countDown();
+        assertTrue(firstTimeSliceFinished.await(10, TimeUnit.SECONDS));
+
+        List<Date> expectedExecutions = asList(timeSlice.toDate(), timeSlice.plusMinutes(1).toDate(),
+                timeSlice.plusMinutes(2).toDate());
+        assertEquals(executions, expectedExecutions);
+    }
+
     /**
      * This test schedules and executes a job that repeats every minute. The test runs over a two minute interval.
      */
@@ -679,7 +742,6 @@ public class JobExecutionTest extends JobSchedulerTest {
         DateTime timeSlice = new DateTime(trigger.getTriggerTime());
         String jobType = "Lots of Jobs";
         int numJobs = Runtime.getRuntime().availableProcessors() * 2;
-//        int numJobs = 5;
         Random random = new Random();
 
         logger.debug("Creating and scheduling " + numJobs + " jobs");

--- a/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
+++ b/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobExecutionTest.java
@@ -334,7 +334,6 @@ public class JobExecutionTest extends JobSchedulerTest {
         jobRunning.countDown();
         assertTrue(firstTimeSliceFinished.await(10, TimeUnit.SECONDS));
         assertTrue(jobExecutions.await(10, TimeUnit.SECONDS));
-        
         logger.debug("All executions for " + job.getJobType() + " should be done");
 
         List<Date> expectedExecutions = asList(timeSlice.toDate(), timeSlice.plusMinutes(1).toDate(),


### PR DESCRIPTION
If a job runs long and misses its next execution time, the scheduler will now
execute the job again immediately for the missed execution. It will do so until
the job is caught up.