### PR TITLE
[HWKMETRICS-445] add "fromEarliest" on most query endpoints

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AggregatedStatsQueryRequest.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/AggregatedStatsQueryRequest.java
@@ -33,6 +33,8 @@ public class AggregatedStatsQueryRequest {
 
     private String end;
 
+    private Boolean fromEarliest;
+
     private Integer buckets;
 
     private String bucketDuration;
@@ -65,6 +67,14 @@ public class AggregatedStatsQueryRequest {
 
     public void setEnd(String end) {
         this.end = end;
+    }
+
+    public Boolean getFromEarliest() {
+        return fromEarliest;
+    }
+
+    public void setFromEarliest(Boolean fromEarliest) {
+        this.fromEarliest = fromEarliest;
     }
 
     public Integer getBuckets() {
@@ -116,6 +126,7 @@ public class AggregatedStatsQueryRequest {
                 Objects.equals(tags, that.tags) &&
                 Objects.equals(start, that.start) &&
                 Objects.equals(end, that.end) &&
+                Objects.equals(fromEarliest, that.fromEarliest) &&
                 Objects.equals(buckets, that.buckets) &&
                 Objects.equals(bucketDuration, that.bucketDuration) &&
                 Objects.equals(percentiles, that.percentiles) &&
@@ -124,7 +135,7 @@ public class AggregatedStatsQueryRequest {
 
     @Override
     public int hashCode() {
-        return Objects.hash(metrics, tags, start, end, buckets, bucketDuration, percentiles, stacked);
+        return Objects.hash(metrics, tags, start, end, fromEarliest, buckets, bucketDuration, percentiles, stacked);
     }
 
     @Override public String toString() {
@@ -133,6 +144,7 @@ public class AggregatedStatsQueryRequest {
                 .add("tags", tags)
                 .add("start", start)
                 .add("end", end)
+                .add("fromEarliest", fromEarliest)
                 .add("buckets", buckets)
                 .add("bucketDuration", bucketDuration)
                 .add("percentiles", percentiles)

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/QueryRequest.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/QueryRequest.java
@@ -29,6 +29,8 @@ public class QueryRequest {
 
     private String end;
 
+    private Boolean fromEarliest;
+
     private Integer limit;
 
     private String order;
@@ -57,6 +59,14 @@ public class QueryRequest {
 
     public void setEnd(String end) {
         this.end = end;
+    }
+
+    public Boolean getFromEarliest() {
+        return fromEarliest;
+    }
+
+    public void setFromEarliest(Boolean fromEarliest) {
+        this.fromEarliest = fromEarliest;
     }
 
     public Integer getLimit() {
@@ -88,6 +98,7 @@ public class QueryRequest {
                 "ids=" + ids +
                 ", start=" + start +
                 ", end=" + end +
+                ", fromEarliest=" + fromEarliest +
                 ", limit=" + limit +
                 ", order=" + order +
                 ", tags=" + tags +

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -23,6 +23,7 @@ import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.badRequest;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.noContent;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.serverError;
 import static org.hawkular.metrics.model.MetricType.COUNTER;
+import static org.hawkular.metrics.model.MetricType.COUNTER_RATE;
 
 import java.net.URI;
 import java.util.Collections;
@@ -53,6 +54,8 @@ import org.hawkular.metrics.api.jaxrs.handler.observer.MetricCreatedObserver;
 import org.hawkular.metrics.api.jaxrs.handler.observer.ResultSetObserver;
 import org.hawkular.metrics.api.jaxrs.handler.template.IMetricsHandler;
 import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransformer;
+import org.hawkular.metrics.api.jaxrs.param.TimeAndBucketParams;
+import org.hawkular.metrics.api.jaxrs.param.TimeAndSortParams;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
 import org.hawkular.metrics.core.service.Functions;
 import org.hawkular.metrics.core.service.Order;
@@ -63,7 +66,6 @@ import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.NumericBucketPoint;
-import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.exception.RuntimeApiError;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
@@ -78,6 +80,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 /**
  * @author Stefan Negrea
@@ -270,12 +273,22 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
                     response = ApiError.class)
     })
+    @Override
     public void getData(
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
                     "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
-        findRawDataPointsForMetrics(asyncResponse, query, COUNTER);
+        findMetricsByNameOrTag(query.getIds(), query.getTags(), COUNTER)
+                .toList()
+                .flatMap(metricIds -> TimeAndSortParams.<Long>deferredBuilder(query.getStart(), query.getEnd())
+                            .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
+                            .sortOptions(query.getLimit(), query.getOrder())
+                            .toObservable()
+                            .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
+                                    p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+                                .observeOn(Schedulers.io())))
+                .subscribe(createNamedDataPointObserver(COUNTER));
     }
 
     @POST
@@ -294,7 +307,16 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
                     "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
-        findRateDataPointsForMetrics(asyncResponse, query, COUNTER);
+        findMetricsByNameOrTag(query.getIds(), query.getTags(), COUNTER)
+                .toList()
+                .flatMap(metricIds -> TimeAndSortParams.<Long>deferredBuilder(query.getStart(), query.getEnd())
+                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
+                        .sortOptions(query.getLimit(), query.getOrder())
+                        .toObservable()
+                        .flatMap(p -> metricsService.findRateData(metricIds, p.getTimeRange().getStart(),
+                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+                            .observeOn(Schedulers.io())))
+                .subscribe(createNamedDataPointObserver(COUNTER_RATE));
     }
 
     @Deprecated
@@ -432,13 +454,11 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
         }
 
         final Percentiles lPercentiles = percentiles != null ? percentiles
-                : new Percentiles(Collections.<Percentile> emptyList());
+                : new Percentiles(Collections.emptyList());
 
         observableConfig
                 .flatMap((config) -> metricsService.findCounterStats(metricId,
-                        config.getTimeRange().getStart(),
-                        config.getTimeRange().getEnd(),
-                        config.getBuckets(), lPercentiles.getPercentiles()))
+                        config, lPercentiles.getPercentiles()))
                 .flatMap(Observable::from)
                 .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
                 .toList()
@@ -468,47 +488,15 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
     ) {
         MetricId<Long> metricId = new MetricId<>(getTenant(), COUNTER, id);
-
-        Observable<TimeRange> observableConfig;
-        if (Boolean.TRUE.equals(fromEarliest)) {
-            if (start != null || end != null) {
-                asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
-                return;
-            }
-
-            observableConfig = metricsService.findMetric(metricId).map((metric) -> {
-                long dataRetention = metric.getDataRetention() * 24 * 60 * 60 * 1000L;
-                long now = System.currentTimeMillis();
-                long earliest = now - dataRetention;
-
-                return new TimeRange(earliest, now);
-            });
-        } else {
-            TimeRange timeRange = new TimeRange(start, end);
-            if (!timeRange.isValid()) {
-                asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
-                return;
-            }
-
-            observableConfig = Observable.just(timeRange);
-        }
-
-        if (limit == null) {
-            limit = 0;
-        }
-        if (order == null) {
-            order = Order.defaultValue(limit, start, end);
-        }
-
-        Integer fLimit = new Integer(limit);
-        Order fOrder = order;
-
-        observableConfig
-                .flatMap(timeRange -> metricsService.findDataPoints(metricId, timeRange.getStart(), timeRange.getEnd(),
-                        fLimit, fOrder))
+        TimeAndSortParams.<Long>deferredBuilder(start, end)
+                .fromEarliest(fromEarliest, metricId, this::findTimeRange)
+                .sortOptions(limit, order)
+                .toObservable()
+                .flatMap(p -> metricsService.findDataPoints(metricId, p.getTimeRange().getStart(), p.getTimeRange()
+                        .getEnd(), p.getLimit(), p.getOrder()))
                 .toList()
                 .map(ApiUtils::collectionToResponse)
-                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
     }
 
     @GET
@@ -537,64 +525,12 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles
     ) {
         MetricId<Long> metricId = new MetricId<>(getTenant(), COUNTER, id);
-
-        if (bucketsCount == null && bucketDuration == null) {
-            asyncResponse
-                    .resume(badRequest(new ApiError("Either the buckets or bucketDuration parameter must be used")));
-            return;
-        }
-
-        Observable<BucketConfig> observableConfig = null;
-
-        if (Boolean.TRUE.equals(fromEarliest)) {
-            if (start != null || end != null) {
-                asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used without start & end")));
-                return;
-            }
-
-            if (bucketsCount == null && bucketDuration == null) {
-                asyncResponse.resume(badRequest(new ApiError("fromEarliest can only be used with bucketed results")));
-                return;
-            }
-
-            observableConfig = metricsService.findMetric(metricId).map((metric) -> {
-                long dataRetention = metric.getDataRetention() * 24 * 60 * 60 * 1000L;
-                long now = System.currentTimeMillis();
-                long earliest = now - dataRetention;
-
-                BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration,
-                        new TimeRange(earliest, now));
-
-                if (!bucketConfig.isValid()) {
-                    throw new RuntimeApiError(bucketConfig.getProblem());
-                }
-
-                return bucketConfig;
-            });
-        } else {
-            TimeRange timeRange = new TimeRange(start, end);
-            if (!timeRange.isValid()) {
-                asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
-                return;
-            }
-
-            BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
-            if (!bucketConfig.isValid()) {
-                asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
-                return;
-            }
-
-            observableConfig = Observable.just(bucketConfig);
-        }
-
-        final Percentiles lPercentiles = percentiles != null ? percentiles
-                : new Percentiles(Collections.<Percentile> emptyList());
-
-        observableConfig
-                .flatMap((config) -> metricsService.findCounterStats(metricId,
-                        config.getTimeRange().getStart(),
-                        config.getTimeRange().getEnd(),
-                        config.getBuckets(), lPercentiles.getPercentiles()))
+        TimeAndBucketParams.<Long>deferredBuilder(start, end)
+                .fromEarliest(fromEarliest, metricId, this::findTimeRange)
+                .bucketConfig(bucketsCount, bucketDuration)
+                .percentiles(percentiles)
+                .toObservable()
+                .flatMap(p -> metricsService.findCounterStats(metricId, p.getBucketConfig(), p.getPercentiles()))
                 .flatMap(Observable::from)
                 .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
                 .toList()
@@ -665,11 +601,10 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
         } else {
             if(percentiles == null) {
-                percentiles = new Percentiles(Collections.<Percentile>emptyList());
+                percentiles = new Percentiles(Collections.emptyList());
             }
 
-            metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
-                    percentiles.getPercentiles())
+            metricsService.findRateStats(metricId, bucketConfig, percentiles.getPercentiles())
                     .map(ApiUtils::collectionToResponse)
                     .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
         }
@@ -696,39 +631,24 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @PathParam("id") String id,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") String start,
             @ApiParam(value = "Defaults to now") @QueryParam("end") String end,
+            @ApiParam(value = "Use data from earliest received, subject to retention period") @QueryParam
+                    ("fromEarliest") Boolean fromEarliest,
             @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
             @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
             @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles
     ) {
-        TimeRange timeRange = new TimeRange(start, end);
-        if (!timeRange.isValid()) {
-            asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
-            return;
-        }
-
-        BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
-        if (!bucketConfig.isValid()) {
-            asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
-            return;
-        }
-
-        if (bucketConfig.isEmpty()) {
-            asyncResponse
-                    .resume(badRequest(new ApiError("Either the buckets or bucketDuration parameter must be used")));
-            return;
-        }
-
         MetricId<Long> metricId = new MetricId<>(getTenant(), COUNTER, id);
-        Buckets buckets = bucketConfig.getBuckets();
-
-        if (percentiles == null) {
-            percentiles = new Percentiles(Collections.<Percentile> emptyList());
-        }
-
-        metricsService.findRateStats(metricId, timeRange.getStart(), timeRange.getEnd(), buckets,
-                percentiles.getPercentiles())
+        TimeAndBucketParams.<Long>deferredBuilder(start, end)
+                .fromEarliest(fromEarliest, metricId, this::findTimeRange)
+                .bucketConfig(bucketsCount, bucketDuration)
+                .percentiles(percentiles)
+                .toObservable()
+                .flatMap(p -> metricsService.findRateStats(metricId, p.getBucketConfig(), p.getPercentiles()))
+                .flatMap(Observable::from)
+                .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+                .toList()
                 .map(ApiUtils::collectionToResponse)
-                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(serverError(t)));
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
     }
 
     @GET
@@ -749,6 +669,8 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") final String start,
             @ApiParam(value = "Defaults to now") @QueryParam("end") final String end,
+            @ApiParam(value = "Use data from earliest received, subject to retention period") @QueryParam
+                    ("fromEarliest") Boolean fromEarliest,
             @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
             @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
             @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles,
@@ -757,45 +679,21 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(value = "Downsample method (if true then sum of stacked individual stats; defaults to false)",
                 required = false) @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
 
-        TimeRange timeRange = new TimeRange(start, end);
-        if (!timeRange.isValid()) {
-            asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
-            return;
-        }
-        BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
-        if (bucketConfig.isEmpty()) {
-            asyncResponse.resume(badRequest(new ApiError(
-                    "Either the buckets or bucketDuration parameter must be used")));
-            return;
-        }
-        if (!bucketConfig.isValid()) {
-            asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
-            return;
-        }
-        if (metricNames.isEmpty() && (tags == null || tags.getTags().isEmpty())) {
-            asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
-            return;
-        }
-        if (!metricNames.isEmpty() && !(tags == null || tags.getTags().isEmpty())) {
-            asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
-            return;
-        }
-
-        if (percentiles == null) {
-            percentiles = new Percentiles(Collections.<Percentile> emptyList());
-        }
-
-        if (metricNames.isEmpty()) {
-            metricsService.findNumericStats(getTenant(), MetricType.COUNTER, tags.getTags(), timeRange.getStart(),
-                    timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-                    .map(ApiUtils::collectionToResponse)
-                    .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
-        } else {
-            metricsService.findNumericStats(getTenant(), MetricType.COUNTER, metricNames, timeRange.getStart(),
-                    timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-                    .map(ApiUtils::collectionToResponse)
-                    .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
-        }
+        findMetricsByNameOrTag(metricNames, tags, MetricType.COUNTER)
+                .toList()
+                .flatMap(metricIds -> TimeAndBucketParams.<Long>deferredBuilder(start, end)
+                        .fromEarliest(fromEarliest, metricIds, this::findTimeRange)
+                        .bucketConfig(bucketsCount, bucketDuration)
+                        .percentiles(percentiles)
+                        .toObservable()
+                        .flatMap(p -> metricsService.findNumericStats(metricIds, p.getTimeRange().getStart(),
+                                    p.getTimeRange().getEnd(), p.getBucketConfig().getBuckets(), p.getPercentiles(),
+                                    stacked, false)))
+                .flatMap(Observable::from)
+                .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+                .toList()
+                .map(ApiUtils::collectionToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
     }
 
     @POST
@@ -815,7 +713,21 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids. " +
                     "The standard start, end, order, and limit query parameters are supported as well.")
                     AggregatedStatsQueryRequest query) {
-        findStatsForAggregatedMetrics(asyncResponse, query, MetricType.COUNTER);
+        findMetricsByNameOrTag(query.getMetrics(), query.getTags(), MetricType.COUNTER)
+                .toList()
+                .flatMap(metricIds -> TimeAndBucketParams.<Long>deferredBuilder(query.getStart(), query.getEnd())
+                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
+                        .bucketConfig(query.getBuckets(), query.getBucketDuration())
+                        .percentiles(query.getPercentiles())
+                        .toObservable()
+                        .flatMap(p -> metricsService.findNumericStats(metricIds, p.getTimeRange().getStart(),
+                                    p.getTimeRange().getEnd(), p.getBucketConfig().getBuckets(), p.getPercentiles(),
+                                    query.isStacked(), false)))
+                .flatMap(Observable::from)
+                .skipWhile(bucket -> Boolean.TRUE.equals(query.getFromEarliest()) && bucket.isEmpty())
+                .toList()
+                .map(ApiUtils::collectionToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
     }
 
     @Deprecated
@@ -834,7 +746,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(value = "List of metric names", required = false) @QueryParam("metrics") List<String> metricNames,
             @ApiParam(value = "Downsample method (if true then sum of stacked individual stats; defaults to false)",
                 required = false) @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-        getStats(asyncResponse, start, end,
+        getStats(asyncResponse, start, end, null,
                 bucketsCount, bucketDuration, percentiles, tags, metricNames, stacked);
     }
 
@@ -856,6 +768,8 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @Suspended AsyncResponse asyncResponse,
             @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") final String start,
             @ApiParam(value = "Defaults to now") @QueryParam("end") final String end,
+            @ApiParam(value = "Use data from earliest received, subject to retention period") @QueryParam
+                    ("fromEarliest") Boolean fromEarliest,
             @ApiParam(value = "Total number of buckets") @QueryParam("buckets") Integer bucketsCount,
             @ApiParam(value = "Bucket duration") @QueryParam("bucketDuration") Duration bucketDuration,
             @ApiParam(value = "Percentiles to calculate") @QueryParam("percentiles") Percentiles percentiles,
@@ -864,45 +778,21 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(value = "Downsample method (if true then sum of stacked individual stats; defaults to false)",
                 required = false) @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
 
-        TimeRange timeRange = new TimeRange(start, end);
-        if (!timeRange.isValid()) {
-            asyncResponse.resume(badRequest(new ApiError(timeRange.getProblem())));
-            return;
-        }
-        BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, timeRange);
-        if (bucketConfig.isEmpty()) {
-            asyncResponse.resume(badRequest(new ApiError(
-                    "Either the buckets or bucketsDuration parameter must be used")));
-            return;
-        }
-        if (!bucketConfig.isValid()) {
-            asyncResponse.resume(badRequest(new ApiError(bucketConfig.getProblem())));
-            return;
-        }
-        if (metricNames.isEmpty() && (tags == null || tags.getTags().isEmpty())) {
-            asyncResponse.resume(badRequest(new ApiError("Either metrics or tags parameter must be used")));
-            return;
-        }
-        if (!metricNames.isEmpty() && !(tags == null || tags.getTags().isEmpty())) {
-            asyncResponse.resume(badRequest(new ApiError("Cannot use both the metrics and tags parameters")));
-            return;
-        }
-
-        if (percentiles == null) {
-            percentiles = new Percentiles(Collections.<Percentile> emptyList());
-        }
-
-        if (metricNames.isEmpty()) {
-            metricsService.findNumericStats(getTenant(), MetricType.COUNTER_RATE, tags.getTags(), timeRange.getStart(),
-                    timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-                    .map(ApiUtils::collectionToResponse)
-                    .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
-        } else {
-            metricsService.findNumericStats(getTenant(), MetricType.COUNTER_RATE, metricNames, timeRange.getStart(),
-                    timeRange.getEnd(), bucketConfig.getBuckets(), percentiles.getPercentiles(), stacked)
-                    .map(ApiUtils::collectionToResponse)
-                    .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
-        }
+        findMetricsByNameOrTag(metricNames, tags, MetricType.COUNTER)
+                .toList()
+                .flatMap(metricIds -> TimeAndBucketParams.<Long>deferredBuilder(start, end)
+                        .fromEarliest(fromEarliest, metricIds, this::findTimeRange)
+                        .bucketConfig(bucketsCount, bucketDuration)
+                        .percentiles(percentiles)
+                        .toObservable()
+                        .flatMap(p -> metricsService.findNumericStats(metricIds, p.getTimeRange().getStart(),
+                                    p.getTimeRange().getEnd(), p.getBucketConfig().getBuckets(), p.getPercentiles(),
+                                    stacked, true)))
+                .flatMap(Observable::from)
+                .skipWhile(bucket -> Boolean.TRUE.equals(fromEarliest) && bucket.isEmpty())
+                .toList()
+                .map(ApiUtils::collectionToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
     }
 
     @Deprecated
@@ -921,7 +811,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(value = "List of metric names", required = false) @QueryParam("metrics") List<String> metricNames,
             @ApiParam(value = "Downsample method (if true then sum of stacked individual stats; defaults to false)",
                     required = false) @DefaultValue("false") @QueryParam("stacked") Boolean stacked) {
-        getStats(asyncResponse, start, end, bucketsCount, bucketDuration, percentiles, tags, metricNames,
+        getStats(asyncResponse, start, end, null, bucketsCount, bucketDuration, percentiles, tags, metricNames,
                 stacked);
     }
 
@@ -953,7 +843,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
         }
         MetricId<Long> metricId = new MetricId<>(getTenant(), COUNTER, id);
         final Percentiles lPercentiles = percentiles != null ? percentiles
-                : new Percentiles(Collections.<Percentile> emptyList());
+                : new Percentiles(Collections.emptyList());
         metricsService.findCounterStats(metricId, tags.getTags(), timeRange.getStart(), timeRange.getEnd(),
                 lPercentiles.getPercentiles())
                 .map(ApiUtils::mapToResponse)

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/template/IMetricsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/template/IMetricsHandler.java
@@ -24,7 +24,6 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.UriInfo;
 
 import org.hawkular.metrics.api.jaxrs.QueryRequest;
-import org.hawkular.metrics.core.service.Order;
 import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.param.TagNames;
@@ -58,7 +57,4 @@ public interface IMetricsHandler<T> {
     void getData(AsyncResponse asyncResponse, QueryRequest query);
 
     void addMetricData(AsyncResponse asyncResponse, String id, List<DataPoint<T>> data);
-
-    void getMetricData(AsyncResponse asyncResponse, String id, String start, String end, Boolean flag, Integer limit,
-            Order order);
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TimeAndBucketParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TimeAndBucketParams.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.hawkular.metrics.model.MetricId;
+import org.hawkular.metrics.model.Percentile;
+import org.hawkular.metrics.model.exception.RuntimeApiError;
+import org.hawkular.metrics.model.param.BucketConfig;
+import org.hawkular.metrics.model.param.Duration;
+import org.hawkular.metrics.model.param.Percentiles;
+import org.hawkular.metrics.model.param.TimeRange;
+
+import rx.Observable;
+import rx.functions.Func4;
+
+/**
+ * @author Joel Takvorian
+ */
+
+public class TimeAndBucketParams {
+
+    private final TimeRange timeRange;
+    private final BucketConfig bucketConfig;
+    private final List<Percentile> percentiles;
+
+    private TimeAndBucketParams(TimeRange timeRange, BucketConfig bucketConfig, List<Percentile> percentiles) {
+        this.timeRange = timeRange;
+        this.bucketConfig = bucketConfig;
+        this.percentiles = percentiles;
+    }
+
+    public static <T> DeferredBuilder<T> deferredBuilder(String start, String end) {
+        return new DeferredBuilder<>(start, end);
+    }
+
+    public TimeRange getTimeRange() {
+        return timeRange;
+    }
+
+    public BucketConfig getBucketConfig() {
+        return bucketConfig;
+    }
+
+    public List<Percentile> getPercentiles() {
+        return percentiles;
+    }
+
+    public static class DeferredBuilder<T> {
+        private final String start;
+        private final String end;
+        private Boolean fromEarliest;
+        private List<MetricId<T>> metricIds;
+        private Integer bucketsCount;
+        private Duration bucketDuration;
+        private List<Percentile> percentiles;
+        private Func4<String, String, Boolean, Collection<MetricId<T>>, Observable<TimeRange>> findTimeRange;
+
+        private DeferredBuilder(String start, String end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        public DeferredBuilder<T> fromEarliest(Boolean fromEarliest, List<MetricId<T>> metricIds, Func4<String, String,
+                Boolean, Collection<MetricId<T>>, Observable<TimeRange>> findTimeRange) {
+            this.fromEarliest = fromEarliest;
+            this.metricIds = metricIds;
+            this.findTimeRange = findTimeRange;
+            return this;
+        }
+
+        public DeferredBuilder<T> fromEarliest(Boolean fromEarliest, MetricId<T> metricId, Func4<String, String,
+                Boolean, Collection<MetricId<T>>, Observable<TimeRange>> findTimeRange) {
+            this.fromEarliest = fromEarliest;
+            this.metricIds = Collections.singletonList(metricId);
+            this.findTimeRange = findTimeRange;
+            return this;
+        }
+
+        public DeferredBuilder<T> bucketConfig(Integer bucketsCount, String bucketDuration) {
+            this.bucketsCount = bucketsCount;
+            this.bucketDuration = bucketDuration == null ? null : new DurationConverter().fromString(bucketDuration);
+            return this;
+        }
+
+        public DeferredBuilder<T> bucketConfig(Integer bucketsCount, Duration bucketDuration) {
+            this.bucketsCount = bucketsCount;
+            this.bucketDuration = bucketDuration;
+            return this;
+        }
+
+        public DeferredBuilder<T> percentiles(String percentiles) {
+            this.percentiles = percentiles == null ? Collections.emptyList() : new PercentilesConverter()
+                .fromString(percentiles).getPercentiles();
+            return this;
+        }
+
+        public DeferredBuilder<T> percentiles(Percentiles percentiles) {
+            this.percentiles = percentiles == null ? Collections.emptyList() : percentiles.getPercentiles();
+            return this;
+        }
+
+        public Observable<TimeAndBucketParams> toObservable() {
+            if (bucketsCount == null && bucketDuration == null) {
+                return Observable.error(new RuntimeApiError("Either the buckets or bucketDuration parameter must be " +
+                        "used"));
+            }
+            return findTimeRange.call(start, end, fromEarliest, metricIds).map(tr -> {
+                BucketConfig bucketConfig = new BucketConfig(bucketsCount, bucketDuration, tr);
+                if (!bucketConfig.isValid()) {
+                    throw new RuntimeApiError(bucketConfig.getProblem());
+                }
+                return new TimeAndBucketParams(tr, bucketConfig, percentiles);
+            });
+        }
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TimeAndSortParams.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/param/TimeAndSortParams.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.param;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.hawkular.metrics.core.service.Order;
+import org.hawkular.metrics.model.MetricId;
+import org.hawkular.metrics.model.param.TimeRange;
+
+import rx.Observable;
+import rx.functions.Func4;
+
+/**
+ * @author Joel Takvorian
+ */
+
+public class TimeAndSortParams {
+
+    private final TimeRange timeRange;
+    private final int limit;
+    private final Order order;
+
+    private TimeAndSortParams(TimeRange timeRange, int limit, Order order) {
+        this.timeRange = timeRange;
+        this.limit = limit;
+        this.order = order;
+    }
+
+    public static <T> DeferredBuilder<T> deferredBuilder(String start, String end) {
+        return new DeferredBuilder<>(start, end);
+    }
+
+    public TimeRange getTimeRange() {
+        return timeRange;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public static class DeferredBuilder<T> {
+        private final String start;
+        private final String end;
+        private Boolean fromEarliest;
+        private List<MetricId<T>> metricIds;
+        private Order order;
+        private int limit;
+        private boolean forString = false;
+        private Func4<String, String, Boolean, Collection<MetricId<T>>, Observable<TimeRange>> findTimeRange;
+
+        private DeferredBuilder(String start, String end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        public DeferredBuilder<T> fromEarliest(Boolean fromEarliest, List<MetricId<T>> metricIds, Func4<String, String,
+                Boolean, Collection<MetricId<T>>, Observable<TimeRange>> findTimeRange) {
+            this.fromEarliest = fromEarliest;
+            this.metricIds = metricIds;
+            this.findTimeRange = findTimeRange;
+            return this;
+        }
+
+        public DeferredBuilder<T> fromEarliest(Boolean fromEarliest, MetricId<T> metricId, Func4<String, String,
+                Boolean, Collection<MetricId<T>>, Observable<TimeRange>> findTimeRange) {
+            this.fromEarliest = fromEarliest;
+            this.metricIds = Collections.singletonList(metricId);
+            this.findTimeRange = findTimeRange;
+            return this;
+        }
+
+        public DeferredBuilder<T> sortOptions(Integer limit, String order) {
+            this.limit = limit == null ? 0 : limit;
+            this.order = order == null ? null : Order.fromText(order);
+            return this;
+        }
+
+        public DeferredBuilder<T> sortOptions(Integer limit, Order order) {
+            this.limit = limit == null ? 0 : limit;
+            this.order = order;
+            return this;
+        }
+
+        public DeferredBuilder<T> forString() {
+            this.forString = true;
+            return this;
+        }
+
+        private Order getOrderForString() {
+            if (order != null) {
+                return order;
+            }
+            if (limit != 0 && start != null && end == null) {
+                return Order.ASC;
+            }
+            return Order.DESC;
+        }
+
+        public Observable<TimeAndSortParams> toObservable() {
+            final Order fOrder;
+            if (forString) {
+                // Specific sorting behaviour for String metric type
+                fOrder = getOrderForString();
+            } else {
+                fOrder = order == null ? Order.defaultValue(limit, start, end) : order;
+            }
+            return findTimeRange.call(start, end, fromEarliest, metricIds).map(tr -> new TimeAndSortParams(tr, limit,
+                    fOrder));
+        }
+    }
+}

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
@@ -43,7 +43,6 @@ import org.hawkular.metrics.model.Buckets;
 import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
-import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.NumericBucketPoint;
 import org.hawkular.metrics.model.Tenant;
 import org.joda.time.DateTime;
@@ -187,20 +186,22 @@ public class GaugeITest extends BaseMetricsITest {
         String tenantId = "findGaugeStatsByMetricNames";
         DateTime start = now().minusMinutes(10);
 
-        Metric<Double> m1 = new Metric<>(new MetricId<>(tenantId, GAUGE, "M1"), getDataPointList("M1", start));
+        MetricId<Double> m1Id = new MetricId<>(tenantId, GAUGE, "M1");
+        Metric<Double> m1 = new Metric<>(m1Id, getDataPointList("M1", start));
         doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m1)));
 
-        Metric<Double> m2 = new Metric<>(new MetricId<>(tenantId, GAUGE, "M2"), getDataPointList("M2", start));
+        MetricId<Double> m2Id = new MetricId<>(tenantId, GAUGE, "M2");
+        Metric<Double> m2 = new Metric<>(m2Id, getDataPointList("M2", start));
         doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m2)));
 
-        Metric<Double> m3 = new Metric<>(new MetricId<>(tenantId, GAUGE, "M3"), getDataPointList("M3", start));
+        MetricId<Double> m3Id = new MetricId<>(tenantId, GAUGE, "M3");
+        Metric<Double> m3 = new Metric<>(m3Id, getDataPointList("M3", start));
         doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m3)));
 
         Buckets buckets = Buckets.fromCount(start.getMillis(), start.plusMinutes(5).getMillis(), 1);
 
-        List<List<NumericBucketPoint>> actual = getOnNextEvents(() -> metricsService.findNumericStats(tenantId,
-                MetricType.GAUGE, asList("M1", "M2"), start.getMillis(), start.plusMinutes(5).getMillis(), buckets,
-                emptyList(), true));
+        List<List<NumericBucketPoint>> actual = getOnNextEvents(() -> metricsService.findNumericStats(asList(m1Id,
+                m2Id), start.getMillis(), start.plusMinutes(5).getMillis(), buckets, emptyList(), true, false));
 
         assertEquals(actual.size(), 1);
 
@@ -231,20 +232,23 @@ public class GaugeITest extends BaseMetricsITest {
         String tenantId = "findGaugeStatsByMetricNames";
         DateTime start = now().minusMinutes(10);
 
-        Metric<Double> m1 = new Metric<>(new MetricId<>(tenantId, GAUGE, "M1"), getDataPointList("M1", start));
+        MetricId<Double> m1Id = new MetricId<>(tenantId, GAUGE, "M1");
+        Metric<Double> m1 = new Metric<>(m1Id, getDataPointList("M1", start));
         doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m1)));
 
-        Metric<Double> m2 = new Metric<>(new MetricId<>(tenantId, GAUGE, "M2"), getDataPointList("M2", start));
+        MetricId<Double> m2Id = new MetricId<>(tenantId, GAUGE, "M2");
+        Metric<Double> m2 = new Metric<>(m2Id, getDataPointList("M2", start));
         doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m2)));
 
-        Metric<Double> m3 = new Metric<>(new MetricId<>(tenantId, GAUGE, "M3"), getDataPointList("M3", start));
+        MetricId<Double> m3Id = new MetricId<>(tenantId, GAUGE, "M3");
+        Metric<Double> m3 = new Metric<>(m3Id, getDataPointList("M3", start));
         doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m3)));
 
         Buckets buckets = Buckets.fromCount(start.getMillis(), start.plusMinutes(5).getMillis(), 1);
 
