### PR TITLE
[HWKMETRICS-480] Ability to filter with non-existing tagName

### DIFF
--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -110,6 +110,8 @@ public interface DataAccess {
 
     Observable<Row> findMetricsByTagNameValue(String tenantId, String tag, String tvalue);
 
+    Observable<Row> findAllMetricsFromTagsIndex();
+
     <T> Observable<ResultSet> deleteAndInsertCompressedGauge(MetricId<T> id, long timeslice,
                                                              CompressedPointContainer cpc,
                                                              long sliceStart, long sliceEnd, int ttl);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
@@ -89,6 +89,8 @@ public class DataAccessImpl implements DataAccess {
 
     private PreparedStatement findMetricInMetricsIndex;
 
+    private PreparedStatement findAllMetricsFromTagsIndex;
+
     private PreparedStatement getMetricTags;
 
     private PreparedStatement insertGaugeData;
@@ -267,6 +269,10 @@ public class DataAccessImpl implements DataAccess {
         findAllMetricsInDataCompressed = session.prepare(
                 "SELECT DISTINCT tenant_id, type, metric, dpart " +
                         "FROM data_compressed");
+
+        findAllMetricsFromTagsIndex = session.prepare(
+                "SELECT tenant_id, type, metric " +
+                        "FROM metrics_tags_idx");
 
         insertCompressedData = session.prepare(
                 "UPDATE data_compressed " +
@@ -500,7 +506,7 @@ public class DataAccessImpl implements DataAccess {
             "WHERE tenant_id = ? AND tname = ? AND tvalue = ? AND type = ? AND metric = ?");
 
         findMetricsByTagName = session.prepare(
-            "SELECT type, metric, tvalue " +
+            "SELECT tenant_id, type, metric, tvalue " +
             "FROM metrics_tags_idx " +
             "WHERE tenant_id = ? AND tname = ?");
 
@@ -994,5 +1000,10 @@ public class DataAccessImpl implements DataAccess {
                 .setUUID(5, getTimeUUID(sliceEnd)))
                 .concatWith(Observable.just(b))
                 .concatMap(st -> rxSession.execute(st));
+    }
+
+    @Override
+    public Observable<Row> findAllMetricsFromTagsIndex() {
+        return rxSession.executeAndFetch(findAllMetricsFromTagsIndex.bind());
     }
 }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -122,7 +122,7 @@ public interface MetricsService {
      * @return Metric's that are filtered with given conditions
      */
     <T> Observable<Metric<T>> findMetricsWithFilters(String tenantId, MetricType<T> type, Map<String, String>
-            tagsQueries, Func1<Metric<T>, Boolean>... filters);
+            tagsQueries);
 
     /**
      * Returns distinct tag values for a given tag query (using the same query format as findMetricsWithFilters).
@@ -166,8 +166,6 @@ public interface MetricsService {
     <T> Observable<DataPoint<T>> findDataPoints(MetricId<T> id, long start, long end, int limit, Order order);
 
     Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long timeSlice);
-
-//    <T> Observable<Void> compressBlock(Observable<MetricId<T>> metrics, long timeSlice);
 
     <T> Observable<NamedDataPoint<T>> findDataPoints(List<MetricId<T>> ids, long start, long end, int limit,
                                                      Order order);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -482,7 +482,8 @@ public class MetricsServiceImpl implements MetricsService {
     @Override
     public Observable<Metric<?>> findAllMetrics() {
         return dataAccess.findAllMetricsInData()
-                .distinct().compose(new MetricFromFullDataRowTransformer(defaultTTL));
+                .compose(new MetricFromFullDataRowTransformer(defaultTTL))
+                .distinct();
     }
 
     @Override

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/TagsIndexRowTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/TagsIndexRowTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,22 +32,20 @@ import rx.Observable.Transformer;
  */
 public class TagsIndexRowTransformer<T> implements Transformer<Row, MetricId<T>> {
     private final MetricType<T> type;
-    private final String tenantId;
 
-    public TagsIndexRowTransformer(String tenantId, MetricType<T> type) {
+    public TagsIndexRowTransformer(MetricType<T> type) {
         this.type = type;
-        this.tenantId = tenantId;
     }
 
     @Override
     public Observable<MetricId<T>> call(Observable<Row> rows) {
         return rows.filter(row -> {
-            MetricType<?> metricType = MetricType.fromCode(row.getByte(0));
+            MetricType<?> metricType = MetricType.fromCode(row.getByte(1));
             return (type == null && metricType.isUserType()) || metricType == type;
         }).map(row1 -> {
             @SuppressWarnings("unchecked")
-            MetricType<T> metricType = (MetricType<T>) MetricType.fromCode(row1.getByte(0));
-            return new MetricId<>(tenantId, metricType, row1.getString(1));
+            MetricType<T> metricType = (MetricType<T>) MetricType.fromCode(row1.getByte(1));
+            return new MetricId<>(row1.getString(0), metricType, row1.getString(2));
         });
     }
 }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -224,4 +224,9 @@ public class DelegatingDataAccess implements DataAccess {
                                                               long sliceStart, long sliceEnd, int ttl) {
         return delegate.deleteAndInsertCompressedGauge(id, timeslice, cpc, sliceStart, sliceEnd, ttl);
     }
+
+    @Override
+    public Observable<Row> findAllMetricsFromTagsIndex() {
+        return delegate.findAllMetricsFromTagsIndex();
+    }
 }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
@@ -90,6 +90,7 @@ public abstract class BaseMetricsITest extends BaseITest {
     public void initMethod() {
         session.execute("TRUNCATE tenants");
         session.execute("TRUNCATE data");
+        session.execute("TRUNCATE data_compressed");
         session.execute("TRUNCATE metrics_idx");
         session.execute("TRUNCATE retentions_idx");
         session.execute("TRUNCATE metrics_tags_idx");

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
@@ -213,9 +213,9 @@ public abstract class BaseMetricsITest extends BaseITest {
         List<MetricsTagsIndexEntry> actual = new ArrayList<>();
 
         for (Row row : rows) {
-            MetricType<?> type = MetricType.fromCode(row.getByte(0));
-            MetricId<?> id = new MetricId<>(tenantId, type, row.getString(1));
-            actual.add(new MetricsTagsIndexEntry(row.getString(2), id)); // Need value here.. pff.
+            MetricType<?> type = MetricType.fromCode(row.getByte(1));
+            MetricId<?> id = new MetricId<>(tenantId, type, row.getString(2));
+            actual.add(new MetricsTagsIndexEntry(row.getString(3), id)); // Need value here.. pff.
         }
 
         assertEquals(actual, expected, "The metrics tags index entries do not match");

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
@@ -271,13 +271,18 @@ public class TagsITest extends BaseMetricsITest {
                 ImmutableMap.of("a1", "4"));
         assertEquals(ids.size(), maps.size(), "ids' size should equal to maps' size");
 
-        // Create the gauges
+        // Create the metrics
         List<Metric<?>> metricsToAdd = new ArrayList<>(ids.size());
         for (int i = 0; i < ids.size(); i++) {
-            metricsToAdd.add(new Metric<>(ids.get(i), maps.get(i), 24));
+            if(ids.get(i).getType() == GAUGE) {
+                metricsToAdd.add(new Metric<>((MetricId<Double>) ids.get(i), maps.get(i), 24, asList(
+                        new DataPoint<>(System.currentTimeMillis(), 1.0))));
+            } else {
+                metricsToAdd.add(new Metric<>(ids.get(i), maps.get(i), 24));
+            }
         }
 
-        // Insert gauges
+        // Insert metrics
         Observable.from(metricsToAdd)
                 .subscribe(m -> metricsService.createMetric(m, false).toBlocking().lastOrDefault(null));
 


### PR DESCRIPTION
Add the ability to filter metrics from tags without a certain tag being set, query format is !tagName:* (value is actually ignored, so it does not matter what is set)