### PR TITLE
[HWKMETRICS-505] Several changes to improve error handling

### DIFF
--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsService.java
@@ -16,9 +16,10 @@
  */
 package org.hawkular.metrics.core.jobs;
 
+import java.util.List;
+
 import org.hawkular.metrics.scheduler.api.JobDetails;
 
-import rx.Observable;
 import rx.Single;
 
 /**
@@ -26,11 +27,10 @@ import rx.Single;
  */
 public interface JobsService {
 
-    void start();
+    List<JobDetails> start();
 
     void shutdown();
 
     Single<JobDetails> submitDeleteTenantJob(String tenantId, String jobName);
 
-    Observable<JobDetails> getJobDetails();
 }

--- a/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
+++ b/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
@@ -55,7 +55,7 @@ public class SchemaService {
         // For now, I am just hard coding the version tag, but a more robust solution would be
         // to calculate the tags using the current version stored in the sys_config table
         // and the new version which we can extract from any of our JAR manifest files.
-        List<String> tags = asList("0.15.x", "0.18.x", "0.19.x", "0.20.x");
+        List<String> tags = asList("0.15.x", "0.18.x", "0.19.x", "0.20.x", "0.21.x");
         URI script = getScript();
         cassalog.execute(script, tags, vars);
 

--- a/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.21.0.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.21.0.groovy
@@ -1,4 +1,3 @@
-package org.hawkular.schema
 /*
  * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
@@ -16,12 +15,37 @@ package org.hawkular.schema
  * limitations under the License.
  */
 
-include '/org/hawkular/schema/bootstrap.groovy'
+schemaChange {
+  version '5.0'
+  author 'jsanda'
+  tags '0.21.x'
+  cql "ALTER TABLE scheduled_jobs_idx ADD job_name text"
+}
 
-setKeyspace keyspace
+schemaChange {
+  version '5.1'
+  author 'jsanda'
+  tags '0.21.x'
+  cql "ALTER TABLE scheduled_jobs_idx ADD job_params frozen<map<text, text>>"
+}
 
-include '/org/hawkular/schema/updates/schema-0.15.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.18.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.19.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.20.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.21.0.groovy'
+schemaChange {
+  version '5.2'
+  author 'jsanda'
+  tags '0.21.x'
+  cql "ALTER TABLE scheduled_jobs_idx ADD trigger frozen<trigger_def>"
+}
+
+schemaChange {
+  version '5.3'
+  author 'jsanda'
+  tags '0.21.x'
+  cql "ALTER TABLE scheduled_jobs_idx ADD job_type text"
+}
+
+schemaChange {
+  version '5.4'
+  author 'jsanda'
+  tags '0.21.x'
+  cql "ALTER TABLE scheduled_jobs_idx ADD status tinyint"
+}

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/JobDetails.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/JobDetails.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.google.common.base.MoreObjects;
+
 /**
  * @author jsanda
  */
@@ -36,12 +38,25 @@ public class JobDetails {
 
     private Trigger trigger;
 
+    private JobStatus status;
+
     public JobDetails(UUID jobId, String jobType, String jobName, Map<String, String> parameters, Trigger trigger) {
         this.jobId = jobId;
         this.jobType = jobType;
         this.jobName = jobName;
         this.parameters = Collections.unmodifiableMap(parameters);
         this.trigger = trigger;
+        status = JobStatus.NONE;
+    }
+
+    public JobDetails(UUID jobId, String jobType, String jobName, Map<String, String> parameters, Trigger trigger,
+            JobStatus status) {
+        this.jobId = jobId;
+        this.jobType = jobType;
+        this.jobName = jobName;
+        this.parameters = Collections.unmodifiableMap(parameters);
+        this.trigger = trigger;
+        this.status = status;
     }
 
     public UUID getJobId() {
@@ -64,31 +79,36 @@ public class JobDetails {
         return trigger;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        JobDetails that = (JobDetails) o;
-        return Objects.equals(jobId, that.jobId) &&
-                Objects.equals(jobType, that.jobType) &&
-                Objects.equals(jobName, that.jobName) &&
-                Objects.equals(parameters, that.parameters) &&
-                Objects.equals(trigger, that.trigger);
+    public JobStatus getStatus() {
+        return status;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(jobId, jobType, jobName, parameters, trigger);
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JobDetails details = (JobDetails) o;
+        return Objects.equals(jobId, details.jobId) &&
+                Objects.equals(jobType, details.jobType) &&
+                Objects.equals(jobName, details.jobName) &&
+                Objects.equals(parameters, details.parameters) &&
+                Objects.equals(trigger, details.trigger) &&
+                Objects.equals(status, details.status);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(jobId, jobType, jobName, parameters, trigger, status);
     }
 
     @Override
     public String toString() {
-        return "JobDetails{" +
-                "jobId=" + jobId +
-                ", jobType='" + jobType + '\'' +
-                ", jobName='" + jobName + '\'' +
-                ", parameters=" + parameters +
-                ", trigger=" + trigger +
-                '}';
+        return MoreObjects.toStringHelper(this)
+                .add("jobId", jobId)
+                .add("jobType", jobType)
+                .add("jobName", jobName)
+                .add("parameters", parameters)
+                .add("trigger", trigger)
+                .add("status", status)
+                .omitNullValues()
+                .toString();
     }
 }

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/JobStatus.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/JobStatus.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.scheduler.api;
+
+/**
+ * Currently only a single status is stored in the database, but it is stored as a byte in case we later decide to
+ * add additional statuses.
+ *
+ * @author jsanda
+ */
+public enum JobStatus {
+
+    /**
+     * When the status column in the database is not set, the C* driver returns zero.
+     */
+    NONE((byte) 0),
+
+    /**
+     * Set when the job has finished execution; however, this will be done prior to other post-execution steps, namely
+     * rescheduling the job (if it is repeating).
+     */
+    FINISHED((byte) 1);
+
+    private byte code;
+
+    JobStatus(byte code) {
+        this.code = code;
+    }
+
+    public byte getCode() {
+        return code;
+    }
+
+    public static JobStatus fromCode(byte code) {
+        switch (code) {
+            case 0: return NONE;
+            case 1: return FINISHED;
+            default: throw new IllegalArgumentException(code + " is not a recognized status code");
+        }
+    }
+}

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/Scheduler.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/api/Scheduler.java
@@ -19,7 +19,6 @@ package org.hawkular.metrics.scheduler.api;
 import java.util.Map;
 
 import rx.Completable;
-import rx.Observable;
 import rx.Single;
 import rx.functions.Func1;
 import rx.functions.Func2;
@@ -72,5 +71,4 @@ public interface Scheduler {
      */
     void shutdown();
 
-    Observable<JobDetails> getAllJobs();
 }

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/TestScheduler.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/TestScheduler.java
@@ -150,11 +150,6 @@ public class TestScheduler implements Scheduler {
         scheduler.shutdown();
     }
 
-    @Override
-    public Observable<JobDetails> getAllJobs() {
-        return scheduler.getAllJobs();
-    }
-
     public void onTimeSliceFinished(Action1<DateTime> callback) {
         finishedTimeSlicesSubscriptions.add(finishedTimeSlices.subscribe(timeSlice ->
                 callback.call(new DateTime(timeSlice))));

--- a/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobSchedulerTest.java
+++ b/job-scheduler/src/test/java/org/hawkular/metrics/scheduler/impl/JobSchedulerTest.java
@@ -17,17 +17,16 @@
 package org.hawkular.metrics.scheduler.impl;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
 import org.hawkular.metrics.scheduler.api.JobDetails;
-import org.hawkular.metrics.scheduler.api.RepeatingTrigger;
-import org.hawkular.metrics.scheduler.api.SingleExecutionTrigger;
 import org.hawkular.metrics.schema.SchemaService;
 import org.hawkular.rx.cassandra.driver.RxSession;
 import org.hawkular.rx.cassandra.driver.RxSessionImpl;
@@ -35,14 +34,14 @@ import org.joda.time.DateTime;
 import org.testng.annotations.BeforeSuite;
 
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
-import com.datastax.driver.core.UDTValue;
+import com.google.common.collect.ImmutableSet;
 
 import rx.Observable;
+import rx.schedulers.Schedulers;
 
 /**
  * @author jsanda
@@ -50,15 +49,18 @@ import rx.Observable;
 public class JobSchedulerTest {
     protected static Session session;
     protected static RxSession rxSession;
-    private static PreparedStatement findJob;
-    private static PreparedStatement findScheduledJobs;
     private static PreparedStatement findFinishedJobs;
     private static PreparedStatement getActiveTimeSlices;
     private static PreparedStatement addActiveTimeSlice;
 
+    protected static JobsService jobsService;
+
     @BeforeSuite
     public static void initSuite() {
-        Cluster cluster = Cluster.builder().addContactPoints("127.0.0.01").build();
+        Cluster cluster = Cluster.builder()
+                .addContactPoints("127.0.0.01")
+                .withQueryOptions(new QueryOptions().setRefreshSchemaIntervalMillis(0))
+                .build();
         String keyspace = System.getProperty("keyspace", "hawkulartest");
         session = cluster.connect("system");
         rxSession = new RxSessionImpl(session);
@@ -70,9 +72,8 @@ public class JobSchedulerTest {
 
         session.execute("USE " + keyspace);
 
-        findJob = session.prepare("SELECT type, name, params, trigger FROM jobs WHERE id = ?")
-                .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM);
-        findScheduledJobs = session.prepare("SELECT job_id FROM scheduled_jobs_idx WHERE time_slice = ?");
+        jobsService = new JobsService(rxSession);
+
         findFinishedJobs = session.prepare("SELECT job_id FROM finished_jobs_idx WHERE time_slice = ?");
         getActiveTimeSlices = session.prepare("SELECT distinct time_slice FROM active_time_slices");
         addActiveTimeSlice = session.prepare("INSERT INTO active_time_slices (time_slice) VALUES (?)");
@@ -111,40 +112,37 @@ public class JobSchedulerTest {
         }
     }
 
-    protected static Set<UUID> getScheduledJobs(DateTime timeSlice) {
-        return getJobs(timeSlice, findScheduledJobs);
+    protected static Set<JobDetails> getScheduledJobs(DateTime timeSlice) {
+        List<JobDetails> jobs = jobsService.findScheduledJobs(timeSlice.toDate(), Schedulers.computation())
+                .toList()
+                .toBlocking()
+                .firstOrDefault(null);
+        assertNotNull(jobs);
+        return ImmutableSet.copyOf(jobs);
+    }
+
+    protected static JobDetails getScheduledJob(JobDetails details) {
+        return getScheduledJobs(new DateTime(details.getTrigger().getTriggerTime()))
+                .stream()
+                .filter(scheduled -> scheduled.getJobId().equals(details.getJobId()))
+                .findFirst()
+                .orElseGet(() -> null);
     }
 
     protected static Set<UUID> getFinishedJobs(DateTime timeSlice) {
-        return getJobs(timeSlice, findFinishedJobs);
-    }
-
-    private static Set<UUID> getJobs(DateTime timeSlice, PreparedStatement query) {
-        return session.execute(query.bind(timeSlice.toDate())).all().stream().map(row -> row.getUUID(0))
+        return session.execute(findFinishedJobs.bind(timeSlice.toDate())).all().stream().map(row -> row.getUUID(0))
                 .collect(Collectors.toSet());
     }
 
     protected static void assertJobEquals(JobDetails expected) {
-        ResultSet resultSet = session.execute(findJob.bind(expected.getJobId()));
-        assertFalse(resultSet.isExhausted(), "Failed to find " + expected + " in jobs table");
-        Row row = resultSet.one();
+        JobDetails actual = getScheduledJob(expected);
 
-        assertEquals(row.getString(0), expected.getJobType(), "The job type does not match");
-        assertEquals(row.getString(1), expected.getJobName(), "The job name does not match");
-        assertEquals(row.getMap(2, String.class, String.class), expected.getParameters(),
+        assertNotNull(actual);
+        assertEquals(actual.getJobType(), expected.getJobType(), "The job type does not match");
+        assertEquals(actual.getJobName(), expected.getJobName(), "The job name does not match");
+        assertEquals(actual.getParameters(), expected.getParameters(),
                 "The job parameters do not match");
-
-        UDTValue udtValue = row.getUDTValue(3);
-        int triggerType = 0;
-        if (expected.getTrigger() instanceof SingleExecutionTrigger) {
-            triggerType = 0;
-        } else if (expected.getTrigger() instanceof RepeatingTrigger) {
-            triggerType = 1;
-        } else {
-            fail(expected.getTrigger().getClass().getName() + " is not a recognized trigger type");
-        }
-        assertEquals(udtValue.getInt(0), triggerType, "The trigger type does not match");
-        assertEquals(udtValue.getLong(1), expected.getTrigger().getTriggerTime(), "The trigger time does not match");
+        assertEquals(actual.getTrigger(), expected.getTrigger(), "The triggers do not match");
     }
 
 }


### PR DESCRIPTION
This commit includes a bunch of changes.

* Store job details in scheduled_jobs_idx
I previously only stored the job id in scheduled_jobs_idx and fetched the
details from the jobs table. This eliminates the extra read. I also am no
longer storing the job details in the jobs table. Right now it doesn't really
serve a purpose, and it has actually made things a little more complex because
there are times when the next trigger gets persisted and the job for the
current trigger still has to be retried.

* Do not updated finished_jobs_idx until other post-execution steps are done
I previously updated finished_jobs_idx right after the job was done executing.
If a subsequent post-execution step failed, namely reschulding, the job would
never run again because the computeRemainingJobs() method which determines
eligible jobs to execute filters out jobs that are already in finished_jobs_idx
for the time slice in question.

* Add status column to scheduled_jobs_idx
Rather than updating finished_jobs_idx right away, I now update this new status
column. If the job is then retried after a failure we first check to see if
the status flag is set. If it is we skip job execution and move right to the
post-execution steps.

* Add error logging
I have added a bunch of doOnError(Throwable) calls in the post-execution steps
for improved debugging to make it easier to see what exactly fails.

* Make sure active jobs cache is updated
Previously if there was an error during post-execution, the job id would not
get removed from the active jobs cache. This would prevent subsequent execution
of the job since we filter out those jobs in the active jobs cache when
determining the eligible jobs. A server restart would have been required. Now
I make sure the cache gets updated in a doOnError(Throwable) callback that is
at the end of the post-execution call chain.