-        List<List<NumericBucketPoint>> actual = getOnNextEvents(() -> metricsService.findNumericStats(tenantId,
-                MetricType.GAUGE, asList("M1", "M2"), start.getMillis(), start.plusMinutes(5).getMillis(), buckets,
-                emptyList(), false));
+        List<List<NumericBucketPoint>> actual = getOnNextEvents(() -> metricsService.findNumericStats(
+                asList(m1Id, m2Id), start.getMillis(), start.plusMinutes(5).getMillis(), buckets,
+                emptyList(), false, false));
 
         assertEquals(actual.size(), 1);
 
@@ -262,24 +266,30 @@ public class GaugeITest extends BaseMetricsITest {
         String tenantId = "findGaugeStatsByTags";
         DateTime start = now().minusMinutes(10);
 
-        Metric<Double> m1 = new Metric<>(new MetricId<>(tenantId, GAUGE, "M1"), getDataPointList("M1", start));
+        MetricId<Double> m1Id = new MetricId<>(tenantId, GAUGE, "M1");
+        Metric<Double> m1 = new Metric<>(m1Id, getDataPointList("M1", start));
         doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m1)));
         doAction(() -> metricsService.addTags(m1, ImmutableMap.of("type", "cpu_usage", "node", "server1")));
 
-        Metric<Double> m2 = new Metric<>(new MetricId<>(tenantId, GAUGE, "M2"), getDataPointList("M2", start));
+        MetricId<Double> m2Id = new MetricId<>(tenantId, GAUGE, "M2");
+        Metric<Double> m2 = new Metric<>(m2Id, getDataPointList("M2", start));
         doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m2)));
         doAction(() -> metricsService.addTags(m2, ImmutableMap.of("type", "cpu_usage", "node", "server2")));
 
