### PR TITLE
[HAWKULAR-1168] make replication_factor configurable

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -30,6 +30,7 @@ import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_M
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_MAX_QUEUE_SIZE;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_MAX_REQUEST_CONN;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_NODES;
+import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_REPLICATION_FACTOR;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_REQUEST_TIMEOUT;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_RESETDB;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_SCHEMA_REFRESH_INTERVAL;
@@ -55,6 +56,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -158,6 +160,11 @@ public class MetricsServiceLifecycle {
     @Configurable
     @ConfigurationProperty(CASSANDRA_KEYSPACE)
     private String keyspace;
+
+    @Inject
+    @Configurable
+    @ConfigurationProperty(CASSANDRA_REPLICATION_FACTOR)
+    private String replicationFactorProp;
 
     @Inject
     @Configurable
@@ -529,11 +536,20 @@ public class MetricsServiceLifecycle {
     }
 
     private void initSchema() {
+        AtomicReference<Integer> replicationFactor = new AtomicReference<>();
+        try {
+            replicationFactor.set(Integer.parseInt(replicationFactorProp));
+        } catch (NumberFormatException e) {
+            log.warnf("Invalid value [%s] for Cassandra replication_factor. Using default value of 1",
+                    replicationFactorProp);
+            replicationFactor.set(1);
+        }
+
         AdvancedCache<String, String> cache = locksCache.getAdvancedCache();
         DistributedLock schemaLock = new DistributedLock(cache, "cassalog");
         schemaLock.lockAndThen(30000, () -> {
             SchemaService schemaService = new SchemaService();
-            schemaService.run(session, keyspace, Boolean.parseBoolean(resetDb));
+            schemaService.run(session, keyspace, Boolean.parseBoolean(resetDb), replicationFactor.get());
             session.execute("USE " + keyspace);
         });
     }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -563,7 +563,7 @@ public class MetricsServiceLifecycle {
             log.warnf("Unable to determine replication_factor for keyspace %s", keyspace);
         }
         Map<String, String> replication = resultSet.one().getMap(0, String.class, String.class);
-        log.infof("The keyspace %s is using a replication_factor of %d", keyspace,
+        log.infof("The keyspace %s is using a replication_factor of %s", keyspace,
                 replication.get("replication_factor"));
     }
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -562,8 +562,9 @@ public class MetricsServiceLifecycle {
         if (resultSet.isExhausted()) {
             log.warnf("Unable to determine replication_factor for keyspace %s", keyspace);
         }
+        Map<String, String> replication = resultSet.one().getMap(0, String.class, String.class);
         log.infof("The keyspace %s is using a replication_factor of %d", keyspace,
-                resultSet.one().getInt(0));
+                replication.get("replication_factor"));
     }
 
     /**

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -35,6 +35,8 @@ public enum ConfigurationKey {
     CASSANDRA_NODES("hawkular.metrics.cassandra.nodes", "127.0.0.1", "CASSANDRA_NODES", false),
     CASSANDRA_CQL_PORT("hawkular.metrics.cassandra.cql-port", "9042", "CASSANDRA_CQL_PORT", false),
     CASSANDRA_KEYSPACE("hawkular.metrics.cassandra.keyspace", "hawkular_metrics", null, false),
+    CASSANDRA_REPLICATION_FACTOR("hawkular.metrics.cassandra.replication-factor", "1", "CASSANDRA_REPLICATION_FACTOR",
+            false),
     CASSANDRA_RESETDB("hawkular.metrics.cassandra.resetdb", null, null, true),
     CASSANDRA_USESSL("hawkular.metrics.cassandra.use-ssl", "false", "CASSANDRA_USESSL", false),
     CASSANDRA_MAX_CONN_HOST("hawkular.metrics.cassandra.max-connections-per-host", "10", "CASSANDRA_MAX_CONN_HOST",

--- a/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
+++ b/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
@@ -42,14 +42,17 @@ import com.google.common.collect.ImmutableMap;
 public class SchemaService {
 
     public void run(Session session, String keyspace, boolean resetDB) {
+        run(session, keyspace, resetDB, 1);
+    }
 
-
+    public void run(Session session, String keyspace, boolean resetDB, int replicationFactor) {
         CassalogBuilder builder = new CassalogBuilder();
         Cassalog cassalog = builder.withKeyspace(keyspace).withSession(session).build();
         Map<String, ?> vars  = ImmutableMap.of(
                 "keyspace", keyspace,
                 "reset", resetDB,
-                "session", session
+                "session", session,
+                "replicationFactor", replicationFactor
         );
         // TODO Add logic to determine the version tags we need to pass
         // For now, I am just hard coding the version tag, but a more robust solution would be

--- a/core/schema/src/main/resources/org/hawkular/schema/bootstrap.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/bootstrap.groovy
@@ -76,7 +76,8 @@ if (!reset && keyspaceExists(keyspace)) {
     executeCQL("DROP KEYSPACE IF EXISTS $keyspace", 20000)
   }
 
-  executeCQL("CREATE KEYSPACE $keyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+  executeCQL("CREATE KEYSPACE $keyspace WITH replication = {'class': 'SimpleStrategy', " +
+      "'replication_factor': $replicationFactor}")
   executeCQL("USE $keyspace")
 
   // The retentions map entries are {metric type, retention} key/value paris where


### PR DESCRIPTION
It can be set at start up using the hawkular.metrics.cassandra.replication-factor
system property or the CASSANDRA_REPLICATION_FACTOR environment variable.