### PR TITLE
HWKMETRICS-501 Fix

### DIFF
--- a/dist/component-ear/pom.xml
+++ b/dist/component-ear/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerter-metrics</artifactId>
-      <version>${version.org.hawkular.alerts}</version>
+      <version>${version.org.hawkular.alerter}</version>
       <type>war</type>
     </dependency>
       <!-- Because metrics war has a dependency on alerting war (to inject AlertsService) and both components

--- a/dist/standalone-ear/pom.xml
+++ b/dist/standalone-ear/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerter-metrics</artifactId>
-      <version>${version.org.hawkular.alerts}</version>
+      <version>${version.org.hawkular.alerter}</version>
       <type>war</type>
     </dependency>
     <!-- Because metrics war has a dependency on alerting war (to inject AlertsService) and both components

--- a/integration-tests/rest-tests-jaxrs-dist/pom.xml
+++ b/integration-tests/rest-tests-jaxrs-dist/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerter-metrics</artifactId>
-      <version>${version.org.hawkular.alerts}</version>
+      <version>${version.org.hawkular.alerter}</version>
       <type>war</type>
     </dependency>
     <!-- Because metrics war has a dependency on alerting war (to inject AlertsService) and both components

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,8 @@
     <!-- Dependencies versions -->
     <version.org.cassalog>0.3.1</version.org.cassalog>
     <version.org.hawkular.accounts>2.0.26.Final</version.org.hawkular.accounts>
-    <version.org.hawkular.alerts>1.2.1.Final</version.org.hawkular.alerts>
+    <version.org.hawkular.alerts>1.2.2.Final</version.org.hawkular.alerts>
+    <version.org.hawkular.alerter>1.2.1.Final</version.org.hawkular.alerter>
     <version.org.hawkular.commons>0.7.1.Final</version.org.hawkular.commons>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
     <version.joda-time>2.7</version.joda-time>


### PR DESCRIPTION
The alerting war contained an older hawkular-metrics-model
jar. This was due to a circular dep forced by having the metrics
x-alerter in the alerting repo. The x-alerter is removed from
Halerts 1.2.2.Final, (to be migrated to Hmetrics in 0.21.0), so
change dep to 1.2.2.Final for all but the alerter, leave that at
1.2.1.Final for this micro release to bridge the gap between now
and the Hmetrics 0.21.0 release.
- Also, add a compression itest for avail data

@stefannegrea please review.