-        Metric<Double> m3 = new Metric<>(new MetricId<>(tenantId, GAUGE, "M3"), getDataPointList("M3", start));
+        MetricId<Double> m3Id = new MetricId<>(tenantId, GAUGE, "M3");
+        Metric<Double> m3 = new Metric<>(m3Id, getDataPointList("M3", start));
         doAction(() -> metricsService.addDataPoints(GAUGE, Observable.just(m3)));
         doAction(() -> metricsService.addTags(m3, ImmutableMap.of("type", "cpu_usage", "node", "server3")));
 
         Buckets buckets = Buckets.fromCount(start.getMillis(), start.plusMinutes(5).getMillis(), 1);
         Map<String, String> tagFilters = ImmutableMap.of("type", "cpu_usage", "node", "server1|server2");
 
-        List<List<NumericBucketPoint>> actual = getOnNextEvents(() -> metricsService.findNumericStats(tenantId,
-                MetricType.GAUGE, tagFilters, start.getMillis(), start.plusMinutes(5).getMillis(), buckets,
-                emptyList(), true));
+        List<List<NumericBucketPoint>> actual = getOnNextEvents(
+                () -> metricsService.findMetricsWithFilters(tenantId, GAUGE, tagFilters)
+                        .map(Metric::getMetricId)
+                        .toList()
+                        .flatMap(metrics -> metricsService.findNumericStats(metrics, start.getMillis(), start
+                                .plusMinutes(5).getMillis(), buckets, emptyList(), true, false)));
 
         assertEquals(actual.size(), 1);
 

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
@@ -28,6 +28,8 @@ import static org.hawkular.metrics.model.MetricType.COUNTER;
 import static org.hawkular.metrics.model.MetricType.COUNTER_RATE;
 import static org.hawkular.metrics.model.MetricType.GAUGE;
 import static org.joda.time.DateTime.now;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
