### PR TITLE
[HWKMETRICS-495] upgrade to cassalog 0.4.0 and add verification checks

### DIFF
--- a/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.15.0.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.15.0.groovy
@@ -27,6 +27,7 @@ CREATE TABLE sys_config (
     PRIMARY KEY (config_id, name)
 ) WITH compaction = { 'class': 'LeveledCompactionStrategy' }
 """
+  verify { tableExists(keyspace, 'sys_config') }
 }
 
 schemaChange {
@@ -43,6 +44,7 @@ schemaChange {
   tags '0.15.x'
   description "Add support for data point tags. See HWKMETRICS-368 for details"
   cql "ALTER TABLE data ADD tags map<text,text>"
+  verify { columnExists(keyspace, 'data', 'tags') }
 }
 
 schemaChange {
@@ -51,6 +53,7 @@ schemaChange {
   tags '0.15.x'
   description 'Add support for string metric type. See HWKMETRICS-384 for details.'
   cql "ALTER TABLE data ADD s_value text"
+  verify { columnExists(keyspace, 'data', 's_value') }
 }
 
 schemaChange {

--- a/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.18.0.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.18.0.groovy
@@ -27,6 +27,7 @@ CREATE TABLE locks (
     value text,
 ) WITH compaction = { 'class': 'LeveledCompactionStrategy' }
 """
+  verify { tableExists(keyspace, 'locks') }
 }
 
 schemaChange {
@@ -42,6 +43,7 @@ CREATE TABLE jobs (
     trigger frozen <trigger_def>
 ) WITH compaction = { 'class': 'LeveledCompactionStrategy' }
 """
+  verify { tableExists(keyspace, 'jobs') }
 }
 
 schemaChange {
@@ -55,6 +57,7 @@ CREATE TABLE scheduled_jobs_idx (
     PRIMARY KEY (time_slice, job_id)
 ) WITH compaction = { 'class': 'LeveledCompactionStrategy' }
 """
+  verify { tableExists(keyspace, 'scheduled_jobs_idx') }
 }
 
 schemaChange {
@@ -68,6 +71,7 @@ CREATE TABLE finished_jobs_idx (
     PRIMARY KEY (time_slice, job_id)
 ) WITH compaction = { 'class': 'LeveledCompactionStrategy' }
 """
+  verify { tableExists(keyspace, 'finished_jobs_idx') }
 }
 
 schemaChange {
@@ -79,4 +83,5 @@ CREATE TABLE active_time_slices (
     time_slice timestamp PRIMARY KEY
 ) WITH compaction = { 'class' : 'LeveledCompactionStrategy' }
 """
+  verify { tableExists(keyspace, 'active_time_slices') }
 }

--- a/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.19.0.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.19.0.groovy
@@ -38,6 +38,7 @@ schemaChange {
   author 'snegre'
   tags '0.19.x'
   cql "ALTER TABLE data DROP aggregates"
+  verify { columnDoesNotExist(keyspace, 'data', 'aggregates') }
 }
 
 schemaChange {
@@ -45,6 +46,7 @@ schemaChange {
   author 'snegrea'
   tags '0.19.x'
   cql "DROP TYPE aggregate_data"
+  verify { typeDoesNotExist(keyspace, 'aggregate_data') }
 }
 
 
@@ -53,6 +55,7 @@ schemaChange {
   author 'snegrea'
   tags '0.19.x'
   cql "ALTER TABLE data DROP data_retention"
+  verify { columnDoesNotExist(keyspace, 'data', 'data_retention') }
 }
 
 schemaChange {
@@ -60,6 +63,7 @@ schemaChange {
   author 'snegrea'
   tags '0.19.x'
   cql "DROP TYPE aggregation_template"
+  verify { typeDoesNotExist(keyspace, 'aggregation_template') }
 }
 
 schemaChange {
@@ -67,4 +71,5 @@ schemaChange {
   author 'snegrea'
   tags '0.19.x'
   cql "DROP TABLE tenants_by_time"
+  verify { tableDoesNotExist(keyspace, 'tenants_by_time') }
 }

--- a/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.20.0.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.20.0.groovy
@@ -34,6 +34,7 @@ CREATE TABLE data_compressed (
     PRIMARY KEY ((tenant_id, type, metric, dpart), time)
 ) WITH CLUSTERING ORDER BY (time DESC)
 """
+  verify { tableExists(keyspace, 'data_compressed') }
 }
 
 schemaChange {

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <test.keyspace>hawkulartest</test.keyspace>
     <nodes>127.0.0.1</nodes>
     <!-- Dependencies versions -->
-    <version.org.cassalog>0.4.0</version.org.cassalog>
+    <version.org.cassalog>0.4.1</version.org.cassalog>
     <version.org.hawkular.accounts>2.0.26.Final</version.org.hawkular.accounts>
     <version.org.hawkular.alerts>1.2.3.Final-SRC-revision-04533604d253236abfa45b052764db9e2ea4ebce</version.org.hawkular.alerts>
     <version.org.hawkular.commons>0.7.1.Final</version.org.hawkular.commons>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <!-- Dependencies versions -->
     <version.org.cassalog>0.4.1</version.org.cassalog>
     <version.org.hawkular.accounts>2.0.26.Final</version.org.hawkular.accounts>
-    <version.org.hawkular.alerts>1.2.3.Final-SRC-revision-04533604d253236abfa45b052764db9e2ea4ebce</version.org.hawkular.alerts>
+    <version.org.hawkular.alerts>1.2.3.Final-SRC-revision-f6c3dab9ff63f0fec8cd6df7195dfcdcae2f3ae2</version.org.hawkular.alerts>
     <version.org.hawkular.commons>0.7.1.Final</version.org.hawkular.commons>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
     <version.joda-time>2.7</version.joda-time>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <test.keyspace>hawkulartest</test.keyspace>
     <nodes>127.0.0.1</nodes>
     <!-- Dependencies versions -->
-    <version.org.cassalog>0.3.1</version.org.cassalog>
+    <version.org.cassalog>0.4.0</version.org.cassalog>
     <version.org.hawkular.accounts>2.0.26.Final</version.org.hawkular.accounts>
     <version.org.hawkular.alerts>1.2.3.Final-SRC-revision-04533604d253236abfa45b052764db9e2ea4ebce</version.org.hawkular.alerts>
     <version.org.hawkular.commons>0.7.1.Final</version.org.hawkular.commons>


### PR DESCRIPTION
The verification checks are used in restart scenarios to help determine whether
or not a change, such as creating a table, has already been applied. Applying
the schema change and updating the changelog table cannot be done atomically
so we need to do some extra work to make sure we are in a known, good state.