### PR TITLE
[HWKMETRICS-556] use TWCS for data_compressed table

### DIFF
--- a/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
+++ b/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +55,7 @@ public class SchemaService {
         // For now, I am just hard coding the version tag, but a more robust solution would be
         // to calculate the tags using the current version stored in the sys_config table
         // and the new version which we can extract from any of our JAR manifest files.
-        List<String> tags = asList("0.15.x", "0.18.x", "0.19.x", "0.20.x", "0.21.x");
+        List<String> tags = asList("0.15.x", "0.18.x", "0.19.x", "0.20.x", "0.21.x", "0.23.x");
         URI script = getScript();
         cassalog.execute(script, tags, vars);
 

--- a/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.23.0.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.23.0.groovy
@@ -1,4 +1,3 @@
-package org.hawkular.schema
 /*
  * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
@@ -16,13 +15,22 @@ package org.hawkular.schema
  * limitations under the License.
  */
 
-include '/org/hawkular/schema/bootstrap.groovy'
+schemaChange {
+  version '6.0'
+  author 'jsanda'
+  tags '0.23.x'
+  cql """
+ALTER TABLE data_compressed WITH compaction = {
+  'class': 'TimeWindowCompactionStrategy',
+  'compaction_window_unit': 'DAYS',
+  'compaction_window_size': '1'
+}
+"""
+}
 
-setKeyspace keyspace
-
-include '/org/hawkular/schema/updates/schema-0.15.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.18.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.19.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.20.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.21.0.groovy'
-include '/org/hawkular/schema/updates/schema-0.23.0.groovy'
+schemaChange {
+  version '6.1'
+  author 'jsanda'
+  tags '0.23.x'
+  cql "ALTER TABLE data WITH compaction = {'class': 'SizeTieredCompactionStrategy'}"
+}


### PR DESCRIPTION
We are also switching back to STCS for the data table because we are now doing
range deletes as part of the compression job. Eventually I think we'll switch
over to using what are essentially temporary tables for raw data that we just
drop once we are done writing to them and have compressed the data.

[HWKEMTRICS-556] license header

[HWKMETRICS-556] this is what i get for trying to catch up with work on the weekend

[HWKMETRICS-556] cehckstyle