@@ -49,11 +51,12 @@ import org.hawkular.metrics.model.Buckets;
 import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
-import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.NumericBucketPoint;
 import org.hawkular.metrics.model.Percentile;
 import org.hawkular.metrics.model.TaggedBucketPoint;
 import org.hawkular.metrics.model.Tenant;
+import org.hawkular.metrics.model.param.BucketConfig;
+import org.hawkular.metrics.model.param.TimeRange;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
@@ -80,27 +83,27 @@ public class TagsITest extends BaseMetricsITest {
                 .toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 5, "Metrics m1-m5 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*", "a2", "2"))
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*", "a2", "2"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 1, "Only metric m3 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE,
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE,
                 ImmutableMap.of("a1", "*", "a2", "2|3")).toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Metrics m3-m4 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a2", "2|3"))
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a2", "2|3"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Metrics m3-m4 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*", "a2", "*"))
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*", "a2", "*"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 3, "Metrics m3-m5 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*", "a5", "*"))
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "*", "a5", "*"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 0, "No gauges should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE,
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE,
                 ImmutableMap.of("a4", "*", "a5", "none")).toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 0, "No gauges should have been returned");
 
@@ -110,19 +113,19 @@ public class TagsITest extends BaseMetricsITest {
         assertEquals(metrics.size(), 6, "Metrics m1-m5 and a1 should have been returned");
 
         // Test that we actually get correct gauges also, not just correct size
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "2", "a2", "2"))
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "2", "a2", "2"))
                 .toList().toBlocking().lastOrDefault(null);
         Metric m3 = metricsToAdd.get(2);
         assertEquals(gauges.size(), 1, "Only metric m3 should have been returned");
         assertEquals(gauges.get(0), m3, "m3 did not match the original inserted metric");
 
         // Test for NOT operator
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a2", "!4"))
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a2", "!4"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only gauges m3-m4 should have been returned");
 
         gauges = metricsService
