### PR TITLE
[HWKMETRICS-520] make query page size configurable

### DIFF
--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -47,6 +47,8 @@ public enum ConfigurationKey {
             "CASSANDRA_CONNECTION_TIMEOUT", false),
     CASSANDRA_SCHEMA_REFRESH_INTERVAL("hawkular.metrics.cassandra.schema.refresh-interval", "1000",
             "CASSANDRA_SCHEMA_REFRESH_INTERVAL", false),
+    PAGE_SIZE("hawkular.metrics.page-size", "5000", "PAGE_SIZE", false),
+    COMPRESSION_QUERY_PAGE_SIZE("hawkular.metrics.compression.page-size", "1000", "COMPRESSION_PAGE_SIZE", false),
     WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
     DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false),
     DISABLE_METRICS_JMX("hawkular.metrics.disable-metrics-jmx-reporting", null, "DISABLE_METRICS_JMX", true),

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -47,7 +47,7 @@ public enum ConfigurationKey {
             "CASSANDRA_CONNECTION_TIMEOUT", false),
     CASSANDRA_SCHEMA_REFRESH_INTERVAL("hawkular.metrics.cassandra.schema.refresh-interval", "1000",
             "CASSANDRA_SCHEMA_REFRESH_INTERVAL", false),
-    PAGE_SIZE("hawkular.metrics.page-size", "5000", "PAGE_SIZE", false),
+    PAGE_SIZE("hawkular.metrics.page-size", "1000", "PAGE_SIZE", false),
     COMPRESSION_QUERY_PAGE_SIZE("hawkular.metrics.compression.page-size", "1000", "COMPRESSION_PAGE_SIZE", false),
     WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
     DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false),

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImpl.java
@@ -102,7 +102,7 @@ public class JobsServiceImpl implements JobsService {
 
         Boolean compressionEnabled = Boolean.valueOf(configuration.get(CompressData.ENABLED_CONFIG, "true"));
         if(compressionEnabled) {
-            CompressData compressDataJob = new CompressData(metricsService);
+            CompressData compressDataJob = new CompressData(metricsService, configurationService);
             scheduler.register(CompressData.JOB_NAME, compressDataJob);
             maybeScheduleCompressData(backgroundJobs);
         }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -75,17 +75,20 @@ public interface DataAccess {
 
     Observable<Integer> insertCounterData(Metric<Long> counter, int ttl);
 
-    Observable<Row> findCounterData(MetricId<Long> id, long startTime, long endTime, int limit, Order order);
+    Observable<Row> findCounterData(MetricId<Long> id, long startTime, long endTime, int limit, Order order,
+            int pageSize);
 
     Observable<Row> findCompressedData(MetricId<?> id, long startTime, long endTime, int limit, Order
             order);
 
-    Observable<Row> findGaugeData(MetricId<Double> id, long startTime, long endTime, int limit, Order order);
+    Observable<Row> findGaugeData(MetricId<Double> id, long startTime, long endTime, int limit, Order order,
+            int pageSize);
 
-    Observable<Row> findStringData(MetricId<String> id, long startTime, long endTime, int limit, Order order);
+    Observable<Row> findStringData(MetricId<String> id, long startTime, long endTime, int limit, Order order,
+            int pageSize);
 
     Observable<Row> findAvailabilityData(MetricId<AvailabilityType> id, long startTime, long endTime, int limit,
-            Order order);
+            Order order, int pageSize);
 
     Observable<Row> findAvailabilityData(MetricId<AvailabilityType> id, long timestamp);
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
@@ -737,27 +737,31 @@ public class DataAccessImpl implements DataAccess {
     }
 
     @Override
-    public Observable<Row> findCounterData(MetricId<Long> id, long startTime, long endTime, int limit,
-            Order order) {
+    public Observable<Row> findCounterData(MetricId<Long> id, long startTime, long endTime, int limit, Order order,
+            int pageSize) {
         if (order == Order.ASC) {
             if (limit <= 0) {
                 return rxSession
                         .executeAndFetch(findCounterDataExclusiveASC.bind(id.getTenantId(), COUNTER.getCode(),
-                                id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+                                id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime))
+                                .setFetchSize(pageSize));
             } else {
                 return rxSession
                         .executeAndFetch(findCounterDataExclusiveWithLimitASC.bind(id.getTenantId(), COUNTER.getCode(),
-                                id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime), limit));
+                                id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime), limit)
+                                .setFetchSize(pageSize));
             }
         } else {
             if (limit <= 0) {
                 return rxSession
                         .executeAndFetch(findCounterDataExclusive.bind(id.getTenantId(), COUNTER.getCode(),
-                                id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+                                id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime))
+                                .setFetchSize(pageSize));
             } else {
                 return rxSession
                         .executeAndFetch(findCounterDataExclusiveWithLimit.bind(id.getTenantId(), COUNTER.getCode(),
-                                id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime), limit));
+                                id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime), limit)
+                                .setFetchSize(pageSize));
             }
         }
     }
