### PR TITLE
Store all values as doubles in the compression block

### DIFF
--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/DataPointCompressTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/DataPointCompressTransformer.java
@@ -66,10 +66,11 @@ public class DataPointCompressTransformer<T> implements Observable.Transformer<D
                             compressor.addValue(d.getTimestamp(), (Double) d.getValue());
                             break;
                         case 1: // AVAILABILITY
-                            compressor.addValue(d.getTimestamp(), ((AvailabilityType) d.getValue()).getCode());
+                            compressor.addValue(d.getTimestamp(), ((Byte) ((AvailabilityType) d.getValue()).getCode())
+                                    .doubleValue());
                             break;
                         case 2: // COUNTER
-                            compressor.addValue(d.getTimestamp(), (Long) d.getValue());
+                            compressor.addValue(d.getTimestamp(), ((Long) d.getValue()).doubleValue());
                             break;
                         default:
                             // Not supported yet

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/DataPointDecompressTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/DataPointDecompressTransformer.java
@@ -93,11 +93,12 @@ public class DataPointDecompressTransformer<T> implements Observable.Transformer
                                         dataPoint = new DataPoint(pair.getTimestamp(), pair.getDoubleValue());
                                         break;
                                     case 1: // AVAILABILITY
-                                        dataPoint = new DataPoint(pair.getTimestamp(), AvailabilityType.fromByte((byte)
-                                            pair.getLongValue()));
+                                        dataPoint = new DataPoint(pair.getTimestamp(), AvailabilityType.fromByte(
+                                                ((Double) pair.getDoubleValue()).byteValue()));
                                         break;
                                     case 2: // COUNTER
-                                        dataPoint = new DataPoint(pair.getTimestamp(), pair.getLongValue());
+                                        dataPoint = new DataPoint(pair.getTimestamp(), ((Double) pair.getDoubleValue
+                                                ()).longValue());
                                         break;
                                     default:
                                         // Not supported yet

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
@@ -45,6 +45,7 @@ import org.apache.commons.math3.stat.descriptive.rank.PSquarePercentile;
 import org.apache.commons.math3.stat.descriptive.summary.Sum;
 import org.hawkular.metrics.core.service.Order;
 import org.hawkular.metrics.core.service.transformers.NumericDataPointCollector;
+import org.hawkular.metrics.datetime.DateTimeService;
 import org.hawkular.metrics.model.Buckets;
 import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
@@ -57,6 +58,8 @@ import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
 import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.TimeRange;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.Duration;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -226,6 +229,53 @@ public class CounterITest extends BaseMetricsITest {
         assertEquals((Integer) testSize, bucket.getSamples());
         assertEquals(percentiles.size(), bucket.getPercentiles().size());
         assertEquals(top.getResult(), bucket.getPercentiles().get(3).getValue());
+    }
+
+    @Test
+    public void addAndCompressData() throws Exception {
+        String tenantId = "t1-counter";
+        DateTime dt = new DateTime(2016, 9, 2, 14, 15); // Causes writes to go to compressed and one uncompressed row
+        DateTimeUtils.setCurrentMillisFixed(dt.getMillis());
+
+        DateTime start = dt.minusMinutes(30);
+        DateTime end = start.plusMinutes(20);
+
+        MetricId<Long> mId = new MetricId<>(tenantId, COUNTER, "m1");
+
+        metricsService.createTenant(new Tenant(tenantId), false).toBlocking().lastOrDefault(null);
+
+        Metric<Long> m1 = new Metric<>(mId, asList(
+                new DataPoint<>(start.getMillis(), 1L),
+                new DataPoint<>(start.plusMinutes(2).getMillis(), 2L),
+                new DataPoint<>(start.plusMinutes(4).getMillis(), 3L),
+                new DataPoint<>(end.getMillis(), 4L)));
+
+        Observable<Void> insertObservable = metricsService.addDataPoints(COUNTER, Observable.just(m1));
+        insertObservable.toBlocking().lastOrDefault(null);
+
+        metricsService.compressBlock(Observable.just(mId), DateTimeService.getTimeSlice(start.getMillis(), Duration
+                .standardHours(2)))
+                .doOnError(Throwable::printStackTrace).toBlocking().lastOrDefault(null);
+
+        Observable<DataPoint<Long>> observable = metricsService.findDataPoints(mId, start.getMillis(),
+                end.getMillis() + 1, 0, Order.DESC);
+        List<DataPoint<Long>> actual = toList(observable);
+        List<DataPoint<Long>> expected = asList(
+                new DataPoint<>(end.getMillis(), 4L),
+                new DataPoint<>(start.plusMinutes(4).getMillis(), 3L),
+                new DataPoint<>(start.plusMinutes(2).getMillis(), 2L),
+                new DataPoint<>(start.getMillis(), 1L));
+
+        assertEquals(actual, expected, "The data does not match the expected values");
+        assertMetricIndexMatches(tenantId, COUNTER, singletonList(new Metric<>(m1.getMetricId(), m1.getDataPoints(),
+                7)));
+
+        observable = metricsService.findDataPoints(mId, start.getMillis(),
+                end.getMillis(), 0, Order.DESC);
+        actual = toList(observable);
+        assertEquals(3, actual.size(), "Last datapoint should be missing (<)");
+
+        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test


### PR DESCRIPTION
This changes the usage of gorilla-tsc by avoiding storing with compressValue(long, long). This compression version has bug in it that might in some cases return wrong values from the compressed block.

This change avoids that issue.