-                .<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "2", "a2", "!4"))
+                .findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("a1", "2", "a2", "!4"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only gauges m3-m4 should have been returned");
 
@@ -140,19 +143,19 @@ public class TagsITest extends BaseMetricsITest {
         }
 
         // More regexp tests
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("hostname", "web.*"))
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("hostname", "web.*"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only websrv01 and websrv02 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("hostname", ".*01"))
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, ImmutableMap.of("hostname", ".*01"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only websrv01 and backend01 should have been returned");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE,
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE,
                 ImmutableMap.of("owner", "h[e|a]de(s?)")).toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Both hede and hades should have been returned, but not 'had'");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE,
+        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE,
                 ImmutableMap.of("owner", "h[e|a]de(s?)"))
                 .filter(metricsService.idFilter(".F"))
                 .toList().toBlocking().lastOrDefault(null);
@@ -458,9 +461,11 @@ public class TagsITest extends BaseMetricsITest {
 
         doAction(() -> metricsService.addDataPoints(COUNTER, Observable.just(counter)));
 
+        BucketConfig bucketConfig = mock(BucketConfig.class);
+        when(bucketConfig.getTimeRange()).thenReturn(new TimeRange(0L, now().getMillis()));
+        when(bucketConfig.getBuckets()).thenReturn(Buckets.fromStep(60_000, 60_000 * 8, 60_000));
         List<NumericBucketPoint> actual = metricsService.findCounterStats(counter.getMetricId(),
-                0, now().getMillis(), Buckets.fromStep(60_000, 60_000 * 8, 60_000),
-                asList(new Percentile("95.0"))).toBlocking().single();
+                bucketConfig, asList(new Percentile("95.0"))).toBlocking().single();
 
         List<NumericBucketPoint> expected = new ArrayList<>();
         for (int i = 1; i < 8; i++) {
@@ -528,9 +533,11 @@ public class TagsITest extends BaseMetricsITest {
         Map<String, String> tagFilters = ImmutableMap.of("type", "cpu_usage", "node", "server1|server2");
 
         List<List<NumericBucketPoint>> actual = getOnNextEvents(
-                () -> metricsService.findNumericStats(tenantId, MetricType.GAUGE,
-                        tagFilters, start.getMillis(), start.plusMinutes(5).getMillis(), buckets,
-                        emptyList(), false));
+                () -> metricsService.findMetricsWithFilters(tenantId, GAUGE, tagFilters)
+                        .map(Metric::getMetricId)
+                        .toList()
+                        .flatMap(ids -> metricsService.findNumericStats(ids, start.getMillis(), start.plusMinutes(5)
+                                        .getMillis(), buckets, emptyList(), false, false)));
 
         assertEquals(actual.size(), 1);
 

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
@@ -379,6 +379,52 @@ class AvailabilityITest extends RESTTest {
             [timestamp: start.plusHours(2).millis, value: 'up']
         ]
     ]))
