### PR TITLE
Update RxJava to 1.2.4

### DIFF
--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/SortedMerge.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/SortedMerge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ import rx.internal.util.unsafe.MpscLinkedQueue;
  *
  * Originally from https://gist.github.com/akarnokd/c86a89738199bbb37348
  *
- * This is modified with remove duplicates from stream
+ * This is modified with remove duplicates from stream and updated to use RxJava 1.2.x API
  *
  * @author Michael Burman
  */
@@ -110,7 +110,7 @@ public final class SortedMerge<T> implements OnSubscribe<T> {
         /** */
         private static final long serialVersionUID = -812969080497027108L;
 
-        final NotificationLite<T> nl = NotificationLite.instance();
+//        final NotificationLite<T> nl = NotificationLite.instance();
 
         final boolean delayErrors;
         final Comparator<? super T> comparator;
@@ -239,7 +239,7 @@ public final class SortedMerge<T> implements OnSubscribe<T> {
                         }
                         // if we already found a value, compare it against the current
                         if (hasAtLeastOne) {
-                            T v = nl.getValue(o);
+                            T v = NotificationLite.getValue(o);
                             int c = comparator.compare(minimum, v);
                             if (c > 0) {
                                 minimum = v;
@@ -250,7 +250,7 @@ public final class SortedMerge<T> implements OnSubscribe<T> {
                             }
                         } else {
                             // this is the first value found
-                            minimum = nl.getValue(o);
+                            minimum = NotificationLite.getValue(o);
                             hasAtLeastOne = true;
                             toPoll = i;
                         }
@@ -333,7 +333,7 @@ public final class SortedMerge<T> implements OnSubscribe<T> {
         @Override
         public void onNext(T t) {
             try {
-                queue.onNext(parent.nl.next(t));
+                queue.onNext(NotificationLite.next(t));
             } catch (MissingBackpressureException mbe) {
                 try {
                     onError(mbe);

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -108,7 +108,7 @@
     <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
     <version.org.infinispan.wildfly>8.0.1.Final</version.org.infinispan.wildfly>
     <version.org.slf4j>1.7.7</version.org.slf4j>
-    <version.io.reactivex.rxjava>1.1.7</version.io.reactivex.rxjava>
+    <version.io.reactivex.rxjava>1.2.4</version.io.reactivex.rxjava>
     <version.io.reactivex.rxjava-math>1.0.0</version.io.reactivex.rxjava-math>
     <version.io.reactivex.rxjava-guava>1.0.3</version.io.reactivex.rxjava-guava>
     <version.org.codehaus.mojo.findbugs-maven-plugin>3.0.0</version.org.codehaus.mojo.findbugs-maven-plugin>


### PR DESCRIPTION
Updates RxJava version 1.2.4 (some API changes and performance improvements compared to 1.1.7)