### PR TITLE
HWKMETRICS-515 Make external alerter cluster-aware

### DIFF
--- a/alerting/alerter-war/pom.xml
+++ b/alerting/alerter-war/pom.xml
@@ -31,8 +31,12 @@
 
   <name>Hawkular Metrics External Alerter</name>
 
-  <dependencies>
+  <properties>
+    <version.javaee.spec>7.0</version.javaee.spec>
+    <version.org.infinispan.wildfly>8.0.1.Final</version.org.infinispan.wildfly>
+  </properties>
 
+  <dependencies>
     <!-- Hawkular Alerting dependencies -->
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
@@ -78,7 +82,14 @@
     <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>7.0</version>
+      <version>${version.javaee.spec}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-core</artifactId>
+      <version>${version.org.infinispan.wildfly}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -88,7 +99,6 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/alerting/alerter-war/src/main/webapp/WEB-INF/web.xml
+++ b/alerting/alerter-war/src/main/webapp/WEB-INF/web.xml
@@ -24,4 +24,9 @@
   <display-name>Hawkular Metrics: External Alerter</display-name>
   <description>A Hawkular Alerting External Alerter for alerting on aggregate Hawkular Metrics data.</description>
 
+  <resource-env-ref>
+    <resource-env-ref-name>container/hawkular-alerts</resource-env-ref-name>
+    <lookup-name>java:jboss/infinispan/container/hawkular-alerts</lookup-name>
+  </resource-env-ref>
+
 </web-app>


### PR DESCRIPTION
- use ISPN CacheManager to inspect and react to cluster topology
- limit expression evaluation to only the cooridinater node