### PR TITLE
[HWKMETRICS-510] add configurable retry logic for inserting data points

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/log/RestLogger.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/log/RestLogger.java
@@ -104,4 +104,14 @@ public interface RestLogger extends BasicLogger {
     @Message(id = 200016, value = "Invalid value [%s] for Cassandra driver schema refresh interval. Will use " +
             "default value of %s")
     void warnInvalidSchemaRefreshInterval(String schemaRefreshInterval, String defaultSchemaRefreshInterval);
+
+    @LogMessage(level = WARN)
+    @Message(id = 200017, value = "Invalid value [%s] for ingestion max retries. The ingestion configuration setting " +
+            "will not be updated")
+    void warnInvalidIngestMaxRetries(String maxRetries);
+
+    @LogMessage(level = WARN)
+    @Message(id = 200018, value = "Invalid value [%s] for ingestion max retry delay. The ingestion configuration " +
+            "setting will not be updated")
+    void warnInvalidIngestMaxRetryDelay(String maxRetries);
 }

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -52,6 +52,9 @@ public enum ConfigurationKey {
     DISABLE_METRICS_JMX("hawkular.metrics.disable-metrics-jmx-reporting", null, "DISABLE_METRICS_JMX", true),
     ADMIN_TOKEN("hawkular.metrics.admin-token", null, "ADMIN_TOKEN", false),
 
+    INGEST_MAX_RETRIES("hawkular.metrics.ingestion.retry.max-retries", null, "INGEST_MAX_RETRIES", false),
+    INGEST_MAX_RETRY_DELAY("hawkular.metrics.ingestion.retry.max-delay", null, "INGEST_MAX_RETRY_DELAY", false),
+
     //Alerting
     METRICS_PUBLISH_PERIOD("hawkular.metrics.publish-period", "2000", "METRICS_PUBLISH_PERIOD", false),
     DISABLE_METRICS_FORWARDING("hawkular.metrics.disable-metrics-forwarding", null, "DISABLE_METRICS_FORWARDING", true),

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -75,6 +75,7 @@ import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
 import org.hawkular.metrics.model.exception.TenantAlreadyExistsException;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.TimeRange;
+import org.hawkular.metrics.sysconfig.Configuration;
 import org.hawkular.metrics.sysconfig.ConfigurationService;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -191,6 +192,10 @@ public class MetricsServiceImpl implements MetricsService {
 
     private int maxStringSize;
 
+    private long insertRetryMaxDelay;
+
+    private int insertMaxRetries;
+
     public void startUp(Session session, String keyspace, boolean resetDb, MetricRegistry metricRegistry) {
         startUp(session, keyspace, resetDb, true, metricRegistry);
     }
@@ -273,7 +278,7 @@ public class MetricsServiceImpl implements MetricsService {
                 .put(STRING, Functions::getStringDataPoint)
                 .build();
 
-        initStringSize(session);
+        initConfiguration(session);
         setDefaultTTL(session, keyspace);
         initMetrics();
 
@@ -324,15 +329,20 @@ public class MetricsServiceImpl implements MetricsService {
                 .build();
     }
 
-    private void initStringSize(Session session) {
-        String configMaxStringSize = configurationService.load("org.hawkular.metrics", "string-size").toBlocking()
+    private void initConfiguration(Session session) {
+        Configuration configuration = configurationService.load("org.hawkular.metrics").toBlocking()
                 .lastOrDefault(null);
+        String configMaxStringSize = configuration.get("string-size");
         if (configMaxStringSize == null) {
             maxStringSize = -1;  // no size limit
         } else {
             maxStringSize = Integer.parseInt(configMaxStringSize);
         }
         log.infoMaxSizeStringMetrics(this.maxStringSize);
+
+        insertRetryMaxDelay = Long.parseLong(configuration.get("ingestion.retry.max-delay", "30000"));
+        insertMaxRetries = Integer.parseInt(configuration.get("ingestion.retry.max-retries", "5"));
+        log.infoInsertRetryConfig(insertMaxRetries, insertRetryMaxDelay);
     }
 
     private void setDefaultTTL(Session session, String keyspace) {
@@ -608,6 +618,15 @@ public class MetricsServiceImpl implements MetricsService {
         Observable<Integer> updates = metrics
                 .filter(metric -> !metric.getDataPoints().isEmpty())
                 .flatMap(metric -> inserter.call(metric, getTTL(metric.getMetricId()))
+                        .retryWhen(errors -> errors
+                                .zipWith(Observable.range(1, insertMaxRetries), (n, i) -> i)
+                                .flatMap(retryCount -> {
+                                    long delay = (long) Math.min(Math.pow(2, retryCount) * 1000, insertRetryMaxDelay);
+                                    log.debug("Retrying insert for " + metric.getMetricId() + " in " + delay + " ms");
+                                    return Observable.timer((long) Math.min(Math.pow(2, retryCount) * 1000, 30000),
+                                            TimeUnit.SECONDS);
+                                }))
+                        .doOnError(t -> log.debug("Failed to insert data points for " + metric.getMetricId()))
                         .doOnNext(i -> insertedDataPointEvents.onNext(metric)))
                 .doOnNext(meter::mark);
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/log/CoreLogger.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/log/CoreLogger.java
@@ -67,4 +67,9 @@ public interface CoreLogger extends BasicLogger {
     @LogMessage(level = INFO)
     @Message(id = 100008, value = "Using max size of %d for string metrics")
     void infoMaxSizeStringMetrics(int maxStringSize);
+
+    @LogMessage(level = INFO)
+    @Message(id = 100009, value = "Using max number of retries %d and max retry delay of %d ms for inserting data " +
+            "points")
+    void infoInsertRetryConfig(int maxRetries, long maxRetryDelay);
 }

--- a/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.21.0.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.21.0.groovy
@@ -56,3 +56,17 @@ schemaChange {
   tags '0.21.x'
   cql "INSERT INTO sys_config (config_id, name, value) VALUES ('org.hawkular.metrics', 'gc_grace_seconds', '604800')"
 }
+
+schemaChange {
+  version '5.6'
+  author 'jsanda'
+  tags '0.21.x'
+  cql """
+BEGIN UNLOGGED BATCH
+    INSERT INTO sys_config (config_id, name, value)
+        VALUES ('org.hawkular.metrics', 'ingestion.retry.max-retries', '5');
+    INSERT INTO sys_config (config_id, name, value)
+        VALUES ('org.hawkular.metrics', 'ingestion.retry.max-delay', '30000');
+APPLY BATCH;
+"""
+}


### PR DESCRIPTION
If insertion of data points fail, we will use an exponential back off delay
with caps on the delay and the number of retries. The max delay and max number
of retries are stored in the sys_config table and can be updated via system
properties or environment variables.