### PR TITLE
[HWKMETRICS-504] set schema refresh interval to zero for tests

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/log/RestLogger.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/log/RestLogger.java
@@ -99,4 +99,9 @@ public interface RestLogger extends BasicLogger {
     @Message(id = 200015, value = "Invalid value [%s] for Cassandra driver connection timeout. Will use default " +
             "value of %s")
     void warnInvalidConnectionTimeout(String connectionTimeout, String defaultConnectionTimeout);
+
+    @LogMessage(level = WARN)
+    @Message(id = 200016, value = "Invalid value [%s] for Cassandra driver schema refresh interval. Will use " +
+            "default value of %s")
+    void warnInvalidSchemaRefreshInterval(String schemaRefreshInterval, String defaultSchemaRefreshInterval);
 }

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -45,7 +45,7 @@ public enum ConfigurationKey {
             false),
     CASSANDRA_CONNECTION_TIMEOUT("hawkular.metrics.cassandra.connection-timeout", "5000",
             "CASSANDRA_CONNECTION_TIMEOUT", false),
-    CASSANDRA_SCHEMA_REFRESH_INTERVAL("hawkular-metrics.cassandra.schema.refresh-interval", "1000",
+    CASSANDRA_SCHEMA_REFRESH_INTERVAL("hawkular.metrics.cassandra.schema.refresh-interval", "1000",
             "CASSANDRA_SCHEMA_REFRESH_INTERVAL", false),
     WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
     DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false),

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -45,8 +45,8 @@ public enum ConfigurationKey {
             false),
     CASSANDRA_CONNECTION_TIMEOUT("hawkular.metrics.cassandra.connection-timeout", "5000",
             "CASSANDRA_CONNECTION_TIMEOUT", false),
-
-    //Service
+    CASSANDRA_SCHEMA_REFRESH_INTERVAL("hawkular-metrics.cassandra.schema.refresh-interval", "1000",
+            "CASSANDRA_SCHEMA_REFRESH_INTERVAL", false),
     WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
     DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false),
     DISABLE_METRICS_JMX("hawkular.metrics.disable-metrics-jmx-reporting", null, "DISABLE_METRICS_JMX", true),

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/BaseITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/BaseITest.java
@@ -36,6 +36,7 @@ import org.testng.annotations.BeforeSuite;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.google.common.collect.ImmutableList;
@@ -65,7 +66,7 @@ public abstract class BaseITest {
         String nodeAddresses = System.getProperty("nodes", "127.0.0.1");
         Cluster cluster = new Cluster.Builder()
                 .addContactPoints(nodeAddresses.split(","))
-//                .withProtocolVersion(ProtocolVersion.V4)
+                .withQueryOptions(new QueryOptions().setRefreshSchemaIntervalMillis(0))
                 .build();
         session = cluster.connect();
         rxSession = new RxSessionImpl(session);

--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -142,6 +142,7 @@
                 <hawkular-metrics.base-uri>${base-uri}/metrics</hawkular-metrics.base-uri>
                 <hawkular-metrics.test.origin>http://test.hawkular.org</hawkular-metrics.test.origin>
                 <hawkular-metrics.test.access-control-allow-headers>random-header1,random-header2</hawkular-metrics.test.access-control-allow-headers>
+                <hawkular-metrics.cassandra.schema.refresh-interval>0</hawkular-metrics.cassandra.schema.refresh-interval>
                 <project.version>${project.version}</project.version>
               </systemPropertyVariables>
             </configuration>

--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -185,6 +185,7 @@
                     <javaOpt>-Dhawkular.metrics.allowed-cors-origins=http://test.hawkular.org,https://secure.hawkular.io</javaOpt>
                     <javaOpt>-Dhawkular.metrics.allowed-cors-access-control-allow-headers=random-header1,random-header2</javaOpt>
                     <javaOpt>-Dhawkular.metrics.admin-token=awesome_secret_sauce</javaOpt>
+                    <javaOpt>-Dhawkular-metrics.cassandra.schema.refresh-interval=0</javaOpt>
                     <javaOpt>-Xdebug</javaOpt>
                     <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
                     <javaOpt>-Dhawkular-alerts.engine-period=50</javaOpt>

--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -185,7 +185,7 @@
                     <javaOpt>-Dhawkular.metrics.allowed-cors-origins=http://test.hawkular.org,https://secure.hawkular.io</javaOpt>
                     <javaOpt>-Dhawkular.metrics.allowed-cors-access-control-allow-headers=random-header1,random-header2</javaOpt>
                     <javaOpt>-Dhawkular.metrics.admin-token=awesome_secret_sauce</javaOpt>
-                    <javaOpt>-Dhawkular-metrics.cassandra.schema.refresh-interval=0</javaOpt>
+                    <javaOpt>-Dhawkular.metrics.cassandra.schema.refresh-interval=0</javaOpt>
                     <javaOpt>-Xdebug</javaOpt>
                     <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
                     <javaOpt>-Dhawkular-alerts.engine-period=50</javaOpt>

--- a/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobSchedulerTest.java
+++ b/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobSchedulerTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.BeforeSuite;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
@@ -58,7 +59,10 @@ public class JobSchedulerTest {
 
     @BeforeSuite
     public static void initSuite() {
-        Cluster cluster = Cluster.builder().addContactPoints("127.0.0.01").build();
+        Cluster cluster = Cluster.builder()
+                .addContactPoints("127.0.0.01")
+                .withQueryOptions(new QueryOptions().setRefreshSchemaIntervalMillis(0))
+                .build();
         String keyspace = System.getProperty("keyspace", "hawkulartest");
         session = cluster.connect("system");
         rxSession = new RxSessionImpl(session);


### PR DESCRIPTION
I have made it configurable so we can set it for REST tests as well. This will
shave quite a few seconds off of the time for schema updates to complete.