### PR TITLE
[HWKMETRICS-514] a distributed lock to coordinate schema changes

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -110,6 +110,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-core</artifactId>
+      <scope>provided</scope>
+      <version>${version.org.infinispan.wildfly}</version>
+    </dependency>
+
     <!-- documentation -->
     <dependency>
       <groupId>io.swagger</groupId>

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DistributedLock.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DistributedLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DistributedLock.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/DistributedLock.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
+import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
+import org.infinispan.remoting.transport.Address;
+import org.jboss.logging.Logger;
+
+/**
+ * This is a lock implementation built on top of an Infinispan replicated/distributed cache. If the cache is local,
+ * the the methods in this class are basically no-ops. Note that the locking implementation is process-wide.
+ *
+ * @author jsanda
+ */
+@Listener
+public class DistributedLock {
+
+    private static Logger log = Logger.getLogger(DistributedLock.class);
+
+    public static final long DEFAULT_RETRY_DELAY = 10000;
+
+    private final AdvancedCache<String, String> locksCache;
+
+    private final String key;
+
+    /**
+     * @param locksCache The cache used for locking. This class will probably refactored at some point so that the cache
+     *                   can be directly injected.
+     * @param key The name or value of the lock.
+     */
+    public DistributedLock(AdvancedCache<String, String> locksCache, String key) {
+        this.key = key;
+        this.locksCache = locksCache;
+        this.locksCache.getCacheManager().addListener(this);
+    }
+
+    private boolean isLocked() {
+        if (isDistributed()) {
+            return getLockValue().equals(locksCache.get(key));
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the cache is local; otherwise, return true if the lock is acquired. The lock is held indefinitely
+     * until either {@link #release()} is called or the owning process goes down. If the owner goes down, the rest of
+     * the cluster will clear the lock such that other cluster members can acquire it.
+     */
+    public boolean lock() {
+        if (isDistributed()) {
+            if (isLocked()) {
+                return true;
+            }
+            return locksCache.putIfAbsent(key, getLockValue()) == null;
+        }
+        return true;
+    }
+
+    /**
+     * Returns true if the cache is local. Returns true if this node owns the lock and is able to remove it from the
+     * cache.
+     */
+    public boolean release() {
+        if (isDistributed() && isLocked()) {
+            return locksCache.remove(key, getLockValue());
+        }
+        return true;
+    }
+
+    /**
+     * Blocks until the lock is acquired and then execute runnable. After runnable finishes, the lock is released.
+     * There is a delay of {@link #DEFAULT_RETRY_DELAY} ms between successive attempts at acquiring the lock.
+     */
+    public void lockAndThen(Runnable runnable) {
+        lockAndThen(DEFAULT_RETRY_DELAY, runnable);
+    }
+
+    /**
+     * Blocks until the lock is acquired and then execute runnable. After runnable finishes, the lock is released.
+     * There is a delay of retryDelay ms between successive attempts at acquiring the lock.
+     */
+    public void lockAndThen(long retryDelay, Runnable runnable) {
+        try {
+            while (!lock()) {
+                log.debugf("Failed to acquire [%s] lock. Trying again in [%d] ms", key, retryDelay);
+                Thread.sleep(retryDelay);
+                lock();
+            }
+            runnable.run();
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        } finally {
+            release();
+        }
+    }
+
+    @ViewChanged
+    public void viewChanged(ViewChangedEvent event) {
+        log.debugf("view changed: %s", event);
+        List<Address> old = new ArrayList<>(event.getOldMembers());
+        old.removeAll(event.getNewMembers());
+        for (Address address : old) {
+            locksCache.remove(key, address.toString());
+        }
+    }
+
+    private boolean isDistributed() {
+        return locksCache.getCacheManager().getTransport() != null;
+    }
+
+    private String getLockValue() {
+        return locksCache.getCacheManager().getAddress().toString();
+    }
+
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -110,7 +110,6 @@ import com.google.common.util.concurrent.Uninterruptibles;
  * @author Thomas Segismont
  */
 @ApplicationScoped
-//@Eager
 public class MetricsServiceLifecycle {
     private static final RestLogger log = RestLogging.getRestLogger(MetricsServiceLifecycle.class);
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -231,9 +231,6 @@ public class MetricsServiceLifecycle {
     @ServiceReady
     Event<ServiceReadyEvent> metricsServiceReady;
 
-//    @Resource(lookup = "java:jboss/infinispan/container/hawkular-alerts")
-//    private EmbeddedCacheManager cacheManager;
-
     @Resource(lookup = "java:jboss/infinispan/cache/hawkular-alerts/locks")
     private Cache<String, String> locksCache;
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -53,8 +53,11 @@ import java.util.concurrent.ThreadFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.net.ssl.SSLContext;
@@ -63,7 +66,6 @@ import org.hawkular.metrics.api.jaxrs.config.Configurable;
 import org.hawkular.metrics.api.jaxrs.config.ConfigurationProperty;
 import org.hawkular.metrics.api.jaxrs.log.RestLogger;
 import org.hawkular.metrics.api.jaxrs.log.RestLogging;
-import org.hawkular.metrics.api.jaxrs.util.Eager;
 import org.hawkular.metrics.api.jaxrs.util.JobSchedulerFactory;
 import org.hawkular.metrics.api.jaxrs.util.MetricRegistryProvider;
 import org.hawkular.metrics.core.jobs.CompressData;
@@ -81,6 +83,8 @@ import org.hawkular.metrics.sysconfig.Configuration;
 import org.hawkular.metrics.sysconfig.ConfigurationService;
 import org.hawkular.rx.cassandra.driver.RxSession;
 import org.hawkular.rx.cassandra.driver.RxSessionImpl;
+import org.infinispan.AdvancedCache;
+import org.infinispan.Cache;
 
 import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
@@ -106,7 +110,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
  * @author Thomas Segismont
  */
 @ApplicationScoped
-@Eager
+//@Eager
 public class MetricsServiceLifecycle {
     private static final RestLogger log = RestLogging.getRestLogger(MetricsServiceLifecycle.class);
 
@@ -227,6 +231,12 @@ public class MetricsServiceLifecycle {
     @ServiceReady
     Event<ServiceReadyEvent> metricsServiceReady;
 
+//    @Resource(lookup = "java:jboss/infinispan/container/hawkular-alerts")
+//    private EmbeddedCacheManager cacheManager;
+
+    @Resource(lookup = "java:jboss/infinispan/cache/hawkular-alerts/locks")
+    private Cache<String, String> locksCache;
+
     private volatile State state;
     private int connectionAttempts;
     private Session session;
@@ -253,6 +263,10 @@ public class MetricsServiceLifecycle {
      */
     public State getState() {
         return state;
+    }
+
+    void eagerInit(@Observes @Initialized(ApplicationScoped.class) Object event) {
+        // init
     }
 
     @PostConstruct
@@ -450,9 +464,13 @@ public class MetricsServiceLifecycle {
     }
 
     private void initSchema() {
-        SchemaService schemaService = new SchemaService();
-        schemaService.run(session, keyspace, Boolean.parseBoolean(resetDb));
-        session.execute("USE " + keyspace);
+        AdvancedCache<String, String> cache = locksCache.getAdvancedCache();
+        DistributedLock schemaLock = new DistributedLock(cache, "cassalog");
+        schemaLock.lockAndThen(30000, () -> {
+            SchemaService schemaService = new SchemaService();
+            schemaService.run(session, keyspace, Boolean.parseBoolean(resetDb));
+            session.execute("USE " + keyspace);
+        });
     }
 
     /**
@@ -480,7 +498,9 @@ public class MetricsServiceLifecycle {
         jobsService.setSession(rxSession);
         scheduler = new JobSchedulerFactory().getJobScheduler(rxSession);
         jobsService.setScheduler(scheduler);
-        jobsService.start();
+
+        DistributedLock jobsLock = new DistributedLock(locksCache.getAdvancedCache(), "background-jobs");
+        jobsLock.lockAndThen(jobsService::start);
     }
 
     private void persistAdminToken() {

--- a/api/metrics-api-jaxrs/src/main/webapp/WEB-INF/web.xml
+++ b/api/metrics-api-jaxrs/src/main/webapp/WEB-INF/web.xml
@@ -24,6 +24,16 @@
 
   <display-name>Hawkular Metrics Rest interface</display-name>
 
+  <resource-env-ref>
+    <resource-env-ref-name>container/hawkular-alerts</resource-env-ref-name>
+    <lookup-name>java:jboss/infinispan/container/hawkular-alerts</lookup-name>
+  </resource-env-ref>
+
+  <resource-env-ref>
+    <resource-env-ref-name>cache/locks</resource-env-ref-name>
+    <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/locks</lookup-name>
+  </resource-env-ref>
+
   <servlet>
     <servlet-name>staticContent</servlet-name>
     <servlet-class>io.undertow.servlet.handlers.DefaultServlet</servlet-class>

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -316,6 +316,9 @@
                       <commmand>
                         /subsystem=infinispan/cache-container=hawkular-alerts/local-cache=schema/:add(indexing=NONE,start=LAZY)
                       </commmand>
+                      <commmand>
+                        /subsystem=infinispan/cache-container=hawkular-alerts/local-cache=locks/:add(indexing=NONE,start=LAZY)
+                      </commmand>
                     </commands>
                   </executeCommands>
                 </configuration>

--- a/dist/component/component-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/dist/component/component-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -27,5 +27,7 @@
       <module name="org.jboss.resteasy.resteasy-jackson2-provider" services="import"/>
       <module name="org.hawkular.bus"/>
     </dependencies>
+    <module name="org.infinispan" export="true" />
+    <module name="org.infinispan.commons" export="true"/>
   </deployment>
 </jboss-deployment-structure>

--- a/dist/standalone/wildfly-standalone/src/main/xsl/subsystem-templates/hawkular-alerting-infinispan.xsl
+++ b/dist/standalone/wildfly-standalone/src/main/xsl/subsystem-templates/hawkular-alerting-infinispan.xsl
@@ -30,6 +30,7 @@
         <local-cache name="data"/>
         <local-cache name="publish"/>
         <local-cache name="schema"/>
+        <local-cache name="locks"/>
       </cache-container>
     </xsl:copy>
   </xsl:template>

--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -236,6 +236,9 @@
                       <commmand>
                         /subsystem=infinispan/cache-container=hawkular-alerts/local-cache=schema/:add(indexing=NONE,start=LAZY)
                       </commmand>
+                      <commmand>
+                        /subsystem=infinispan/cache-container=hawkular-alerts/local-cache=locks/:add(indexing=NONE,start=LAZY)
+                      </commmand>
                     </commands>
                   </executeCommands>
                 </configuration>


### PR DESCRIPTION
This PR requires changes to standalone.xml and standalone-ha.xml. For standalone.xml we need:

```xml
<cache-container name="hawkular-alerts" default-cache="triggers" statistics-enabled="true">
    <local-cache name="partition"/>
    <local-cache name="triggers"/>
    <local-cache name="data"/>
    <local-cache name="publish"/>
    <local-cache name="schema"/>
    <local-cache name="locks"/>
```

Note the addition of the **locks** cache. And for standalone-ha.xml:

```xml
<cache-container name="hawkular-alerts" 
                              default-cache="triggers"
                              module="org.wildfly.clustering.server" 
                              statistics-enabled="true">
    <replicated-cache name="partition" mode="SYNC">
        <transaction mode="BATCH"/>
    </replicated-cache>
    <replicated-cache name="triggers" mode="ASYNC">
        <transaction mode="BATCH"/>
    </replicated-cache>
    <replicated-cache name="data" mode="ASYNC">
        <transaction mode="BATCH"/>
    </replicated-cache>
    <replicated-cache name="publish" mode="ASYNC">
        <transaction mode="BATCH"/>
    </replicated-cache>
    <replicated-cache name="schema" mode="SYNC">
        <transaction mode="NON_XA"/>
    </replicated-cache>
    <replicated-cache name="locks" mode="SYNC">
        <transaction mode="NON_XA" locking="PESSIMISTIC"/>
    </replicated-cache>
```