### PR TITLE
[HWKMETRICS-532] Add /tags endpoint which fetches available tag names

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -149,9 +149,11 @@ public class MetricHandler {
             @ApiResponse(code = 500, message = "Unexpected error occurred while fetching tags.",
                     response = ApiError.class)
     })
-    public void getTagNames(@Suspended final AsyncResponse asyncResponse,
-                            @ApiParam(value = "Tag name regexp filter") @QueryParam("filter") String tagNameFilter) {
-        metricsService.getTagNames(getTenant(), tagNameFilter)
+    public <T> void getTagNames(@Suspended final AsyncResponse asyncResponse,
+                            @ApiParam(value = "Tag name regexp filter") @QueryParam("filter") String tagNameFilter,
+                            @ApiParam(value = "Tags applied to defined metric type", allowableValues = "gauge, " +
+                                    "availability, counter, string") @QueryParam("type") MetricType<T> metricType) {
+        metricsService.getTagNames(getTenant(), metricType, tagNameFilter)
                 .toList()
                 .map(ApiUtils::collectionToResponse)
                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
@@ -167,7 +169,8 @@ public class MetricHandler {
                     response = ApiError.class)
     })
     public <T> void getTags(@Suspended final AsyncResponse asyncResponse,
-                            @ApiParam(value = "Queried metric type", allowableValues = "gauge, availability, counter")
+                            @ApiParam(value = "Queried metric type", allowableValues = "gauge, availability, counter," +
+                                    " string")
                             @QueryParam("type") MetricType<T> metricType,
                             @ApiParam("Tag query") @PathParam("tags") Tags tags) {
         metricsService.getTagValues(getTenant(), metricType, tags.getTags())

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -141,6 +141,23 @@ public class MetricHandler {
     }
 
     @GET
+    @Path("/tags")
+    @ApiOperation(value = "Retrieve available tag names", response = List.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Tags successfully retrieved."),
+            @ApiResponse(code = 204, message = "No tags were found"),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching tags.",
+                    response = ApiError.class)
+    })
+    public void getTagNames(@Suspended final AsyncResponse asyncResponse,
+                            @ApiParam(value = "Tag name regexp filter") @QueryParam("filter") String tagNameFilter) {
+        metricsService.getTagNames(getTenant(), tagNameFilter)
+                .toList()
+                .map(ApiUtils::collectionToResponse)
+                .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.serverError(t)));
+    }
+
+    @GET
     @Path("/tags/{tags}")
     @ApiOperation(value = "Retrieve metrics' tag values", response = Map.class)
     @ApiResponses(value = {

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -55,6 +55,8 @@ public interface DataAccess {
 
     Observable<Row> getTagNames();
 
+    Observable<Row> getTagNamesWithType();
+
     <T> Observable<ResultSet> addTags(Metric<T> metric, Map<String, String> tags);
 
     <T> Observable<ResultSet> deleteTags(Metric<T> metric, Set<String> tags);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -53,6 +53,8 @@ public interface DataAccess {
 
     <T> Observable<Row> getMetricTags(MetricId<T> id);
 
+    Observable<Row> getTagNames();
+
     <T> Observable<ResultSet> addTags(Metric<T> metric, Map<String, String> tags);
 
     <T> Observable<ResultSet> deleteTags(Metric<T> metric, Set<String> tags);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
@@ -95,6 +95,8 @@ public class DataAccessImpl implements DataAccess {
 
     private PreparedStatement getTagNames;
 
+    private PreparedStatement getTagNamesWithType;
+
     private PreparedStatement insertGaugeData;
 
     private PreparedStatement insertCompressedData;
@@ -237,8 +239,12 @@ public class DataAccessImpl implements DataAccess {
             "WHERE tenant_id = ? AND type = ? AND metric = ?");
 
         getTagNames = session.prepare(
-        "SELECT DISTINCT tenant_id, tname " +
-                "FROM metrics_tags_idx"); // Cassandra 3.10 will allow filtering by tenant_id
+                "SELECT DISTINCT tenant_id, tname " +
+                        "FROM metrics_tags_idx"); // Cassandra 3.10 will allow filtering by tenant_id
+
+        getTagNamesWithType = session.prepare(
+                "SELECT tenant_id, tname, type " +
+                        "FROM metrics_tags_idx");
 
         insertIntoMetricsIndex = session.prepare(
             "INSERT INTO metrics_idx (tenant_id, type, metric, data_retention, tags) " +
@@ -583,6 +589,11 @@ public class DataAccessImpl implements DataAccess {
     @Override
     public Observable<Row> getTagNames() {
         return rxSession.executeAndFetch(getTagNames.bind());
+    }
+
+    @Override
+    public Observable<Row> getTagNamesWithType() {
+        return rxSession.executeAndFetch(getTagNamesWithType.bind());
     }
 
     @Override

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
@@ -93,6 +93,8 @@ public class DataAccessImpl implements DataAccess {
 
     private PreparedStatement getMetricTags;
 
+    private PreparedStatement getTagNames;
+
     private PreparedStatement insertGaugeData;
 
     private PreparedStatement insertCompressedData;
@@ -233,6 +235,10 @@ public class DataAccessImpl implements DataAccess {
             "SELECT tags " +
             "FROM metrics_idx " +
             "WHERE tenant_id = ? AND type = ? AND metric = ?");
+
+        getTagNames = session.prepare(
+        "SELECT DISTINCT tenant_id, tname " +
+                "FROM metrics_tags_idx"); // Cassandra 3.10 will allow filtering by tenant_id
 
         insertIntoMetricsIndex = session.prepare(
             "INSERT INTO metrics_idx (tenant_id, type, metric, data_retention, tags) " +
@@ -572,6 +578,11 @@ public class DataAccessImpl implements DataAccess {
     @Override
     public <T> Observable<Row> getMetricTags(MetricId<T> id) {
         return rxSession.executeAndFetch(getMetricTags.bind(id.getTenantId(), id.getType().getCode(), id.getName()));
+    }
+
+    @Override
+    public Observable<Row> getTagNames() {
+        return rxSession.executeAndFetch(getTagNames.bind());
     }
 
     @Override

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -138,7 +138,7 @@ public interface MetricsService {
 
     Observable<Map<String, String>> getMetricTags(MetricId<?> id);
 
-    Observable<String> getTagNames(String tenantId, String filter);
+    Observable<String> getTagNames(String tenantId, MetricType<?> metricType, String filter);
 
     Observable<Void> addTags(Metric<?> metric, Map<String, String> tags);
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -138,6 +138,8 @@ public interface MetricsService {
 
     Observable<Map<String, String>> getMetricTags(MetricId<?> id);
 
+    Observable<String> getTagNames(String tenantId, String filter);
+
     Observable<Void> addTags(Metric<?> metric, Map<String, String> tags);
 
     Observable<Void> deleteTags(Metric<?> metric, Set<String> tags);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -567,8 +567,8 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    public Observable<String> getTagNames(String tenantId, String filter) {
-        return tagQueryParser.getTagNames(tenantId, filter);
+    public Observable<String> getTagNames(String tenantId, MetricType<?> metricType, String filter) {
+        return tagQueryParser.getTagNames(tenantId, metricType, filter);
     }
 
     // Adding/deleting metric tags currently involves writing to three tables - data,

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -566,6 +566,11 @@ public class MetricsServiceImpl implements MetricsService {
                 .defaultIfEmpty(new HashMap<>());
     }
 
+    @Override
+    public Observable<String> getTagNames(String tenantId, String filter) {
+        return tagQueryParser.getTagNames(tenantId, filter);
+    }
+
     // Adding/deleting metric tags currently involves writing to three tables - data,
     // metrics_idx, and metrics_tags_idx. It might make sense to refactor tag related
     // functionality into a separate class.

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/TagQueryParser.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/TagQueryParser.java
@@ -199,8 +199,25 @@ public class TagQueryParser {
                 });
     }
 
+    public Observable<String> getTagNames(String tenantId, String filter) {
+        return dataAccess.getTagNames()
+                .filter(r -> tenantId.equals(r.getString(0)))
+                .map(r -> r.getString(1))
+                .distinct()
+                .filter(tagNameFilter(filter));
+    }
+
     private Func1<Metric<?>, Boolean> tagNotExistsFilter(String unwantedTagName) {
         return tMetric -> !tMetric.getTags().keySet().contains(unwantedTagName);
+    }
+
+    private Func1<String, Boolean> tagNameFilter(String regexp) {
+        if(regexp != null) {
+            boolean positive = (!regexp.startsWith("!"));
+            Pattern p = PatternUtil.filterPattern(regexp);
+            return s -> positive == p.matcher(s).matches(); // XNOR
+        }
+        return s -> true;
     }
 
     private Func1<Row, Boolean> tagValueFilter(String regexp, int index) {

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/TagQueryParser.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/TagQueryParser.java
@@ -149,7 +149,7 @@ public class TagQueryParser {
         // Row: 0 = type, 1 = metricName, 2 = tagValue, e.getKey = tagName, e.getValue = regExp
         return Observable.from(tagsQueries.entrySet())
                 .flatMap(e -> dataAccess.findMetricsByTagName(tenantId, e.getKey())
-                        .filter(typeFilter(metricType))
+                        .filter(typeFilter(metricType, 1))
                         .filter(tagValueFilter(e.getValue(), 3))
                         .map(row -> {
                             Map<String, Map<String, String>> idMap = new HashMap<>();
@@ -199,12 +199,22 @@ public class TagQueryParser {
                 });
     }
 
-    public Observable<String> getTagNames(String tenantId, String filter) {
-        return dataAccess.getTagNames()
-                .filter(r -> tenantId.equals(r.getString(0)))
-                .map(r -> r.getString(1))
-                .distinct()
-                .filter(tagNameFilter(filter));
+    public Observable<String> getTagNames(String tenantId, MetricType<?> metricType, String filter) {
+        Observable<String> tagNames;
+        if(metricType == null) {
+            tagNames = dataAccess.getTagNames()
+                    .filter(r -> tenantId.equals(r.getString(0)))
+                    .map(r -> r.getString(1))
+                    .distinct();
+        } else {
+            // This query is slower than without type - we have to request all the rows, not just partition keys
+            tagNames = dataAccess.getTagNamesWithType()
+                    .filter(typeFilter(metricType, 2))
+                    .filter(r -> tenantId.equals(r.getString(0)))
+                    .map(r -> r.getString(1))
+                    .distinct();
+        }
+        return tagNames.filter(tagNameFilter(filter));
     }
 
     private Func1<Metric<?>, Boolean> tagNotExistsFilter(String unwantedTagName) {
@@ -226,9 +236,9 @@ public class TagQueryParser {
         return r -> positive == p.matcher(r.getString(index)).matches(); // XNOR
     }
 
-    public Func1<Row, Boolean> typeFilter(MetricType<?> type) {
+    public Func1<Row, Boolean> typeFilter(MetricType<?> type, int index) {
         return row -> {
-            MetricType<?> metricType = MetricType.fromCode(row.getByte(1));
+            MetricType<?> metricType = MetricType.fromCode(row.getByte(index));
             return (type == null && metricType.isUserType()) || metricType == type;
         };
     }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -80,6 +80,10 @@ public class DelegatingDataAccess implements DataAccess {
         return delegate.getMetricTags(id);
     }
 
+    @Override public Observable<Row> getTagNames() {
+        return delegate.getTagNames();
+    }
+
     @Override
     public <T> Observable<ResultSet> addTags(Metric<T> metric, Map<String, String> tags) {
         return delegate.addTags(metric, tags);

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -85,6 +85,11 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
+    public Observable<Row> getTagNamesWithType() {
+        return delegate.getTagNamesWithType();
+    }
+
+    @Override
     public <T> Observable<ResultSet> addTags(Metric<T> metric, Map<String, String> tags) {
         return delegate.addTags(metric, tags);
     }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
@@ -209,7 +209,7 @@ public class TagsITest extends BaseMetricsITest {
         String tenantId = "t1tag";
         createTagMetrics(tenantId);
 
-        Observable<String> tagNames = metricsService.getTagNames(tenantId, null);
+        Observable<String> tagNames = metricsService.getTagNames(tenantId, null, null);
         TestSubscriber<String> testSubscriber = new TestSubscriber<>();
         tagNames.subscribe(testSubscriber);
 
@@ -217,7 +217,15 @@ public class TagsITest extends BaseMetricsITest {
         testSubscriber.assertCompleted();
         testSubscriber.assertValueCount(5);
 
-        tagNames = metricsService.getTagNames(tenantId, "host.*");
+        tagNames = metricsService.getTagNames(tenantId, null, "host.*");
+        testSubscriber = new TestSubscriber<>();
+        tagNames.subscribe(testSubscriber);
+
+        testSubscriber.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        testSubscriber.assertCompleted();
+        testSubscriber.assertValueCount(1);
+
+        tagNames = metricsService.getTagNames(tenantId, AVAILABILITY, null);
         testSubscriber = new TestSubscriber<>();
         tagNames.subscribe(testSubscriber);
 

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -65,6 +66,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import rx.Observable;
+import rx.observers.TestSubscriber;
 
 public class TagsITest extends BaseMetricsITest {
 
@@ -200,6 +202,28 @@ public class TagsITest extends BaseMetricsITest {
                 .toBlocking()
                 .lastOrDefault(null);
         assertEquals(tagMap.get("a1").size(), 1, "a1 should have only one valid value");
+    }
+
+    @Test
+    public void tagNameSearch() throws Exception {
+        String tenantId = "t1tag";
+        createTagMetrics(tenantId);
+
+        Observable<String> tagNames = metricsService.getTagNames(tenantId, null);
+        TestSubscriber<String> testSubscriber = new TestSubscriber<>();
+        tagNames.subscribe(testSubscriber);
+
+        testSubscriber.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        testSubscriber.assertCompleted();
+        testSubscriber.assertValueCount(5);
+
+        tagNames = metricsService.getTagNames(tenantId, "host.*");
+        testSubscriber = new TestSubscriber<>();
+        tagNames.subscribe(testSubscriber);
+
+        testSubscriber.awaitTerminalEvent(5, TimeUnit.SECONDS);
+        testSubscriber.assertCompleted();
+        testSubscriber.assertValueCount(1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -365,6 +365,17 @@ class TagsITest extends RESTTest {
         query: [filter: 'e*'],
         headers: [(tenantHeaderName): tenantId])
     assertEquals(204, response.status)
+
+    // Test type filter
+    response = hawkularMetrics.delete(path: "gauges/N2/tags/d3", headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+
+    response = hawkularMetrics.get(path: "metrics/tags",
+        query: [filter: 'd.*', type: 'gauge'],
+        headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    assertEquals(1, response.data.size)
+    assertTrue(response.data.contains('d1'))
   }
 
 

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -322,6 +322,53 @@ class TagsITest extends RESTTest {
   }
 
   @Test
+  void findTagNames() {
+    def tenantId = nextTenantId()
+
+    metricTypes.each {
+
+      // Create metric
+      def response = hawkularMetrics.post(path: it.path, body: [
+          id  : 'N1',
+          tags: ['a1': 'A/B', 'd1': 'B:A']
+      ], headers: [(tenantHeaderName): tenantId])
+      assertEquals(201, response.status)
+
+      response = hawkularMetrics.post(path: it.path, body: [
+          id  : 'N2',
+          tags: ['a1': 'a', 'd3': 'B:A']
+      ], headers: [(tenantHeaderName): tenantId])
+      assertEquals(201, response.status)
+    }
+
+    // Fetch available tag names
+    def response = hawkularMetrics.get(path: "metrics/tags",
+        headers: [(tenantHeaderName): tenantId]);
+    assertEquals(200, response.status)
+    assertEquals(3, response.data.size)
+
+    assertTrue(response.data.contains('a1'))
+    assertTrue(response.data.contains('d1'))
+    assertTrue(response.data.contains('d3'))
+
+    // Fetch with filter
+    response = hawkularMetrics.get(path: "metrics/tags",
+        query: [filter: 'd.*'],
+        headers: [(tenantHeaderName): tenantId])
+    assertEquals(200, response.status)
+    assertEquals(2, response.data.size)
+    assertTrue(response.data.contains('d1'))
+    assertTrue(response.data.contains('d3'))
+
+    // Fetch filter without match
+    response = hawkularMetrics.get(path: "metrics/tags",
+        query: [filter: 'e*'],
+        headers: [(tenantHeaderName): tenantId])
+    assertEquals(204, response.status)
+  }
+
+
+  @Test
   void addTaggedDataPoints() {
     def dataValues = [:]
     dataValues['counter'] = [1, 99, 2]


### PR DESCRIPTION
This PR adds the ability to fetch available tag names.

Compared to the tag values interface:

```
michael@grace-mint18 ~/projects/git/gorilla-tsc $ curl -X GET -H 'Hawkular-Tenant: t1' 'http://localhost:8080/hawkular/metrics/metrics/tags/hostname:*'
{"hostname":["localhost"]}
michael@grace-mint18 ~/projects/git/gorilla-tsc $ curl -X GET -H 'Hawkular-Tenant: t1' 'http://localhost:8080/hawkular/metrics/metrics/tags'
["hostname"]
michael@grace-mint18 ~/projects/git/gorilla-tsc $
```
