### PR TITLE
[HWKMETRICS-524] add flag for disabling compression job

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -32,6 +32,7 @@ import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_R
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_RESETDB;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_SCHEMA_REFRESH_INTERVAL;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_USESSL;
+import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.COMPRESSION_JOB_ENABLED;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.COMPRESSION_QUERY_PAGE_SIZE;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.DEFAULT_TTL;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.DISABLE_METRICS_JMX;
@@ -213,6 +214,11 @@ public class MetricsServiceLifecycle {
     @Configurable
     @ConfigurationProperty(COMPRESSION_QUERY_PAGE_SIZE)
     private String compressionPageSize;
+
+    @Inject
+    @Configurable
+    @ConfigurationProperty(COMPRESSION_JOB_ENABLED)
+    private String compressionJobEnabled;
 
     @Inject
     DriverUsageMetricsManager driverUsageMetricsManager;
@@ -523,6 +529,10 @@ public class MetricsServiceLifecycle {
                         .toCompletable()
                         .await(10, SECONDS);
             }
+        }
+
+        if (compressionJobEnabled != null) {
+            configurationService.save(CompressData.CONFIG_ID, "enabled", compressionJobEnabled);
         }
     }
 

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -49,6 +49,7 @@ public enum ConfigurationKey {
             "CASSANDRA_SCHEMA_REFRESH_INTERVAL", false),
     PAGE_SIZE("hawkular.metrics.page-size", "1000", "PAGE_SIZE", false),
     COMPRESSION_QUERY_PAGE_SIZE("hawkular.metrics.compression.page-size", "1000", "COMPRESSION_PAGE_SIZE", false),
+    COMPRESSION_JOB_ENABLED("hawkular.metrics.jobs.compression.enabled", null, "COMPRESSION_JOB_ENABLED", false),
     WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
     DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false),
     DISABLE_METRICS_JMX("hawkular.metrics.disable-metrics-jmx-reporting", null, "DISABLE_METRICS_JMX", true),

--- a/core/configuration-service/src/main/java/org/hawkular/metrics/sysconfig/Configuration.java
+++ b/core/configuration-service/src/main/java/org/hawkular/metrics/sysconfig/Configuration.java
@@ -17,6 +17,7 @@
 package org.hawkular.metrics.sysconfig;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -27,6 +28,11 @@ public class Configuration {
     private String id;
 
     private Map<String, String> properties;
+
+    public Configuration(String id) {
+        this.id = id;
+        properties = new HashMap<>();
+    }
 
     public Configuration(String id, Map<String, String> properties) {
         this.id = id;

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/CompressData.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/CompressData.java
@@ -48,7 +48,6 @@ public class CompressData implements Func1<JobDetails, Completable> {
     private static Logger logger = Logger.getLogger(CompressData.class);
 
     public static final String JOB_NAME = "COMPRESS_DATA";
-    public static final String ENABLED_CONFIG = "compression.enabled";
     public static final String BLOCK_SIZE = "compression.block.size";
     public static final String CONFIG_ID = "org.hawkular.metrics.jobs." + JOB_NAME;
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImpl.java
@@ -100,12 +100,9 @@ public class JobsServiceImpl implements JobsService {
                 };
         scheduler.register(DeleteTenant.JOB_NAME, deleteTenant, deleteTenantRetryPolicy);
 
-        Boolean compressionEnabled = Boolean.valueOf(configuration.get(CompressData.ENABLED_CONFIG, "true"));
-        if(compressionEnabled) {
-            CompressData compressDataJob = new CompressData(metricsService, configurationService);
-            scheduler.register(CompressData.JOB_NAME, compressDataJob);
-            maybeScheduleCompressData(backgroundJobs);
-        }
+        CompressData compressDataJob = new CompressData(metricsService, configurationService);
+        scheduler.register(CompressData.JOB_NAME, compressDataJob);
+        maybeScheduleCompressData(backgroundJobs);
 
         return backgroundJobs;
     }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -667,51 +667,6 @@ public class MetricsServiceImpl implements MetricsService {
     @Override
     public <T> Observable<DataPoint<T>> findDataPoints(MetricId<T> metricId, long start, long end, int limit,
             Order order) {
-//        checkArgument(isValidTimeRange(start, end), "Invalid time range");
-//        Order safeOrder = (null == order) ? Order.ASC : order;
-//        MetricType<T> metricType = metricId.getType();
-//        Timer timer = getDataPointFindTimer(metricType);
-//        Func1<Row, DataPoint<T>> mapper = getDataPointMapper(metricType);
-//
-//        Func6<MetricId<T>, Long, Long, Integer, Order, Integer, Observable<Row>> finder =
-//                getDataPointFinder(metricType);
-//
-//        if(metricType == GAUGE || metricType == AVAILABILITY || metricType == COUNTER) {
-//            long sliceStart = DateTimeService.getTimeSlice(start, Duration.standardHours(2));
-//
-//            Observable<DataPoint<T>> uncompressedPoints = finder.call(metricId, start, end, limit, safeOrder)
-//                    .map(mapper);
-//
-//            Observable<DataPoint<T>> compressedPoints =
-//                    dataAccess.findCompressedData(metricId, sliceStart, end, limit, safeOrder)
-//                            .compose(new DataPointDecompressTransformer(metricType, safeOrder, limit, start, end));
-//
-//            Comparator<DataPoint<T>> comparator;
-//
-//            switch(safeOrder) {
-//                case ASC:
-//                    comparator = (tDataPoint, t1) -> (int) (tDataPoint.getTimestamp() - t1.getTimestamp());
-//                    break;
-//                case DESC:
-//                    comparator = (tDataPoint, t1) -> (int) (t1.getTimestamp() - tDataPoint.getTimestamp());
-//                    break;
-//                default:
-//                    throw new RuntimeException(safeOrder.toString() + " is not correct sorting order");
-//            }
-//
-//            Observable<DataPoint<T>> dataPoints = SortedMerge
-//                    .create(Arrays.asList(uncompressedPoints, compressedPoints), comparator, false, true);
-//
-//            if(limit > 0) {
-//                dataPoints = dataPoints.take(limit);
-//            }
-//
-//            return dataPoints;
-//        }
-//
-//        return time(timer, () -> finder.call(metricId, start, end, limit, safeOrder)
-//                .map(mapper));
-
         return findDataPoints(metricId, start, end, limit, order, defaultPageSize);
     }
 

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/CompressDataJobITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/CompressDataJobITest.java
@@ -26,10 +26,6 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.assertNotNull;
-//import static org.junit.Assert.assertNull;
-//import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -72,6 +68,11 @@ import com.google.common.collect.ImmutableMap;
 
 import rx.Observable;
 import rx.observers.TestSubscriber;
+
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertNotNull;
+//import static org.junit.Assert.assertNull;
+//import static org.junit.Assert.assertTrue;
 
 /**
  * Test the compression ETL jobs


### PR DESCRIPTION
The job can be enabled/disabled with either the system property

```
-Dhawkular.metrics.jobs.compression.enabled=false
```

or using the environment variable

`export COMPRESSION_JOB_ENABLED=false`

The job actually still runs but is just a no-op. This is important from a job scheduling standpoint. 
suppose the job is disabled just before 13:00, and it is re-enabled at 23:00. Raw data ingested
between 11:00 and 21:00 will not get compressed.

This has to be merged after [PR 665](https://github.com/hawkular/hawkular-metrics/pull/665).