@@ -787,71 +791,79 @@ public class DataAccessImpl implements DataAccess {
     }
 
     @Override
-    public Observable<Row> findGaugeData(MetricId<Double> id, long startTime, long endTime, int limit, Order order) {
+    public Observable<Row> findGaugeData(MetricId<Double> id, long startTime, long endTime, int limit, Order order,
+            int pageSize) {
         if (order == Order.ASC) {
             if (limit <= 0) {
                 return rxSession.executeAndFetch(findGaugeDataByDateRangeExclusiveASC.bind(id.getTenantId(),
-                        GAUGE.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+                        GAUGE.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime))
+                        .setFetchSize(pageSize));
             } else {
                 return rxSession.executeAndFetch(findGaugeDataByDateRangeExclusiveWithLimitASC.bind(
                         id.getTenantId(), GAUGE.getCode(), id.getName(), DPART, getTimeUUID(startTime),
-                        getTimeUUID(endTime), limit));
+                        getTimeUUID(endTime), limit)
+                        .setFetchSize(pageSize));
             }
         } else {
             if (limit <= 0) {
                 return rxSession.executeAndFetch(findGaugeDataByDateRangeExclusive.bind(id.getTenantId(),
-                        GAUGE.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+                        GAUGE.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime))
+                        .setFetchSize(pageSize));
             } else {
                 return rxSession.executeAndFetch(findGaugeDataByDateRangeExclusiveWithLimit.bind(id.getTenantId(),
                         GAUGE.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime),
-                        limit));
+                        limit).setFetchSize(pageSize));
             }
         }
     }
 
     @Override
-    public Observable<Row> findStringData(MetricId<String> id, long startTime, long endTime, int limit, Order order) {
+    public Observable<Row> findStringData(MetricId<String> id, long startTime, long endTime, int limit, Order order,
+            int pageSize) {
         if (order == Order.ASC) {
             if (limit <= 0) {
                 return rxSession.executeAndFetch(findStringDataByDateRangeExclusiveASC.bind(id.getTenantId(),
-                        STRING.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+                        STRING.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime))
+                        .setFetchSize(pageSize));
             } else {
                 return rxSession.executeAndFetch(findStringDataByDateRangeExclusiveWithLimitASC.bind(
                         id.getTenantId(), STRING.getCode(), id.getName(), DPART, getTimeUUID(startTime),
-                        getTimeUUID(endTime), limit));
+                        getTimeUUID(endTime), limit).setFetchSize(pageSize));
             }
         } else {
             if (limit <= 0) {
                 return rxSession.executeAndFetch(findStringDataByDateRangeExclusive.bind(id.getTenantId(),
-                        STRING.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+                        STRING.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime))
+                        .setFetchSize(pageSize));
             } else {
                 return rxSession.executeAndFetch(findStringDataByDateRangeExclusiveWithLimit.bind(id.getTenantId(),
                         STRING.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime),
-                        limit));
+                        limit).setFetchSize(pageSize));
             }
         }
     }
 
     @Override
     public Observable<Row> findAvailabilityData(MetricId<AvailabilityType> id, long startTime, long endTime,
-            int limit, Order order) {
+            int limit, Order order, int pageSize) {
         if (order == Order.ASC) {
             if (limit <= 0) {
                 return rxSession.executeAndFetch(findAvailabilitiesASC.bind(id.getTenantId(),
-                        AVAILABILITY.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+                        AVAILABILITY.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime))
+                        .setFetchSize(pageSize));
             } else {
                 return rxSession.executeAndFetch(findAvailabilitiesWithLimitASC.bind(id.getTenantId(),
                         AVAILABILITY.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime),
-                        limit));
+                        limit).setFetchSize(pageSize));
             }
         } else {
             if (limit <= 0) {
                 return rxSession.executeAndFetch(findAvailabilities.bind(id.getTenantId(), AVAILABILITY.getCode(),
-                        id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)));
+                        id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime)).setFetchSize(pageSize));
             } else {
                 return rxSession.executeAndFetch(findAvailabilitiesWithLimit.bind(id.getTenantId(),
                         AVAILABILITY.getCode(), id.getName(), DPART, getTimeUUID(startTime), getTimeUUID(endTime),
-                        limit));
+                        limit).setFetchSize(pageSize));
             }
         }
     }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -166,7 +166,10 @@ public interface MetricsService {
      */
     <T> Observable<DataPoint<T>> findDataPoints(MetricId<T> id, long start, long end, int limit, Order order);
 
-    Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long timeSlice);
+    <T> Observable<DataPoint<T>> findDataPoints(MetricId<T> id, long start, long end, int limit, Order order,
+            int pageSize);
+
+    Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long timeSlice, int pageSize);
 
     <T> Observable<NamedDataPoint<T>> findDataPoints(List<MetricId<T>> ids, long start, long end, int limit,
                                                      Order order);

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/CompressDataJobITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/CompressDataJobITest.java
@@ -22,10 +22,14 @@ import static org.hawkular.metrics.core.jobs.CompressData.JOB_NAME;
 import static org.hawkular.metrics.model.MetricType.AVAILABILITY;
 import static org.hawkular.metrics.model.MetricType.COUNTER;
 import static org.hawkular.metrics.model.MetricType.GAUGE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertNotNull;
