### PR TITLE
Remove okhttp version from parent pom. The library is no longer used …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
     <version.org.codehaus.groovy.modules.http-builder>0.7</version.org.codehaus.groovy.modules.http-builder>
     <version.org.codehaus.mojo.dashboard-maven-plugin>1.0.0-beta-1</version.org.codehaus.mojo.dashboard-maven-plugin>
     <version.org.jmxtrans.embedded.embedded-jmxtrans>1.0.15</version.org.jmxtrans.embedded.embedded-jmxtrans>
-    <version.com.squareup.okhttp>2.0.0</version.com.squareup.okhttp>
     <version.fi.iki.yak.compression-gorilla>1.1.0</version.fi.iki.yak.compression-gorilla>
   </properties>
 


### PR DESCRIPTION
…by the project.