### PR TITLE
[HWKMETRICS-535] use configurable, parallel queries for compression job

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/log/RestLogger.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/log/RestLogger.java
@@ -22,6 +22,7 @@ import static org.jboss.logging.Logger.Level.FATAL;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import org.hawkular.metrics.core.jobs.CompressData;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
@@ -114,4 +115,9 @@ public interface RestLogger extends BasicLogger {
     @Message(id = 200018, value = "Invalid value [%s] for ingestion max retry delay. The ingestion configuration " +
             "setting will not be updated")
     void warnInvalidIngestMaxRetryDelay(String maxRetries);
+
+    @LogMessage(level = WARN)
+    @Message(id = 200019, value = "There was an error updating the configuration of the " + CompressData.JOB_NAME +
+            " job")
+    void warnCompressionJobConfigUpdateFailed(@Cause Exception e);
 }

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -49,6 +49,8 @@ public enum ConfigurationKey {
             "CASSANDRA_SCHEMA_REFRESH_INTERVAL", false),
     PAGE_SIZE("hawkular.metrics.page-size", "1000", "PAGE_SIZE", false),
     COMPRESSION_QUERY_PAGE_SIZE("hawkular.metrics.compression.page-size", "1000", "COMPRESSION_PAGE_SIZE", false),
+    COMPRESSION_JOB_PARALLEL_READS("hawkular.metrics.jobs.compression.parallel-reads", "1",
+            "COMPRESSION_PARALLEL_READS", false),
     COMPRESSION_JOB_ENABLED("hawkular.metrics.jobs.compression.enabled", null, "COMPRESSION_JOB_ENABLED", false),
     WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
     DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false),

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -169,7 +169,8 @@ public interface MetricsService {
     <T> Observable<DataPoint<T>> findDataPoints(MetricId<T> id, long start, long end, int limit, Order order,
             int pageSize);
 
-    Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long timeSlice, int pageSize);
+    Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long timeSlice, int pageSize,
+            int parallelReads);
 
     <T> Observable<NamedDataPoint<T>> findDataPoints(List<MetricId<T>> ids, long start, long end, int limit,
                                                      Order order);

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
@@ -254,7 +254,7 @@ public class CounterITest extends BaseMetricsITest {
         insertObservable.toBlocking().lastOrDefault(null);
 
         metricsService.compressBlock(Observable.just(mId), DateTimeService.getTimeSlice(start.getMillis(), Duration
-                .standardHours(2)), COMPRESSION_PAGE_SIZE)
+                .standardHours(2)), COMPRESSION_PAGE_SIZE, 1)
                 .doOnError(Throwable::printStackTrace).toBlocking().lastOrDefault(null);
 
         Observable<DataPoint<Long>> observable = metricsService.findDataPoints(mId, start.getMillis(),

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
@@ -365,7 +365,7 @@ public class GaugeITest extends BaseMetricsITest {
         insertObservable.toBlocking().lastOrDefault(null);
 
         metricsService.compressBlock(Observable.just(mId), DateTimeService.getTimeSlice(start.getMillis(), Duration
-                .standardHours(2)), COMPRESSION_PAGE_SIZE)
+                .standardHours(2)), COMPRESSION_PAGE_SIZE, 1)
                 .doOnError(Throwable::printStackTrace).toBlocking().lastOrDefault(null);
 
         Observable<DataPoint<Double>> observable = metricsService.findDataPoints(mId, start.getMillis(),
@@ -435,7 +435,7 @@ public class GaugeITest extends BaseMetricsITest {
         expected = expectCreator.apply(cStart);
 
         metricsService.compressBlock(Observable.just(mId), DateTimeService.getTimeSlice(cStart.getMillis(), Duration
-                .standardHours(2)), COMPRESSION_PAGE_SIZE).toBlocking().lastOrDefault(null);
+                .standardHours(2)), COMPRESSION_PAGE_SIZE, 1).toBlocking().lastOrDefault(null);
 
         actual = toList(metricsService.findDataPoints(new MetricId<>(tenantId, GAUGE, "m1"),
                 cStart.plusMinutes(1).getMillis(), end, 3, Order.ASC));


### PR DESCRIPTION
The main part of this commit is using flatMap instead of concactMap in
MetricsService.compressBlocks(). By default, we are not introducing any
parallelism; however, it is configurable with the system property ```hawkular.metrics.jobs.compression.parallel-reads``` or the environment variable ```COMPRESSION_PARALLEL_READS```.