+
+    // From Earliest
+    response = hawkularMetrics.post(
+        path: "availability/raw/query",
+        headers: [(tenantHeaderName): tenantId],
+        body: [
+            ids: ['A1', 'A2', 'A3'],
+            fromEarliest: true,
+            order: 'desc'
+        ]
+    )
+
+    assertEquals(200, response.status)
+    assertEquals(3, response.data.size)
+    assertTrue(response.data.contains([
+        id: 'A1',
+        data: [
+            [timestamp: start.plusHours(4).millis, value: 'up'],
+            [timestamp: start.plusHours(3).millis, value: 'down'],
+            [timestamp: start.plusHours(2).millis, value: 'down'],
+            [timestamp: start.plusHours(1).millis, value: 'up'],
+            [timestamp: start.millis, value: 'up']
+        ]
+    ]))
+
+    assertTrue(response.data.contains([
+        id: 'A2',
+        data: [
+            [timestamp: start.plusHours(4).millis, value: 'down'],
+            [timestamp: start.plusHours(3).millis, value: 'down'],
+            [timestamp: start.plusHours(2).millis, value: 'up'],
+            [timestamp: start.plusHours(1).millis, value: 'down'],
+            [timestamp: start.millis, value: 'up']
+        ]
+    ]))
+
+    assertTrue(response.data.contains([
+        id: 'A3',
+        data: [
+            [timestamp: start.plusHours(4).millis, value: 'down'],
+            [timestamp: start.plusHours(3).millis, value: 'up'],
+            [timestamp: start.plusHours(2).millis, value: 'up'],
+            [timestamp: start.plusHours(1).millis, value: 'up'],
+            [timestamp: start.millis, value: 'down']
+        ]
+    ]))
   }
 
   @Test

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StringITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StringITest.groovy
@@ -394,6 +394,52 @@ class StringITest extends RESTTest {
             [timestamp: start.plusHours(2).millis, value: 'maintenance']
         ]
     ]))
