### PR TITLE
[HWKMETRICS-545] [HWKMETRICS-502] Compression job control

### DIFF
--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/CompressData.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/CompressData.java
@@ -128,14 +128,12 @@ public class CompressData implements Func1<JobDetails, Completable> {
 
         // Fetch all partition keys and compress the previous timeSlice
         // TODO Optimization - new worker per token - use parallelism in Cassandra (with configured parallelism)
-        return Completable.fromObservable(
-                metricsService.compressBlock(metricIds, startOfSlice, endOfSlice, pageSize)
-                        .doOnError(t -> logger.warn("Failed to compress data", t))
-                        .doOnCompleted(() -> {
-                            stopwatch.stop();
-                            logger.info("Finished compressing data in " + stopwatch.elapsed(TimeUnit.MILLISECONDS) +
-                                    " ms");
-                        })
-        );
+        return metricsService.compressBlock(metricIds, startOfSlice, endOfSlice, pageSize)
+                .doOnError(t -> logger.warn("Failed to compress data", t))
+                .doOnCompleted(() -> {
+                    stopwatch.stop();
+                    logger.info("Finished compressing data in " + stopwatch.elapsed(TimeUnit.MILLISECONDS) +
+                            " ms");
+                });
     }
 }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImpl.java
@@ -41,6 +41,7 @@ import org.joda.time.Minutes;
 import com.google.common.collect.ImmutableMap;
 
 import rx.Single;
+import rx.Subscriber;
 import rx.functions.Func2;
 
 /**
@@ -140,8 +141,21 @@ public class JobsServiceImpl implements JobsService, JobsServiceImplMBean {
     // JMX management
     private void submitCompressJob(Map<String, String> parameters) {
         String jobName = String.format("%s_single_%s", CompressData.JOB_NAME, parameters.get(CompressData.TARGET_TIME));
-        scheduler.scheduleJob(CompressData.JOB_NAME, jobName, parameters,
+        Single<JobDetails> jobDetailsSingle = scheduler.scheduleJob(CompressData.JOB_NAME, jobName, parameters,
                 new SingleExecutionTrigger.Builder().withDelay(1, TimeUnit.MINUTES).build());
+        jobDetailsSingle.subscribe(new Subscriber<JobDetails>() {
+            @Override public void onCompleted() {
+                logger.info("submitCompressJob->onCompleted");
+            }
+
+            @Override public void onError(Throwable throwable) {
+                logger.error("submitCompressJob->onError", throwable);
+            }
+
+            @Override public void onNext(JobDetails jobDetails) {
+                logger.info("submitCompressJob->onNext");
+            }
+        });
     }
 
     @Override

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImpl.java
@@ -41,7 +41,6 @@ import org.joda.time.Minutes;
 import com.google.common.collect.ImmutableMap;
 
 import rx.Single;
-import rx.Subscriber;
 import rx.functions.Func2;
 
 /**
@@ -141,21 +140,10 @@ public class JobsServiceImpl implements JobsService, JobsServiceImplMBean {
     // JMX management
     private void submitCompressJob(Map<String, String> parameters) {
         String jobName = String.format("%s_single_%s", CompressData.JOB_NAME, parameters.get(CompressData.TARGET_TIME));
-        Single<JobDetails> jobDetailsSingle = scheduler.scheduleJob(CompressData.JOB_NAME, jobName, parameters,
-                new SingleExecutionTrigger.Builder().withDelay(1, TimeUnit.MINUTES).build());
-        jobDetailsSingle.subscribe(new Subscriber<JobDetails>() {
-            @Override public void onCompleted() {
-                logger.info("submitCompressJob->onCompleted");
-            }
-
-            @Override public void onError(Throwable throwable) {
-                logger.error("submitCompressJob->onError", throwable);
-            }
-
-            @Override public void onNext(JobDetails jobDetails) {
-                logger.info("submitCompressJob->onNext");
-            }
-        });
+        // Blocking to ensure it is actually scheduled..
+        scheduler.scheduleJob(CompressData.JOB_NAME, jobName, parameters,
+                new SingleExecutionTrigger.Builder().withDelay(1, TimeUnit.MINUTES).build())
+                .toBlocking().value();
     }
 
     @Override

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImplMBean.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/JobsServiceImplMBean.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.jobs;
+
+/**
+ * @author Michael Burman
+ */
+public interface JobsServiceImplMBean {
+
+    /**
+     * Execute compression job that includes the given timestamp (automatic range calculation)
+     *
+     * @param timestamp A timestamp inside the block (inclusive)
+     */
+    void submitCompressJob(long timestamp);
+
+    /**
+     * Execute compression job that includes the given timestamp (automatic range calculation) with
+     * configurable blockSize.
+     *
+     * @param timestamp A timestamp inside the block (inclusive)
+     * @param blockSize blockSize in ISO8601 format @see <a href="https://docs.oracle
+     *                  .com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence">Duration</a>
+     */
+    void submitCompressJob(long timestamp, String blockSize);
+}

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -171,7 +171,17 @@ public interface MetricsService {
     <T> Observable<DataPoint<T>> findDataPoints(MetricId<T> id, long start, long end, int limit, Order order,
             int pageSize);
 
-    Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long timeSlice, int pageSize);
+    /**
+     * Compresses the given range between timestamps to a single block.
+     *
+     * @param metrics Compressed metric definitions
+     * @param startTimeSlice Start time of the block
+     * @param endTimeSlice End time of the block
+     * @param pageSize Cassandra query parameter
+     * @return onComplete when job is done
+     */
+    Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long startTimeSlice, long endTimeSlice,
+                                   int pageSize);
 
     <T> Observable<NamedDataPoint<T>> findDataPoints(List<MetricId<T>> ids, long start, long end, int limit,
                                                      Order order);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -37,6 +37,7 @@ import org.hawkular.metrics.model.Tenant;
 import org.hawkular.metrics.model.exception.MetricAlreadyExistsException;
 import org.hawkular.metrics.model.param.BucketConfig;
 
