### PR TITLE
[HWKMETRICS-483] bump cassalog version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <test.keyspace>hawkulartest</test.keyspace>
     <nodes>127.0.0.1</nodes>
     <!-- Dependencies versions -->
-    <version.org.cassalog>0.2.1</version.org.cassalog>
+    <version.org.cassalog>0.3.0</version.org.cassalog>
     <version.org.hawkular.accounts>2.0.26.Final</version.org.hawkular.accounts>
     <version.org.hawkular.commons>0.7.1.Final</version.org.hawkular.commons>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>


### PR DESCRIPTION
Cassalog 0.3.0 changes the default behavior of the setKeyspace function to always run. This should address the problems encountered in HWKMETRICS-483.