+
+    // From Earliest
+    response = hawkularMetrics.post(
+        path: "strings/raw/query",
+        headers: [(tenantHeaderName): tenantId],
+        body: [
+            ids: ['S1', 'S2', 'S3'],
+            fromEarliest: true,
+            order: 'asc'
+        ]
+    )
+
+    assertEquals(200, response.status)
+    assertEquals(3, response.data.size)
+    assertTrue(response.data.contains([
+        id: 'S1',
+        data: [
+            [timestamp: start.millis, value: 'running'],
+            [timestamp: start.plusHours(1).millis, value: 'running'],
+            [timestamp: start.plusHours(2).millis, value: 'maintenance'],
+            [timestamp: start.plusHours(3).millis, value: 'maintenance'],
+            [timestamp: start.plusHours(4).millis, value: 'down']
+        ]
+    ]))
+
+    assertTrue(response.data.contains([
+        id: 'S2',
+        data: [
+            [timestamp: start.millis, value: 'stopped'],
+            [timestamp: start.plusHours(1).millis, value: 'starting'],
+            [timestamp: start.plusHours(2).millis, value: 'running'],
+            [timestamp: start.plusHours(3).millis, value: 'running'],
+            [timestamp: start.plusHours(4).millis, value: 'unknown']
+        ]
+    ]))
+
+    assertTrue(response.data.contains([
+        id: 'S3',
+        data: [
+            [timestamp: start.millis, value: 'maintenance'],
+            [timestamp: start.plusHours(1).millis, value: 'running'],
+            [timestamp: start.plusHours(2).millis, value: 'maintenance'],
+            [timestamp: start.plusHours(3).millis, value: 'reboot'],
+            [timestamp: start.plusHours(4).millis, value: 'starting']
+        ]
+    ]))
   }
 
   @Test


### PR DESCRIPTION
- Add fromEarliest in raw/rate/stats queries, for all types of metrics

- To avoid more and more duplicated code, refactored query building; now most of the parameters validation is centralized in "TimeAndSortParams" and "TimeAndBucketParams" and their builders

- Some little changes in the MetricsService java api to uniformize method calls with "BucketConfig"