+//import static org.junit.Assert.assertNull;
+//import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
@@ -55,6 +55,8 @@ public class DataAccessITest extends BaseITest {
 
     private static int DEFAULT_TTL = 600;
 
+    private static int DEFAULT_PAGE_SIZE = 5000;
+
     private DataAccessImpl dataAccess;
 
     private PreparedStatement truncateTenants;
@@ -118,7 +120,7 @@ public class DataAccessITest extends BaseITest {
         dataAccess.insertGaugeData(metric, DEFAULT_TTL).toBlocking().last();
 
         Observable<Row> observable = dataAccess.findGaugeData(new MetricId<>("tenant-1", GAUGE, "metric-1"),
-                start.getMillis(), end.getMillis(), 0, Order.DESC);
+                start.getMillis(), end.getMillis(), 0, Order.DESC, DEFAULT_PAGE_SIZE);
         List<DataPoint<Double>> actual = ImmutableList.copyOf(observable
                 .map(Functions::getGaugeDataPoint)
                 .toBlocking()
@@ -149,7 +151,7 @@ public class DataAccessITest extends BaseITest {
         dataAccess.insertGaugeData(metric, DEFAULT_TTL).toBlocking().last();
 
         Observable<Row> observable = dataAccess.findGaugeData(new MetricId<>("tenant-1", GAUGE, "metric-1"),
-                start.getMillis(), end.getMillis(), 0, Order.DESC);
+                start.getMillis(), end.getMillis(), 0, Order.DESC, DEFAULT_PAGE_SIZE);
         List<DataPoint<Double>> actual = ImmutableList.copyOf(observable
                 .map(Functions::getGaugeDataPoint)
                 .toBlocking()
@@ -176,7 +178,7 @@ public class DataAccessITest extends BaseITest {
 
         List<DataPoint<AvailabilityType>> actual = dataAccess
                 .findAvailabilityData(new MetricId<>(tenantId, AVAILABILITY, "m1"), start.getMillis(), end.getMillis(),
-                        0, Order.DESC)
+                        0, Order.DESC, DEFAULT_PAGE_SIZE)
                 .map(Functions::getAvailabilityDataPoint)
                 .toList().toBlocking().lastOrDefault(null);
         List<DataPoint<AvailabilityType>> expected = singletonList(new DataPoint<AvailabilityType>(start.getMillis(),

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -122,8 +122,8 @@ public class DelegatingDataAccess implements DataAccess {
 
     @Override
     public Observable<Row> findCounterData(MetricId<Long> id, long startTime, long endTime, int limit,
-            Order order) {
-        return delegate.findCounterData(id, startTime, endTime, limit, order);
+            Order order, int pageSize) {
+        return delegate.findCounterData(id, startTime, endTime, limit, order, pageSize);
     }
 
     @Override
@@ -132,8 +132,9 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<Row> findGaugeData(MetricId<Double> id, long startTime, long endTime, int limit, Order order) {
-        return delegate.findGaugeData(id, startTime, endTime, limit, order);
+    public Observable<Row> findGaugeData(MetricId<Double> id, long startTime, long endTime, int limit, Order order,
+            int pageSize) {
+        return delegate.findGaugeData(id, startTime, endTime, limit, order, pageSize);
     }
 
     @Override
@@ -152,14 +153,15 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<Row> findStringData(MetricId<String> id, long startTime, long endTime, int limit, Order order) {
-        return delegate.findStringData(id, startTime, endTime, limit, order);
+    public Observable<Row> findStringData(MetricId<String> id, long startTime, long endTime, int limit, Order order,
+            int pageSize) {
+        return delegate.findStringData(id, startTime, endTime, limit, order, pageSize);
     }
 
     @Override
     public Observable<Row> findAvailabilityData(MetricId<AvailabilityType> id, long startTime, long endTime,
-            int limit, Order order) {
-        return delegate.findAvailabilityData(id, startTime, endTime, limit, order);
+            int limit, Order order, int pageSize) {
+        return delegate.findAvailabilityData(id, startTime, endTime, limit, order, pageSize);
     }
 
     @Override

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/AvailabilityITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/AvailabilityITest.java
@@ -61,7 +61,6 @@ public class AvailabilityITest extends BaseMetricsITest {
     @BeforeClass
     public void initClass() {
         super.initClass();
-
         insertAvailabilityDateWithTimestamp = session.prepare(
                 "INSERT INTO data (tenant_id, type, metric, dpart, time, availability) " +
                         "VALUES (?, ?, ?, ?, ?, ?) " +

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
@@ -64,6 +64,8 @@ public abstract class BaseMetricsITest extends BaseITest {
 
     protected static final int DEFAULT_TTL = 7; //days
 
+    protected static final int COMPRESSION_PAGE_SIZE = 1000;
+
     protected MetricsServiceImpl metricsService;
 
     protected DataAccess dataAccess;

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
@@ -254,7 +254,7 @@ public class CounterITest extends BaseMetricsITest {
         insertObservable.toBlocking().lastOrDefault(null);
 
         metricsService.compressBlock(Observable.just(mId), DateTimeService.getTimeSlice(start.getMillis(), Duration
-                .standardHours(2)))
+                .standardHours(2)), COMPRESSION_PAGE_SIZE)
                 .doOnError(Throwable::printStackTrace).toBlocking().lastOrDefault(null);
 
         Observable<DataPoint<Long>> observable = metricsService.findDataPoints(mId, start.getMillis(),

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
@@ -365,7 +365,7 @@ public class GaugeITest extends BaseMetricsITest {
         insertObservable.toBlocking().lastOrDefault(null);
 
         metricsService.compressBlock(Observable.just(mId), DateTimeService.getTimeSlice(start.getMillis(), Duration
-                .standardHours(2)))
+                .standardHours(2)), COMPRESSION_PAGE_SIZE)
                 .doOnError(Throwable::printStackTrace).toBlocking().lastOrDefault(null);
 
         Observable<DataPoint<Double>> observable = metricsService.findDataPoints(mId, start.getMillis(),
@@ -435,7 +435,7 @@ public class GaugeITest extends BaseMetricsITest {
         expected = expectCreator.apply(cStart);
 
         metricsService.compressBlock(Observable.just(mId), DateTimeService.getTimeSlice(cStart.getMillis(), Duration
-                .standardHours(2))).toBlocking().lastOrDefault(null);
+                .standardHours(2)), COMPRESSION_PAGE_SIZE).toBlocking().lastOrDefault(null);
 
         actual = toList(metricsService.findDataPoints(new MetricId<>(tenantId, GAUGE, "m1"),
                 cStart.plusMinutes(1).getMillis(), end, 3, Order.ASC));


### PR DESCRIPTION
The compression job defaults to a page size of 1,000. This only effects queries
on raw data.
