### PR TITLE
[HWKMETRICS-526] report status of Cassandra nodes

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/AdminFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/AdminFilter.java
@@ -72,7 +72,7 @@ public class AdminFilter implements ContainerRequestFilter {
         UriInfo uriInfo = requestContext.getUriInfo();
         String path = uriInfo.getPath();
 
-        if (path.startsWith("/tenants")) {
+        if (path.startsWith("/tenants") || path.startsWith("/admin")) {
             String tenant = requestContext.getHeaders().getFirst(TENANT_HEADER_NAME);
             if (tenant == null || tenant.trim().isEmpty()) {
                 // Fail on missing tenant info

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AdminHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AdminHandler.java
@@ -60,7 +60,7 @@ public class AdminHandler {
         MetricsServiceLifecycle.State metricState = metricsServiceLifecycle.getState();
         status.setMetricsServiceStatus(metricsServiceLifecycle.getState().toString());
 
-        Map<String, String> manifestInfo = manifestInformation.getFrom(servletContext);
+        Map<String, String> manifestInfo = manifestInformation.getAttributes();
         status.setImplementationVersion(manifestInfo.get("Implementation-Version"));
         status.setGitSHA(manifestInfo.get("Built-From-Git-SHA1"));
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AdminHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AdminHandler.java
@@ -18,34 +18,32 @@ package org.hawkular.metrics.api.jaxrs.handler;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.servlet.ServletContext;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle;
-import org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle.State;
 import org.hawkular.metrics.api.jaxrs.util.ManifestInformation;
+import org.hawkular.metrics.model.Status;
 
 import io.swagger.annotations.ApiOperation;
 
 /**
- * @author Matt Wringe
+ * @author jsanda
  */
-@Path(StatusHandler.PATH)
+@Path("/admin")
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
 @ApplicationScoped
-public class StatusHandler {
-    public static final String PATH = "/status";
-
-    private static final String METRICSSERVICE_NAME = "MetricsService";
+public class AdminHandler {
 
     @Inject
     MetricsServiceLifecycle metricsServiceLifecycle;
@@ -54,13 +52,21 @@ public class StatusHandler {
     ManifestInformation manifestInformation;
 
     @GET
+    @Path("status")
     @ApiOperation(value = "Returns the current status for various components.",
             response = Map.class)
-    public Response status() {
-        Map<String, String> status = new HashMap<>();
-        State metricState = metricsServiceLifecycle.getState();
-        status.put(METRICSSERVICE_NAME, metricState.toString());
-        status.putAll(manifestInformation.getFrom(servletContext));
+    public Response status(@Context ServletContext servletContext) {
+        Status status = new Status();
+        MetricsServiceLifecycle.State metricState = metricsServiceLifecycle.getState();
+        status.setMetricsServiceStatus(metricsServiceLifecycle.getState().toString());
+
+        Map<String, String> manifestInfo = manifestInformation.getFrom(servletContext);
+        status.setImplementationVersion(manifestInfo.get("Implementation-Version"));
+        status.setGitSHA(manifestInfo.get("Built-From-Git-SHA1"));
+
+        status.setCassandraStatus(metricsServiceLifecycle.getCassandraStatus());
+
         return Response.ok(status).build();
     }
+
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StatusHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StatusHandler.java
@@ -62,7 +62,7 @@ public class StatusHandler {
         Map<String, String> status = new HashMap<>();
         State metricState = metricsServiceLifecycle.getState();
         status.put(METRICSSERVICE_NAME, metricState.toString());
-        status.putAll(manifestInformation.getFrom(servletContext));
+        status.putAll(manifestInformation.getAttributes());
 
         List<CassandraStatus> cassandraStatuses = metricsServiceLifecycle.getCassandraStatus();
         int nodesUp = 0;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StatusHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StatusHandler.java
@@ -18,7 +18,6 @@ package org.hawkular.metrics.api.jaxrs.handler;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -32,6 +31,7 @@ import javax.ws.rs.core.Response;
 import org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle;
 import org.hawkular.metrics.api.jaxrs.MetricsServiceLifecycle.State;
 import org.hawkular.metrics.api.jaxrs.util.ManifestInformation;
+import org.hawkular.metrics.model.Status;
 
 import io.swagger.annotations.ApiOperation;
 
@@ -59,8 +59,14 @@ public class StatusHandler {
     public Response status() {
         Map<String, String> status = new HashMap<>();
         State metricState = metricsServiceLifecycle.getState();
-        status.put(METRICSSERVICE_NAME, metricState.toString());
-        status.putAll(manifestInformation.getAttributes());
+        status.setMetricsServiceStatus(metricsServiceLifecycle.getState().toString());
+
+        Map<String, String> manifestInfo = manifestInformation.getFrom(servletContext);
+        status.setImplementationVersion(manifestInfo.get("Implementation-Version"));
+        status.setGitSHA(manifestInfo.get("Built-From-Git-SHA1"));
+
+        status.setCassandraStatus(metricsServiceLifecycle.getCassandraStatus());
+
         return Response.ok(status).build();
     }
 }

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/CassandraStatus.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/CassandraStatus.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.model;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+import io.swagger.annotations.ApiModelProperty;
+
+/**
+ * @author jsanda
+ */
+public class CassandraStatus {
+
+    private String address;
+
+    private String status;
+
+    public CassandraStatus() {
+    }
+
+    public CassandraStatus(String address, String status) {
+        this.address = address;
+        this.status = status;
+    }
+
+    @ApiModelProperty("The address on which the Cassandra node listens for client requests")
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    @ApiModelProperty("Indicates whether the node is up or down")
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CassandraStatus that = (CassandraStatus) o;
+        return Objects.equals(address, that.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address);
+    }
+
+    @Override public String toString() {
+        return MoreObjects.toStringHelper(this).add("address", address).add("status", status).toString();
+    }
+}

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/Status.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/Status.java
@@ -43,7 +43,7 @@ public class Status {
         this.metricsServiceStatus = metricsServiceStatus;
     }
 
-    @JsonProperty("Built-From-Git-SHA")
+    @JsonProperty("Built-From-Git-SHA1")
     public String getGitSHA() {
         return gitSHA;
     }

--- a/core/metrics-model/src/main/java/org/hawkular/metrics/model/Status.java
+++ b/core/metrics-model/src/main/java/org/hawkular/metrics/model/Status.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+/**
+ * @author jsanda
+ */
+public class Status {
+
+    private String metricsServiceStatus;
+
+    private String gitSHA;
+
+    private String implementationVersion;
+
+    private List<CassandraStatus> cassandraStatusList;
+
+    @JsonProperty("MetricsService")
+    public String getMetricsServiceStatus() {
+        return metricsServiceStatus;
+    }
+
+    public void setMetricsServiceStatus(String metricsServiceStatus) {
+        this.metricsServiceStatus = metricsServiceStatus;
+    }
+
+    @JsonProperty("Built-From-Git-SHA")
+    public String getGitSHA() {
+        return gitSHA;
+    }
+
+    public void setGitSHA(String gitSHA) {
+        this.gitSHA = gitSHA;
+    }
+
+    @JsonProperty("Implementation-Version")
+    public String getImplementationVersion() {
+        return implementationVersion;
+    }
+
+    public void setImplementationVersion(String implementationVersion) {
+        this.implementationVersion = implementationVersion;
+    }
+
+    @JsonProperty("Cassandra")
+    public List<CassandraStatus> getCassandraStatus() {
+        return cassandraStatusList;
+    }
+
+    public void setCassandraStatus(List<CassandraStatus> cassandraStatusList) {
+        this.cassandraStatusList = cassandraStatusList;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("metricsServiceStatus", metricsServiceStatus)
+                .add("gitSHA", gitSHA)
+                .add("implementationVersion", implementationVersion)
+                .add("cassandraStatusList", cassandraStatusList)
+                .toString();
+    }
+}

--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -127,6 +127,9 @@
           <name>!skipTests</name>
         </property>
       </activation>
+      <properties>
+        <admin-token>awesome_secret_sauce</admin-token>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -143,6 +146,7 @@
                 <hawkular-metrics.test.origin>http://test.hawkular.org</hawkular-metrics.test.origin>
                 <hawkular-metrics.test.access-control-allow-headers>random-header1,random-header2</hawkular-metrics.test.access-control-allow-headers>
                 <hawkular-metrics.cassandra.schema.refresh-interval>0</hawkular-metrics.cassandra.schema.refresh-interval>
+                <hawkular.metrics.admin-token>${admin-token}</hawkular.metrics.admin-token>
                 <project.version>${project.version}</project.version>
               </systemPropertyVariables>
             </configuration>
@@ -184,7 +188,7 @@
                     <javaOpt>-Dhawkular.terminal-event.timeout=${terminal-event.timeout}</javaOpt>
                     <javaOpt>-Dhawkular.metrics.allowed-cors-origins=http://test.hawkular.org,https://secure.hawkular.io</javaOpt>
                     <javaOpt>-Dhawkular.metrics.allowed-cors-access-control-allow-headers=random-header1,random-header2</javaOpt>
-                    <javaOpt>-Dhawkular.metrics.admin-token=awesome_secret_sauce</javaOpt>
+                    <javaOpt>-Dhawkular.metrics.admin-token=${admin-token}</javaOpt>
                     <javaOpt>-Dhawkular.metrics.cassandra.schema.refresh-interval=0</javaOpt>
                     <javaOpt>-Xdebug</javaOpt>
                     <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/AdminITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/AdminITest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.rest
+
+import org.junit.Test
+
+import static org.junit.Assert.*
+import static org.junit.Assume.assumeTrue
+/**
+ * @author jsanda
+ */
+class AdminITest extends RESTTest {
+
+  def tenantId = nextTenantId()
+
+  @Test
+  void getStatus() {
+    def version = System.properties.getProperty('project.version');
+    assumeTrue('This test only works in a Maven build', version != null)
+
+    def response = hawkularMetrics.get(path: "admin/status",
+        headers: [
+            (tenantHeaderName): tenantId,
+            (adminTokenHeaderName): adminToken
+        ]
+    )
+    assertEquals(200, response.status)
+
+    def expectedState = ['MetricsService': 'STARTED']
+
+    assertEquals(expectedState.MetricsService, response.data.MetricsService)
+    assertEquals(version, response.data['Implementation-Version'])
+    assertNotNull(response.data['Built-From-Git-SHA1'])
+    assertNotEquals('Unknown', response.data['Built-From-Git-SHA1'])
+
+    assertFalse(response.data.Cassandra.empty)
+    assertEquals([[address: 'localhost', status: 'up']], response.data.Cassandra)
+  }
+
+}

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/RESTTest.groovy
@@ -90,6 +90,10 @@ ${text}
     return "T${TENANT_PREFIX}${TENANT_ID_COUNTER.incrementAndGet()}"
   }
 
+  static String getAdminToken() {
+    return System.getProperty("hawkular.metrics.admin-token")
+  }
+
   static void assertDoubleEquals(expected, actual) {
     assertDoubleEquals(null, expected, actual)
   }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StatusITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StatusITest.groovy
@@ -17,6 +17,7 @@
 package org.hawkular.metrics.rest
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotEquals
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assume.assumeTrue
@@ -41,5 +42,8 @@ class StatusITest extends RESTTest {
         assertEquals(version, response.data['Implementation-Version'])
         assertNotNull(response.data['Built-From-Git-SHA1'])
         assertNotEquals('Unknown', response.data['Built-From-Git-SHA1'])
+
+        assertFalse(response.data.Cassandra.empty)
+        assertEquals([[address: 'localhost', status: 'up']], response.data.Cassandra)
     }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StatusITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StatusITest.groovy
@@ -16,14 +16,10 @@
  */
 package org.hawkular.metrics.rest
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNotEquals
-import static org.junit.Assert.assertNotNull
-import static org.junit.Assume.assumeTrue
-
 import org.junit.Test
 
+import static org.junit.Assert.*
+import static org.junit.Assume.assumeTrue
 /**
  * @author mwringe
  */
@@ -42,8 +38,5 @@ class StatusITest extends RESTTest {
         assertEquals(version, response.data['Implementation-Version'])
         assertNotNull(response.data['Built-From-Git-SHA1'])
         assertNotEquals('Unknown', response.data['Built-From-Git-SHA1'])
-
-        assertFalse(response.data.Cassandra.empty)
-        assertEquals([[address: 'localhost', status: 'up']], response.data.Cassandra)
     }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TenantITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/TenantITest.groovy
@@ -33,8 +33,6 @@ import org.junit.Test
 class TenantITest extends RESTTest {
   def tenantId = nextTenantId()
 
-  def adminToken = "awesome_secret_sauce"
-
   @Test
   void createAndReadTest() {
     def secondTenantId = nextTenantId()


### PR DESCRIPTION
The output of the status endpoint now looks like:

```json
{
  "MetricsService": "STARTED", 
  "Built-From-Git-SHA": "291fabc1214149653ee3df14e0f2c60b10c64360", 
  "Implementation-Version": "0.22.0-SNAPSHOT", 
  "Cassandra": [
    {
      "address": "127.0.0.1", 
      "status": "up"
    }, 
    {
      "address": "127.0.0.2", 
      "status": "up"
    }, 
    {
        "address": "127.0.0.3",
        "status": "up"
    }
  ]
}
```

@mwringe does this work for you?