### PR TITLE
hwkmetrics-512 jndi bind issue

### DIFF
--- a/dist/component/component-war/pom.xml
+++ b/dist/component/component-war/pom.xml
@@ -35,6 +35,10 @@
   <name>Hawkular Metrics WAR for Hawkular Services</name>
   <description>Hawkular Metrics WAR for Hawkular Services</description>
 
+  <properties>
+    <version.javaee.spec>7.0</version.javaee.spec>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -115,6 +119,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+      <version>${version.javaee.spec}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/dist/component/component-war/src/main/java/org/hawkular/metrics/component/MetricsJNDIPublisher.java
+++ b/dist/component/component-war/src/main/java/org/hawkular/metrics/component/MetricsJNDIPublisher.java
@@ -17,24 +17,19 @@
 package org.hawkular.metrics.component;
 
 import javax.annotation.PostConstruct;
-//import javax.enterprise.context.ApplicationScoped;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import org.hawkular.metrics.api.jaxrs.util.Eager;
 import org.hawkular.metrics.core.service.MetricsService;
 
 /**
  * @author Pavol Loffay
  */
-
-// [jshaughn] I'm not sure why this bean should be Eager or ApplicationScoped but as it turns out, these two
-// annotations together cause the bind to fail due to "Naming context is read-only" (which is a little crazy for
-// java:global).  I'm not sure about the necessity of Eager, so I left it in place, I think we can survive without
-// this bean being ApplicationScoped.  I sort of think perhaps neither of these is necessary.
-//@ApplicationScoped
-@Eager
+@Singleton
+@Startup
 public class MetricsJNDIPublisher {
 
     @Inject
@@ -46,7 +41,7 @@ public class MetricsJNDIPublisher {
         try {
             ctx = new InitialContext();
             ctx.bind("java:global/Hawkular/Metrics", metricsService);
-        } catch (NamingException e) {
+        } catch (Exception e) {
             throw new IllegalStateException("Could not register metrics in JNDI", e);
         } finally {
             if (ctx != null) {


### PR DESCRIPTION
- change from @ApplicationScoped+@Eager to @Singleton+@Startup
  - In general Hmetrics does not use EJB, but I have not found a
    way to get this working using other annotations.  This is only
    not in any metrics jars, just the component war.

@stefannegrea @jsanda @pavolloffay Please review and decide whether you are OK with using EJB annotations to solve this issue.  I know EJB is a four-letter word in Hmetrics, but I did not see another way to get this working.  I am open to alternatives if you have suggestions.