### PR TITLE
Fix JMH benchmarks to work with current version of Hawkular-Metrics.

### DIFF
--- a/integration-tests/jmh-benchmark/pom.xml
+++ b/integration-tests/jmh-benchmark/pom.xml
@@ -21,8 +21,8 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>hawkular-metrics-parent</artifactId>
     <groupId>org.hawkular.metrics</groupId>
+    <artifactId>hawkular-metrics-integration-tests</artifactId>
     <version>0.25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -30,18 +30,45 @@
   <artifactId>hawkular-metrics-jmh-benchmark</artifactId>
 
   <properties>
-    <jmh.version>1.12</jmh.version>
+    <jmh.version>1.17.4</jmh.version>
     <jar.name>benchmark</jar.name>
     <javac.target>1.8</javac.target>
   </properties>
 
 
   <dependencies>
+    <!-- Internal dependencies -->
     <dependency>
-      <groupId>org.hawkular.metrics</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>hawkular-metrics-core-service</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hawkular-metrics-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hawkular-metrics-rx-java-driver</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hawkular-metrics-schema</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hawkular-metrics-configuration-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hawkular-metrics-datetime-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
@@ -65,6 +92,10 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.logging</groupId>

--- a/integration-tests/jmh-benchmark/run.sh
+++ b/integration-tests/jmh-benchmark/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+# Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,5 +16,8 @@
 # limitations under the License.
 #
 
-#mvn clean install
-java -Xmx2048m -Xms1024m -jar target/benchmark.jar
+cd ../../core/metrics-core-service/ &&
+mvn clean install -DskipTests=true -Dlicense.skip &&
+cd - &&
+mvn clean install &&
+java -Xmx1024m -Xms1024m -jar target/benchmark.jar &&

--- a/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/InsertBenchmark.java
+++ b/integration-tests/jmh-benchmark/src/main/java/org/hawkular/metrics/benchmark/jmh/InsertBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,8 +58,8 @@ import rx.Subscriber;
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 @Fork(1)
-@Warmup(iterations = 5)
-@Measurement(iterations = 10) // Reduce the amount of iterations if you start to see GC interference
+@Warmup(iterations = 3)
+@Measurement(iterations = 5) // Reduce the amount of iterations if you start to see GC interference
 public class InsertBenchmark {
 
     @State(Scope.Benchmark)
@@ -122,9 +122,9 @@ public class InsertBenchmark {
     }
 
     // Equivalent to REST-tests for inserting size-amount of metrics in one call
-//    @Benchmark
-//    @OperationsPerInvocation(100000) // Note, this is metric amount from param size, not datapoints
-    public void insertBenchmark(GaugeMetricCreator creator, ServiceCreator service, Blackhole bh) {
+    @Benchmark
+    @OperationsPerInvocation(100000) // Note, this is metric amount from param size, not datapoints
+    public void insertBenchmarkRxJava1(GaugeMetricCreator creator, ServiceCreator service, Blackhole bh) {
         bh.consume(service.getMetricsService().addDataPoints(GAUGE, creator.getMetricObservable())
                 .toBlocking().lastOrDefault(null));
     }


### PR DESCRIPTION
Refactoring of the packages in Hawkular-Metrics did not fix all the packages (such as JMH benchmarks) which are not compiled in the normal clean install process.