+import rx.Completable;
 import rx.Observable;
 import rx.functions.Func1;
 
@@ -180,8 +181,8 @@ public interface MetricsService {
      * @param pageSize Cassandra query parameter
      * @return onComplete when job is done
      */
-    Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long startTimeSlice, long endTimeSlice,
-                                   int pageSize);
+    Completable compressBlock(Observable<? extends MetricId<?>> metrics, long startTimeSlice, long endTimeSlice,
+                              int pageSize);
 
     <T> Observable<NamedDataPoint<T>> findDataPoints(List<MetricId<T>> ids, long start, long end, int limit,
                                                      Order order);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -746,18 +746,19 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long timeSlice, int pageSize) {
+    public Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long startTimeSlice, long
+            endTimeSlice, int pageSize) {
         // Fetches all the datapoints between timeslice start and timeslice end (end must not be included!)
-        long endOfSlice = new DateTime(timeSlice).plus(CompressData.DEFAULT_BLOCK_SIZE).getMillis() - 1;
+//        long endOfSlice = new DateTime(startTimeSlice).plus(CompressData.DEFAULT_BLOCK_SIZE).getMillis() - 1;
 
         return metrics
                 .compose(applyRetryPolicy())
                 .concatMap(metricId ->
-                        findDataPoints(metricId, timeSlice, endOfSlice, 0, ASC, pageSize)
+                        findDataPoints(metricId, startTimeSlice, endTimeSlice, 0, ASC, pageSize)
                                 .compose(applyRetryPolicy())
-                                .compose(new DataPointCompressTransformer(metricId.getType(), timeSlice))
-                                .concatMap(cpc -> dataAccess.deleteAndInsertCompressedGauge(metricId, timeSlice,
-                                        (CompressedPointContainer) cpc, timeSlice, endOfSlice, getTTL(metricId))
+                                .compose(new DataPointCompressTransformer(metricId.getType(), startTimeSlice))
+                                .concatMap(cpc -> dataAccess.deleteAndInsertCompressedGauge(metricId, startTimeSlice,
+                                        (CompressedPointContainer) cpc, startTimeSlice, endTimeSlice, getTTL(metricId))
                                         .compose(applyRetryPolicy())
                                 ))
                 .map(rs -> null);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -44,7 +44,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import org.hawkular.metrics.core.jobs.CompressData;
 import org.hawkular.metrics.core.service.compress.CompressedPointContainer;
 import org.hawkular.metrics.core.service.log.CoreLogger;
 import org.hawkular.metrics.core.service.log.CoreLogging;
@@ -77,7 +76,6 @@ import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.TimeRange;
 import org.hawkular.metrics.sysconfig.Configuration;
 import org.hawkular.metrics.sysconfig.ConfigurationService;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import com.codahale.metrics.Meter;

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -95,6 +95,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
+import rx.Completable;
 import rx.Observable;
 import rx.exceptions.Exceptions;
 import rx.functions.Func1;
@@ -744,12 +745,10 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Observable<Void> compressBlock(Observable<? extends MetricId<?>> metrics, long startTimeSlice, long
+    public Completable compressBlock(Observable<? extends MetricId<?>> metrics, long startTimeSlice, long
             endTimeSlice, int pageSize) {
-        // Fetches all the datapoints between timeslice start and timeslice end (end must not be included!)
-//        long endOfSlice = new DateTime(startTimeSlice).plus(CompressData.DEFAULT_BLOCK_SIZE).getMillis() - 1;
 
-        return metrics
+        return Completable.fromObservable(metrics
                 .compose(applyRetryPolicy())
                 .concatMap(metricId ->
                         findDataPoints(metricId, startTimeSlice, endTimeSlice, 0, ASC, pageSize)
@@ -758,8 +757,7 @@ public class MetricsServiceImpl implements MetricsService {
                                 .concatMap(cpc -> dataAccess.deleteAndInsertCompressedGauge(metricId, startTimeSlice,
                                         (CompressedPointContainer) cpc, startTimeSlice, endTimeSlice, getTTL(metricId))
                                         .compose(applyRetryPolicy())
-                                ))
-                .map(rs -> null);
+                                )));
     }
 
     @Override

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
@@ -43,6 +43,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.math3.stat.descriptive.rank.PSquarePercentile;
 import org.apache.commons.math3.stat.descriptive.summary.Sum;
+import org.hawkular.metrics.core.jobs.CompressData;
 import org.hawkular.metrics.core.service.Order;
 import org.hawkular.metrics.core.service.transformers.NumericDataPointCollector;
 import org.hawkular.metrics.datetime.DateTimeService;
@@ -253,9 +254,11 @@ public class CounterITest extends BaseMetricsITest {
         Observable<Void> insertObservable = metricsService.addDataPoints(COUNTER, Observable.just(m1));
         insertObservable.toBlocking().lastOrDefault(null);
 
-        metricsService.compressBlock(Observable.just(mId), DateTimeService.getTimeSlice(start.getMillis(), Duration
-                .standardHours(2)), COMPRESSION_PAGE_SIZE)
-                .doOnError(Throwable::printStackTrace).toBlocking().lastOrDefault(null);
+        DateTime startSlice = DateTimeService.getTimeSlice(start, CompressData.DEFAULT_BLOCK_SIZE);
+        DateTime endSlice = startSlice.plus(CompressData.DEFAULT_BLOCK_SIZE);
+
+        metricsService.compressBlock(Observable.just(mId), startSlice.getMillis(), endSlice.getMillis(),
+                COMPRESSION_PAGE_SIZE).doOnError(Throwable::printStackTrace).toBlocking().lastOrDefault(null);
 
         Observable<DataPoint<Long>> observable = metricsService.findDataPoints(mId, start.getMillis(),
                 end.getMillis() + 1, 0, Order.DESC);

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
@@ -60,7 +60,6 @@ import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.TimeRange;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.joda.time.Duration;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
@@ -49,7 +49,6 @@ import org.hawkular.metrics.model.NumericBucketPoint;
 import org.hawkular.metrics.model.Tenant;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.joda.time.Duration;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 

--- a/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/SchedulerImpl.java
+++ b/job-scheduler/src/main/java/org/hawkular/metrics/scheduler/impl/SchedulerImpl.java
@@ -246,7 +246,8 @@ public class SchedulerImpl implements Scheduler {
                 })
                 .flatMap(details -> jobsService.insert(new Date(trigger.getTriggerTime()), details)
                         .map(resultSet -> details))
-                .toSingle();
+                .toSingle()
+                .doOnError(t -> logger.warn("Failed to schedule job " + name, t));
     }
 
     @Override


### PR DESCRIPTION
This PR adds the ability of manually adjusting the blockSize of the compression (accepting the ISO8601 format as parameter) as well as creating MBean for the compression job triggering for given timestamp.

Calculation of the compressed range is moved from MetricsServiceImpl to CompressData to allow customized ranges to be triggered.