### PR TITLE
[HWKMETRICS-543] Missing type in exact id filtering should return 400

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -192,7 +192,8 @@ public class MetricHandler {
     public <T> void findMetrics(
             @Suspended
             AsyncResponse asyncResponse,
-            @ApiParam(value = "Queried metric type", required = false, allowableValues = "gauge, availability, counter")
+            @ApiParam(value = "Queried metric type", required = false, allowableValues = "gauge, availability, " +
+                    "counter, string")
             @QueryParam("type") MetricType<T> metricType,
             @ApiParam(value = "List of tags filters", required = false) @QueryParam("tags") Tags tags,
             @ApiParam(value = "Regexp to match metricId if tags filtering is used, otherwise exact matching",
@@ -207,6 +208,10 @@ public class MetricHandler {
         if(tags == null) {
             if(!Strings.isNullOrEmpty(id)) {
                 // HWKMETRICS-461
+                if(metricType == null) {
+                    asyncResponse.resume(badRequest(new ApiError("Exact id search requires type to be set")));
+                    return;
+                }
                 String[] ids = id.split("\\|");
                 metricObservable = Observable.from(ids)
                         .map(idPart -> new MetricId<>(getTenant(), metricType, idPart))

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TagsITest.groovy
@@ -511,6 +511,12 @@ class TagsITest extends RESTTest {
             tags    : ['c1': 'C'],
             type: it.type
         ]))
+
+      badGet(path: "metrics", query: [id: '91c171ed-0294-44b3-bcdb-42253b58aa5a'],
+          headers: [(tenantHeaderName): tenantId]) { exception ->
+        // Missing type
+        assertEquals(400, exception.response.status)
+      }
     }
   }
 }


### PR DESCRIPTION
The id filtering without tags allows only exact matching, so the type is required. If it's missing, return 400 instead of 500.