### PR TITLE
[HWKMETRICS-582] Upgrade joda-time 2.7 -> 2.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <version.org.hawkular.alerts>1.5.0.Final</version.org.hawkular.alerts>
     <version.org.hawkular.commons>0.9.1.Final</version.org.hawkular.commons>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
-    <version.joda-time>2.7</version.joda-time>
+    <version.joda-time>2.9.5</version.joda-time>
     <version.logback>1.1.3</version.logback>
     <!-- Taken from Wildfly BOM, keep in sync (core-impl cannot import Wildfly BOM) -->
     <version.org.jboss.logging>3.3.0.Final</version.org.jboss.logging>


### PR DESCRIPTION
(cherry picked from commit cd83a172307d7ecccd6436c6336018e09601219f)
Signed-off-by: Stefan Negrea <snegrea@redhat.com>