### PR TITLE
[HWKMETRICS-572] Make admin tenant configurable. The admin tenant is …

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.metrics.api.jaxrs;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -22,6 +21,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 
+import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.ADMIN_TENANT;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.ADMIN_TOKEN;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_CONNECTION_TIMEOUT;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CASSANDRA_CQL_PORT;
@@ -41,7 +41,7 @@ import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.DEFAULT_TTL
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.DISABLE_METRICS_JMX;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.INGEST_MAX_RETRIES;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.INGEST_MAX_RETRY_DELAY;
-import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.METRICS_REPOPRTING_HOSTNAME;
+import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.METRICS_REPORTING_HOSTNAME;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.PAGE_SIZE;
 import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.WAIT_FOR_SERVICE;
 
@@ -229,6 +229,11 @@ public class MetricsServiceLifecycle {
 
     @Inject
     @Configurable
+    @ConfigurationProperty(ADMIN_TENANT)
+    private String adminTenant;
+
+    @Inject
+    @Configurable
     @ConfigurationProperty(INGEST_MAX_RETRIES)
     private String ingestMaxRetries;
 
@@ -254,7 +259,7 @@ public class MetricsServiceLifecycle {
 
     @Inject
     @Configurable
-    @ConfigurationProperty(METRICS_REPOPRTING_HOSTNAME)
+    @ConfigurationProperty(METRICS_REPORTING_HOSTNAME)
     private String metricsReportingHostname;
 
     @Inject
@@ -386,9 +391,9 @@ public class MetricsServiceLifecycle {
 
             MetricNameService metricNameService;
             if (metricsReportingHostname == null) {
-                metricNameService = new MetricNameService();
+                metricNameService = new MetricNameService(adminTenant);
             } else {
-                metricNameService = new MetricNameService(metricsReportingHostname);
+                metricNameService = new MetricNameService(metricsReportingHostname, adminTenant);
             }
             metricsService.setMetricNameService(metricNameService);
 

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,8 +56,11 @@ public enum ConfigurationKey {
     WAIT_FOR_SERVICE("hawkular.metrics.waitForService", null, null, true),
     DEFAULT_TTL("hawkular.metrics.default-ttl", "7", "DEFAULT_TTL", false),
     DISABLE_METRICS_JMX("hawkular.metrics.disable-metrics-jmx-reporting", null, "DISABLE_METRICS_JMX", true),
+
+    //Admin
     ADMIN_TOKEN("hawkular.metrics.admin-token", null, "ADMIN_TOKEN", false),
-    METRICS_REPOPRTING_HOSTNAME("hawkular.metrics.reporting.hostname", null, "METRICS_REPORTING_HOSTNAME", false),
+    ADMIN_TENANT("hawkular.metrics.admin-tenant", "admin", "ADMIN_TENANT", false),
+    METRICS_REPORTING_HOSTNAME("hawkular.metrics.reporting.hostname", null, "METRICS_REPORTING_HOSTNAME", false),
 
     INGEST_MAX_RETRIES("hawkular.metrics.ingestion.retry.max-retries", null, "INGEST_MAX_RETRIES", false),
     INGEST_MAX_RETRY_DELAY("hawkular.metrics.ingestion.retry.max-delay", null, "INGEST_MAX_RETRY_DELAY", false),

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/DropWizardReporter.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/DropWizardReporter.java
@@ -183,7 +183,7 @@ public class DropWizardReporter extends ScheduledReporter {
     }
 
     private <T> MetricId<T> getMetricId(String metric, MetricType<T> type) {
-        String tenantId = MetricNameService.TENANT_ID;
+        String tenantId = metricNameService.getTenantId();
         return new MetricId<>(tenantId, type, metric);
     }
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/MetricNameService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/MetricNameService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,11 +33,11 @@ import com.google.common.base.Preconditions;
  */
 public class MetricNameService implements MetricFilter {
 
-    public static final String TENANT_ID = "admin";
 
     private static final String separator = ":";
 
-    private String hostname;
+    private final String adminTenant;
+    private final String hostname;
 
     public MetricNameService() {
         try {
@@ -45,14 +45,31 @@ public class MetricNameService implements MetricFilter {
         } catch (UnknownHostException e) {
             throw new RuntimeException("Failed to get hostname", e);
         }
+
+        this.adminTenant = "admin";
     }
 
-    public MetricNameService(String hostname) {
+    public MetricNameService(String adminTenant) {
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException("Failed to get hostname", e);
+        }
+
+        this.adminTenant = adminTenant;
+    }
+
+    public MetricNameService(String hostname, String adminTenant) {
         this.hostname = hostname;
+        this.adminTenant = adminTenant;
     }
 
     public String getHostName() {
         return hostname;
+    }
+
+    public String getTenantId() {
+        return adminTenant;
     }
 
     /**

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/MetricsInitializer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/MetricsInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,7 +71,7 @@ public class MetricsInitializer {
         List<Metric<Long>> counterMetrics = new ArrayList<>();
 
         metricRegistry.getMeters(metricNameService).entrySet().forEach(entry -> {
-            String tenantId = MetricNameService.TENANT_ID;
+            String tenantId = metricNameService.getTenantId();
             String metricName = entry.getKey();
             Map<String, String> tags = getTags(metricName);
 
@@ -84,7 +84,7 @@ public class MetricsInitializer {
         });
 
         metricRegistry.getTimers(metricNameService).entrySet().forEach(entry -> {
-            String tenantId = MetricNameService.TENANT_ID;
+            String tenantId = metricNameService.getTenantId();
             String metricName = entry.getKey();
             Map<String, String> tags = getTags(metricName);
 


### PR DESCRIPTION
…used for persisting internal metrics.