### PR TITLE
[HWKMETRICS-589] Add REST API request logging

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -53,6 +53,7 @@ import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransfo
 import org.hawkular.metrics.api.jaxrs.param.TimeAndBucketParams;
 import org.hawkular.metrics.api.jaxrs.param.TimeAndSortParams;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
+import org.hawkular.metrics.api.jaxrs.util.Logged;
 import org.hawkular.metrics.core.service.Functions;
 import org.hawkular.metrics.core.service.Order;
 import org.hawkular.metrics.model.ApiError;
@@ -88,6 +89,7 @@ import rx.schedulers.Schedulers;
 @Produces(APPLICATION_JSON)
 @Api(tags = "Availability")
 @ApplicationScoped
+@Logged
 public class AvailabilityHandler extends MetricsServiceHandler implements IMetricsHandler<AvailabilityType> {
 
     @POST

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -56,6 +56,7 @@ import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransfo
 import org.hawkular.metrics.api.jaxrs.param.TimeAndBucketParams;
 import org.hawkular.metrics.api.jaxrs.param.TimeAndSortParams;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
+import org.hawkular.metrics.api.jaxrs.util.Logged;
 import org.hawkular.metrics.core.service.Functions;
 import org.hawkular.metrics.core.service.Order;
 import org.hawkular.metrics.model.ApiError;
@@ -90,6 +91,7 @@ import rx.schedulers.Schedulers;
 @Produces(APPLICATION_JSON)
 @Api(tags = "Counter")
 @ApplicationScoped
+@Logged
 public class CounterHandler extends MetricsServiceHandler implements IMetricsHandler<Long> {
 
     @POST

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -57,6 +57,7 @@ import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransfo
 import org.hawkular.metrics.api.jaxrs.param.TimeAndBucketParams;
 import org.hawkular.metrics.api.jaxrs.param.TimeAndSortParams;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
+import org.hawkular.metrics.api.jaxrs.util.Logged;
 import org.hawkular.metrics.core.service.Functions;
 import org.hawkular.metrics.core.service.Order;
 import org.hawkular.metrics.model.ApiError;
@@ -93,6 +94,7 @@ import rx.schedulers.Schedulers;
 @Produces(APPLICATION_JSON)
 @Api(tags = "Gauge")
 @ApplicationScoped
+@Logged
 public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandler<Double> {
 
     private Logger logger = Logger.getLogger(GaugeHandler.class);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -62,6 +62,7 @@ import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransfo
 import org.hawkular.metrics.api.jaxrs.param.DurationConverter;
 import org.hawkular.metrics.api.jaxrs.param.PercentilesConverter;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
+import org.hawkular.metrics.api.jaxrs.util.Logged;
 import org.hawkular.metrics.api.jaxrs.util.MetricTypeTextConverter;
 import org.hawkular.metrics.core.service.Functions;
 import org.hawkular.metrics.core.service.MetricsService;
@@ -98,6 +99,7 @@ import rx.Observable;
 @Produces(APPLICATION_JSON)
 @Api(tags = "Metric")
 @ApplicationScoped
+@Logged
 public class MetricHandler {
     @Inject
     private MetricsService metricsService;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
@@ -52,6 +52,7 @@ import org.hawkular.metrics.api.jaxrs.handler.template.IMetricsHandler;
 import org.hawkular.metrics.api.jaxrs.handler.transformer.MinMaxTimestampTransformer;
 import org.hawkular.metrics.api.jaxrs.param.TimeAndSortParams;
 import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
+import org.hawkular.metrics.api.jaxrs.util.Logged;
 import org.hawkular.metrics.core.service.Functions;
 import org.hawkular.metrics.core.service.Order;
 import org.hawkular.metrics.model.ApiError;
@@ -80,6 +81,7 @@ import rx.schedulers.Schedulers;
 @Api(tags = "String", description = "This resource is experimental and changes may be made to it in subsequent " +
         "releases that are not backwards compatible.")
 @ApplicationScoped
+@Logged
 public class StringHandler extends MetricsServiceHandler implements IMetricsHandler<String> {
 
     @POST

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/TenantsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/TenantsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/TenantsHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/TenantsHandler.java
@@ -42,6 +42,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.hawkular.metrics.api.jaxrs.handler.observer.TenantCreatedObserver;
+import org.hawkular.metrics.api.jaxrs.util.Logged;
 import org.hawkular.metrics.core.jobs.JobsService;
 import org.hawkular.metrics.core.service.MetricsService;
 import org.hawkular.metrics.model.ApiError;
@@ -64,6 +65,7 @@ import io.swagger.annotations.ApiResponses;
 @Produces(APPLICATION_JSON)
 @Api(tags = "Tenant")
 @ApplicationScoped
+@Logged
 public class TenantsHandler {
 
     private Logger logger = Logger.getLogger(TenantsHandler.class);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/Logged.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/Logged.java
@@ -28,9 +28,13 @@ import javax.ws.rs.NameBinding;
 /**
  * Annotation that can be applied to a JAX-RS resource class (i.e., handler) or method to enable logging of HTTP
  * requests for REST endpoints. The
- * {@link org.hawkular.metrics.api.jaxrs.config.ConfigurationKey#REQUEST_LOGGING_LEVEL REQUEST_LOGGING_LEVEL} and
+ * {@link org.hawkular.metrics.api.jaxrs.config.ConfigurationKey#REQUEST_LOGGING_LEVEL REQUEST_LOGGING_LEVEL} property
+ * must be set to enable logging for most endpoints. The value should a logging level, e.g., TRACE, DEBUG, INFO, WARN,
+ * ERROR, or FATAL. The value should be upper case. If the value does not match any of the logging levels, then DEBUG is
+ * used. The
  * {@link org.hawkular.metrics.api.jaxrs.config.ConfigurationKey#REQUEST_LOGGING_LEVEL_WRITES REQUEST_LOGGING_LEVEL_WRITES}
- * configuration properties specify the level at which to log requests.
+ * property must be set to enable logging for endpoints that write data points. Its value should also be an upper case
+ * logging level.
  *
  * @author jsanda
  */

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/Logged.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/Logged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,16 +16,6 @@
  */
 package org.hawkular.metrics.api.jaxrs.util;
 
-/**
- * Annotation that can be applied to a JAX-RS resource class (i.e., handler) or method to enable logging of HTTP
- * requests for REST endpoints. The
- * {@link org.hawkular.metrics.api.jaxrs.config.ConfigurationKey#REQUEST_LOGGING_LEVEL REQUEST_LOGGING_LEVEL} and
- * {@link org.hawkular.metrics.api.jaxrs.config.ConfigurationKey#REQUEST_LOGGING_LEVEL_WRITES REQUEST_LOGGING_LEVEL_WRITES}
- * configuration properties specify the level at which to log requests.
- *
- * @author jsanda
- */
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -35,6 +25,15 @@ import java.lang.annotation.Target;
 
 import javax.ws.rs.NameBinding;
 
+/**
+ * Annotation that can be applied to a JAX-RS resource class (i.e., handler) or method to enable logging of HTTP
+ * requests for REST endpoints. The
+ * {@link org.hawkular.metrics.api.jaxrs.config.ConfigurationKey#REQUEST_LOGGING_LEVEL REQUEST_LOGGING_LEVEL} and
+ * {@link org.hawkular.metrics.api.jaxrs.config.ConfigurationKey#REQUEST_LOGGING_LEVEL_WRITES REQUEST_LOGGING_LEVEL_WRITES}
+ * configuration properties specify the level at which to log requests.
+ *
+ * @author jsanda
+ */
 @NameBinding
 @Retention(RUNTIME)
 @Target({TYPE, METHOD})

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/Logged.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/Logged.java
@@ -17,6 +17,12 @@
 package org.hawkular.metrics.api.jaxrs.util;
 
 /**
+ * Annotation that can be applied to a JAX-RS resource class (i.e., handler) or method to enable logging of HTTP
+ * requests for REST endpoints. The
+ * {@link org.hawkular.metrics.api.jaxrs.config.ConfigurationKey#REQUEST_LOGGING_LEVEL REQUEST_LOGGING_LEVEL} and
+ * {@link org.hawkular.metrics.api.jaxrs.config.ConfigurationKey#REQUEST_LOGGING_LEVEL_WRITES REQUEST_LOGGING_LEVEL_WRITES}
+ * configuration properties specify the level at which to log requests.
+ *
  * @author jsanda
  */
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/Logged.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/Logged.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.util;
+
+/**
+ * @author jsanda
+ */
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.NameBinding;
+
+@NameBinding
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+public @interface Logged {
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/RequestLoggingFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/RequestLoggingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/RequestLoggingFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/util/RequestLoggingFilter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.util;
+
+import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.REQUEST_LOGGING_LEVEL;
+import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.REQUEST_LOGGING_LEVEL_WRITES;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.PathSegment;
+import javax.ws.rs.ext.Provider;
+
+import org.hawkular.metrics.api.jaxrs.config.Configurable;
+import org.hawkular.metrics.api.jaxrs.config.ConfigurationProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * @author jsanda
+ */
+@Logged
+@Provider
+public class RequestLoggingFilter implements ContainerRequestFilter {
+
+    private static Logger logger = Logger.getLogger(RequestLoggingFilter.class);
+
+    @Inject
+    @Configurable
+    @ConfigurationProperty(REQUEST_LOGGING_LEVEL)
+    private String loggingLevelConfig;
+
+    @Inject
+    @Configurable
+    @ConfigurationProperty(REQUEST_LOGGING_LEVEL_WRITES)
+    private String writesLoggingLevelConfig;
+
+    private Logger.Level logLevel;
+
+    private Logger.Level writesLogLevel;
+
+    @PostConstruct
+    public void init() {
+        logLevel = getLogLevel(loggingLevelConfig);
+        writesLogLevel = getLogLevel(writesLoggingLevelConfig);
+    }
+
+    private Logger.Level getLogLevel(String config) {
+        if (config == null) {
+            return  null;
+        }
+        switch (config) {
+            case "TRACE": return Logger.Level.TRACE;
+            case "INFO": return Logger.Level.INFO;
+            case "WARN": return Logger.Level.WARN;
+            case "ERROR": return Logger.Level.ERROR;
+            case "FATAL": return Logger.Level.FATAL;
+            default: return Logger.Level.DEBUG;
+        }
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        try {
+            if (isInsertDataRequest(requestContext)) {
+                if (writesLogLevel != null) {
+                    logRequest(writesLogLevel, requestContext);
+                }
+            } else if (logLevel != null) {
+                logRequest(logLevel, requestContext);
+            }
+        } catch (Exception e) {
+            logger.info("Failed to log request", e);
+        }
+    }
+
+    private boolean isInsertDataRequest(ContainerRequestContext requestContext) {
+        List<PathSegment> pathSegments = requestContext.getUriInfo().getPathSegments();
+        return (requestContext.getMethod().equals("POST")) && !pathSegments.get(pathSegments.size() - 1).getPath()
+                .equals("query");
+    }
+
+    private void logRequest(Logger.Level level, ContainerRequestContext requestContext) {
+        String request =
+                "\n" +
+                "REST API request:\n" +
+                "--------------------------------------\n" +
+                "path: " + requestContext.getUriInfo().getPath() + "\n" +
+                "segments: " + requestContext.getUriInfo().getPathSegments() + "\n" +
+                "method: " + requestContext.getMethod() + "\n" +
+                "query parameters: " + requestContext.getUriInfo().getQueryParameters() + "\n" +
+                "headers: " + requestContext.getHeaders() + "\n" +
+                "--------------------------------------\n";
+        logger.log(level, request);
+    }
+
+
+}

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -65,7 +65,7 @@ public enum ConfigurationKey {
 
     // Request logging properties
     // Useful for debugging
-    REQUEST_LOGGING_LEVEL("hawkular.metrics.request.logging.level", "DEBUG", "REQUEST_LOGGING_LEVEL", false),
+    REQUEST_LOGGING_LEVEL("hawkular.metrics.request.logging.level", null, "REQUEST_LOGGING_LEVEL", false),
     REQUEST_LOGGING_LEVEL_WRITES("hawkular.metrics.request.logging.level.writes", null, "REQUEST_LOGGING_LEVEL_WRITES",
             false),
 

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -63,6 +63,12 @@ public enum ConfigurationKey {
     METRICS_REPORTING_HOSTNAME("hawkular.metrics.reporting.hostname", null, "METRICS_REPORTING_HOSTNAME", false),
     METRICS_REPORTING_ENABLED("hawkular.metrics.reporting.enabled", null, "METRICS_REPORTING_ENABLED", true),
 
+    // Request logging properties
+    // Useful for debugging
+    REQUEST_LOGGING_LEVEL("hawkular.metrics.request.logging.level", "DEBUG", "REQUEST_LOGGING_LEVEL", false),
+    REQUEST_LOGGING_LEVEL_WRITES("hawkular.metrics.request.logging.level.writes", null, "REQUEST_LOGGING_LEVEL_WRITES",
+            false),
+
     INGEST_MAX_RETRIES("hawkular.metrics.ingestion.retry.max-retries", null, "INGEST_MAX_RETRIES", false),
     INGEST_MAX_RETRY_DELAY("hawkular.metrics.ingestion.retry.max-delay", null, "INGEST_MAX_RETRY_DELAY", false),
 


### PR DESCRIPTION
There are two properties that control request logging one of which is for writes. I felt it necessary to have a separate property for logging writes because it could result in lots of extra logging.

The output looks like:

```
INFO  [org.hawkular.metrics.api.jaxrs.util.RequestLoggingFilter] (default task-49)
REST API request:
--------------------------------------
path: /metrics
segments: [metrics]
method: GET
query parameters: {type=[availability]}
Tenant: T9a116f18-28cf-41b3-8ff8-c9752ac60e26232
```