### PR TITLE
[HWKMETRICS-565]

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -146,6 +146,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -146,10 +146,10 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
             metricObservable = metricsService.findMetrics(getTenant(), AVAILABILITY);
         }
 
-        metricObservable
-                .compose(new MinMaxTimestampTransformer<>(metricsService))
-                .observeOn(Schedulers.io())
-                .subscribe(createMetricObserver(AVAILABILITY));
+//        metricObservable
+//                .compose(new MinMaxTimestampTransformer<>(metricsService))
+//                .observeOn(Schedulers.io())
+//                .subscribe(createMetricObserver(AVAILABILITY));
     }
 
     @GET
@@ -313,7 +313,7 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
                         .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
                                 p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
                                 .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(AVAILABILITY));
+                .subscribe(createNamedDataPointObserver(null, AVAILABILITY));
     }
 
     @Deprecated

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -26,7 +26,6 @@ import static org.hawkular.metrics.model.MetricType.AVAILABILITY;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.PatternSyntaxException;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Consumes;
@@ -150,7 +149,7 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
         metricObservable
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
                 .observeOn(Schedulers.io())
-                .subscribe(createMetricObserver(asyncResponse, AVAILABILITY));
+                .subscribe(createMetricObserver(AVAILABILITY));
     }
 
     @GET
@@ -314,7 +313,7 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
                         .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
                                 p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
                                 .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(asyncResponse, AVAILABILITY));
+                .subscribe(createNamedDataPointObserver(AVAILABILITY));
     }
 
     @Deprecated

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -149,15 +149,8 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
 
         metricObservable
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
-                .toList()
-                .map(ApiUtils::collectionToResponse)
-                .subscribe(asyncResponse::resume, t -> {
-                    if (t instanceof PatternSyntaxException) {
-                        asyncResponse.resume(badRequest(t));
-                    } else {
-                        asyncResponse.resume(serverError(t));
-                    }
-                });
+                .observeOn(Schedulers.io())
+                .subscribe(createMetricObserver(asyncResponse, AVAILABILITY));
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -22,7 +22,6 @@ import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.badRequest;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.noContent;
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.serverError;
 import static org.hawkular.metrics.model.MetricType.COUNTER;
-import static org.hawkular.metrics.model.MetricType.COUNTER_RATE;
 
 import java.net.URI;
 import java.util.Collections;
@@ -79,7 +78,6 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import rx.Observable;
-import rx.schedulers.Schedulers;
 
 /**
  * @author Stefan Negrea
@@ -152,10 +150,10 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             metricObservable = metricsService.findMetrics(getTenant(), COUNTER);
         }
 
-        metricObservable
-                .compose(new MinMaxTimestampTransformer<>(metricsService))
-                .observeOn(Schedulers.io())
-                .subscribe(createMetricObserver(COUNTER));
+//        metricObservable
+//                .compose(new MinMaxTimestampTransformer<>(metricsService))
+//                .observeOn(Schedulers.io())
+//                .subscribe(createMetricObserver(COUNTER));
     }
 
     @GET
@@ -275,16 +273,17 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
                     "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
-        findMetricsByNameOrTag(query.getIds(), query.getTags(), COUNTER)
-                .toList()
-                .flatMap(metricIds -> TimeAndSortParams.<Long>deferredBuilder(query.getStart(), query.getEnd())
-                            .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
-                            .sortOptions(query.getLimit(), query.getOrder())
-                            .toObservable()
-                            .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
-                                    p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
-                                .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(COUNTER));
+//        findMetricsByNameOrTag(query.getIds(), query.getTags(), COUNTER)
+//                .toList()
+//                .flatMap(metricIds -> TimeAndSortParams.<Long>deferredBuilder(query.getStart(), query.getEnd())
+//                            .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
+//                            .sortOptions(query.getLimit(), query.getOrder())
+//                            .toObservable()
+//                            .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
+//                                    p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+//                                .observeOn(Schedulers.io())))
+//                .subscribe(createNamedDataPointObserver(COUNTER));
+        throw new UnsupportedOperationException();
     }
 
     @POST
@@ -303,16 +302,17 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
                     "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
-        findMetricsByNameOrTag(query.getIds(), query.getTags(), COUNTER)
-                .toList()
-                .flatMap(metricIds -> TimeAndSortParams.<Long>deferredBuilder(query.getStart(), query.getEnd())
-                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
-                        .sortOptions(query.getLimit(), query.getOrder())
-                        .toObservable()
-                        .flatMap(p -> metricsService.findRateData(metricIds, p.getTimeRange().getStart(),
-                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
-                            .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(COUNTER_RATE));
+//        findMetricsByNameOrTag(query.getIds(), query.getTags(), COUNTER)
+//                .toList()
+//                .flatMap(metricIds -> TimeAndSortParams.<Long>deferredBuilder(query.getStart(), query.getEnd())
+//                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
+//                        .sortOptions(query.getLimit(), query.getOrder())
+//                        .toObservable()
+//                        .flatMap(p -> metricsService.findRateData(metricIds, p.getTimeRange().getStart(),
+//                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+//                            .observeOn(Schedulers.io())))
+//                .subscribe(createNamedDataPointObserver(COUNTER_RATE));
+        throw new UnsupportedOperationException();
     }
 
     @Deprecated

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -155,7 +155,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
         metricObservable
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
                 .observeOn(Schedulers.io())
-                .subscribe(createMetricObserver(asyncResponse, COUNTER));
+                .subscribe(createMetricObserver(COUNTER));
     }
 
     @GET
@@ -284,7 +284,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
                             .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
                                     p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
                                 .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(asyncResponse, COUNTER));
+                .subscribe(createNamedDataPointObserver(COUNTER));
     }
 
     @POST
@@ -312,7 +312,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
                         .flatMap(p -> metricsService.findRateData(metricIds, p.getTimeRange().getStart(),
                                 p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
                             .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(asyncResponse, COUNTER_RATE));
+                .subscribe(createNamedDataPointObserver(COUNTER_RATE));
     }
 
     @Deprecated

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -28,7 +28,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.PatternSyntaxException;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Consumes;
@@ -155,15 +154,8 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
 
         metricObservable
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
-                .toList()
-                .map(ApiUtils::collectionToResponse)
-                .subscribe(asyncResponse::resume, t -> {
-                    if (t instanceof PatternSyntaxException) {
-                        asyncResponse.resume(badRequest(t));
-                    } else {
-                        asyncResponse.resume(serverError(t));
-                    }
-                });
+                .observeOn(Schedulers.io())
+                .subscribe(createMetricObserver(asyncResponse, COUNTER));
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -151,10 +151,10 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
             metricObservable = metricsService.findMetrics(getTenant(), GAUGE);
         }
 
-        metricObservable
-                .compose(new MinMaxTimestampTransformer<>(metricsService))
-                .observeOn(Schedulers.io())
-                .subscribe(createMetricObserver(GAUGE));
+//        metricObservable
+//                .compose(new MinMaxTimestampTransformer<>(metricsService))
+//                .observeOn(Schedulers.io())
+//                .subscribe(createMetricObserver(GAUGE));
     }
 
     @GET
@@ -307,16 +307,17 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
             @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
                     "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
-        findMetricsByNameOrTag(query.getIds(), query.getTags(), GAUGE)
-                .toList()
-                .flatMap(metricIds -> TimeAndSortParams.<Double>deferredBuilder(query.getStart(), query.getEnd())
-                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
-                        .sortOptions(query.getLimit(), query.getOrder())
-                        .toObservable()
-                        .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
-                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
-                                .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(GAUGE));
+//        findMetricsByNameOrTag(query.getIds(), query.getTags(), GAUGE)
+//                .toList()
+//                .flatMap(metricIds -> TimeAndSortParams.<Double>deferredBuilder(query.getStart(), query.getEnd())
+//                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
+//                        .sortOptions(query.getLimit(), query.getOrder())
+//                        .toObservable()
+//                        .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
+//                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+//                                .observeOn(Schedulers.io())))
+//                .subscribe(createNamedDataPointObserver(GAUGE));
+        throw new UnsupportedOperationException();
     }
 
     @POST
@@ -335,16 +336,17 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
             @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
                     "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
-        findMetricsByNameOrTag(query.getIds(), query.getTags(), GAUGE)
-                .toList()
-                .flatMap(metricIds -> TimeAndSortParams.<Double>deferredBuilder(query.getStart(), query.getEnd())
-                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
-                        .sortOptions(query.getLimit(), query.getOrder())
-                        .toObservable()
-                        .flatMap(p -> metricsService.findRateData(metricIds, p.getTimeRange().getStart(),
-                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
-                                .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver( GAUGE_RATE));
+//        findMetricsByNameOrTag(query.getIds(), query.getTags(), GAUGE)
+//                .toList()
+//                .flatMap(metricIds -> TimeAndSortParams.<Double>deferredBuilder(query.getStart(), query.getEnd())
+//                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
+//                        .sortOptions(query.getLimit(), query.getOrder())
+//                        .toObservable()
+//                        .flatMap(p -> metricsService.findRateData(metricIds, p.getTimeRange().getStart(),
+//                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+//                                .observeOn(Schedulers.io())))
+//                .subscribe(createNamedDataPointObserver( GAUGE_RATE));
+        throw new UnsupportedOperationException();
     }
 
     @Deprecated

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -155,15 +155,8 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
 
         metricObservable
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
-                .toList()
-                .map(ApiUtils::collectionToResponse)
-                .subscribe(asyncResponse::resume, t -> {
-                    if (t instanceof PatternSyntaxException) {
-                        asyncResponse.resume(badRequest(t));
-                    } else {
-                        asyncResponse.resume(serverError(t));
-                    }
-                });
+                .observeOn(Schedulers.io())
+                .subscribe(createMetricObserver(asyncResponse, GAUGE));
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -19,7 +19,6 @@ package org.hawkular.metrics.api.jaxrs.handler;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.badRequest;
-import static org.hawkular.metrics.api.jaxrs.util.ApiUtils.serverError;
 import static org.hawkular.metrics.model.MetricType.GAUGE;
 import static org.hawkular.metrics.model.MetricType.GAUGE_RATE;
 import static org.hawkular.metrics.model.MetricType.UNDEFINED;
@@ -29,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.regex.PatternSyntaxException;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Consumes;
@@ -156,7 +154,7 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
         metricObservable
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
                 .observeOn(Schedulers.io())
-                .subscribe(createMetricObserver(asyncResponse, GAUGE));
+                .subscribe(createMetricObserver(GAUGE));
     }
 
     @GET
@@ -318,7 +316,7 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
                         .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
                                 p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
                                 .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(asyncResponse, GAUGE));
+                .subscribe(createNamedDataPointObserver(GAUGE));
     }
 
     @POST
@@ -346,7 +344,7 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
                         .flatMap(p -> metricsService.findRateData(metricIds, p.getTimeRange().getStart(),
                                 p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
                                 .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(asyncResponse, GAUGE_RATE));
+                .subscribe(createNamedDataPointObserver( GAUGE_RATE));
     }
 
     @Deprecated

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricHandler.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -76,6 +78,7 @@ import org.hawkular.metrics.model.param.BucketConfig;
 import org.hawkular.metrics.model.param.Duration;
 import org.hawkular.metrics.model.param.Tags;
 import org.hawkular.metrics.model.param.TimeRange;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import com.google.common.base.Strings;
 
@@ -222,10 +225,13 @@ public class MetricHandler extends MetricsServiceHandler {
             }
         }
 
+        HttpServletRequest request = ResteasyProviderFactory.getContextData(HttpServletRequest.class);
+        HttpServletResponse response = ResteasyProviderFactory.getContextData(HttpServletResponse.class);
+
         metricObservable
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
                 .observeOn(Schedulers.io())
-                .subscribe(createMetricObserver(asyncResponse, metricType));
+                .subscribe(createMetricObserver(metricType));
     }
 
     @Deprecated

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricsServiceHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricsServiceHandler.java
@@ -23,7 +23,8 @@ import java.util.List;
 import java.util.Optional;
 
 import javax.inject.Inject;
-import javax.ws.rs.container.AsyncResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 
@@ -35,6 +36,7 @@ import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.exception.RuntimeApiError;
 import org.hawkular.metrics.model.param.TimeRange;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -58,8 +60,10 @@ abstract class MetricsServiceHandler {
         return httpHeaders.getRequestHeaders().getFirst(TENANT_HEADER_NAME);
     }
 
-    <T> NamedDataPointObserver<T> createNamedDataPointObserver(AsyncResponse response, MetricType<T> type) {
-        return new NamedDataPointObserver<>(response, mapper, type);
+    <T> NamedDataPointObserver<T> createNamedDataPointObserver(MetricType<T> type) {
+        HttpServletRequest request = ResteasyProviderFactory.getContextData(HttpServletRequest.class);
+        HttpServletResponse response = ResteasyProviderFactory.getContextData(HttpServletResponse.class);
+        return new NamedDataPointObserver<>(request, response, mapper, type);
     }
 
     <T> Observable<MetricId<T>> findMetricsByNameOrTag(List<String> metricNames, String tags, MetricType<T> type) {
@@ -108,7 +112,9 @@ abstract class MetricsServiceHandler {
         return Observable.just(timeRange);
     }
 
-    <T> MetricObserver<T> createMetricObserver(AsyncResponse response, MetricType<T> type) {
-        return new MetricObserver<>(response, mapper);
+    <T> MetricObserver<T> createMetricObserver(MetricType<T> type) {
+        HttpServletRequest request = ResteasyProviderFactory.getContextData(HttpServletRequest.class);
+        HttpServletResponse response = ResteasyProviderFactory.getContextData(HttpServletResponse.class);
+        return new MetricObserver<>(request, response, mapper);
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricsServiceHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricsServiceHandler.java
@@ -27,6 +27,7 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 
+import org.hawkular.metrics.api.jaxrs.handler.observer.MetricObserver;
 import org.hawkular.metrics.api.jaxrs.handler.observer.NamedDataPointObserver;
 import org.hawkular.metrics.core.service.MetricsService;
 import org.hawkular.metrics.model.Metric;
@@ -105,5 +106,9 @@ abstract class MetricsServiceHandler {
             return Observable.error(new RuntimeApiError(timeRange.getProblem()));
         }
         return Observable.just(timeRange);
+    }
+
+    <T> MetricObserver<T> createMetricObserver(AsyncResponse response, MetricType<T> type) {
+        return new MetricObserver<>(response, mapper);
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
@@ -68,7 +68,6 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import rx.Observable;
-import rx.schedulers.Schedulers;
 
 /**
  * @author jsanda
@@ -134,10 +133,10 @@ public class StringHandler extends MetricsServiceHandler implements IMetricsHand
             metricObservable = metricsService.findMetrics(getTenant(), STRING);
         }
 
-        metricObservable
-                .compose(new MinMaxTimestampTransformer<>(metricsService))
-                .observeOn(Schedulers.io())
-                .subscribe(createMetricObserver(STRING));
+//        metricObservable
+//                .compose(new MinMaxTimestampTransformer<>(metricsService))
+//                .observeOn(Schedulers.io())
+//                .subscribe(createMetricObserver(STRING));
     }
 
     @GET
@@ -271,17 +270,18 @@ public class StringHandler extends MetricsServiceHandler implements IMetricsHand
             @ApiParam(required = true, value = "Query parameters that minimally must include a list of metric ids or " +
                     "tags. The standard start, end, order, and limit query parameters are supported as well.")
                     QueryRequest query) {
-        findMetricsByNameOrTag(query.getIds(), query.getTags(), STRING)
-                .toList()
-                .flatMap(metricIds -> TimeAndSortParams.<String>deferredBuilder(query.getStart(), query.getEnd())
-                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
-                        .sortOptions(query.getLimit(), query.getOrder())
-                        .forString()
-                        .toObservable()
-                        .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
-                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
-                                .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(STRING));
+//        findMetricsByNameOrTag(query.getIds(), query.getTags(), STRING)
+//                .toList()
+//                .flatMap(metricIds -> TimeAndSortParams.<String>deferredBuilder(query.getStart(), query.getEnd())
+//                        .fromEarliest(query.getFromEarliest(), metricIds, this::findTimeRange)
+//                        .sortOptions(query.getLimit(), query.getOrder())
+//                        .forString()
+//                        .toObservable()
+//                        .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
+//                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+//                                .observeOn(Schedulers.io())))
+//                .subscribe(createNamedDataPointObserver(STRING));
+        throw new UnsupportedOperationException();
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
@@ -137,7 +137,7 @@ public class StringHandler extends MetricsServiceHandler implements IMetricsHand
         metricObservable
                 .compose(new MinMaxTimestampTransformer<>(metricsService))
                 .observeOn(Schedulers.io())
-                .subscribe(createMetricObserver(asyncResponse, STRING));
+                .subscribe(createMetricObserver(STRING));
     }
 
     @GET
@@ -281,7 +281,7 @@ public class StringHandler extends MetricsServiceHandler implements IMetricsHand
                         .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
                                 p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
                                 .observeOn(Schedulers.io())))
-                .subscribe(createNamedDataPointObserver(asyncResponse, STRING));
+                .subscribe(createNamedDataPointObserver(STRING));
     }
 
     @GET

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/observer/MetricObserver.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/observer/MetricObserver.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.handler.observer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.hawkular.metrics.api.jaxrs.util.ApiUtils;
+import org.hawkular.metrics.model.Metric;
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import rx.Subscriber;
+
+/**
+ * @author jsanda
+ */
+// TODO Create a base class for MetricObserver and NamedDataPointObserver
+public class MetricObserver<T> extends Subscriber<Metric<T>> {
+
+    private static Logger logger = Logger.getLogger(MetricObserver.class);
+
+    @FunctionalInterface
+    private interface WriteValue<T> {
+        void call(Metric<T> dataPoint) throws IOException;
+    }
+
+    private final AsyncResponse response;
+    private final JsonGenerator generator;
+    private AtomicInteger count;
+    private final ByteArrayOutputStream jsonOutputStream;
+
+    private volatile Metric<T> current;
+
+    public MetricObserver(AsyncResponse response, ObjectMapper mapper) {
+        this.response = response;
+        count = new AtomicInteger();
+        jsonOutputStream = new ByteArrayOutputStream();
+        try {
+            generator = mapper.getFactory().createGenerator(jsonOutputStream, JsonEncoding.UTF8);
+            generator.writeStartArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void onNext(Metric<T> metric) {
+        try {
+            count.incrementAndGet();
+            generator.writeStartObject();
+            generator.writeStringField("id", metric.getMetricId().getName());
+            generator.writeStringField("tenantId", metric.getMetricId().getTenantId());
+            generator.writeStringField("type", metric.getMetricId().getType().toString());
+            if (!metric.getTags().isEmpty()) {
+                generator.writeObjectFieldStart("tags");
+                for (Map.Entry<String, String> tag : metric.getTags().entrySet()) {
+                    generator.writeStringField(tag.getKey(), tag.getValue());
+                }
+                generator.writeEndObject();
+            }
+            if (metric.getDataRetention() != null) {
+                generator.writeNumberField("dataRetention", metric.getDataRetention());
+            }
+            if (metric.getMinTimestamp() != null) {
+                generator.writeNumberField("minTimestamp", metric.getMinTimestamp());
+            }
+            if (metric.getMaxTimestamp() != null) {
+                generator.writeNumberField("maxTimestamp", metric.getMaxTimestamp());
+            }
+            generator.writeEndObject();
+        } catch (IOException e) {
+            throw new RuntimeException("Streaming data to client failed", e);
+        }
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        logger.warn("Fetching data failed", e);
+        try {
+            if (count.get() == 0) {
+                response.resume(ApiUtils.serverError(e));
+            } else {
+                generator.close();
+            }
+        } catch (IOException ie) {
+            logger.warn("There was an error closing the JSON generator", ie);
+        }
+    }
+
+    @Override
+    public void onCompleted() {
+        Response result = null;
+        try {
+            if (count.get() == 0) {
+                generator.close();
+                result = Response.ok().status(HttpServletResponse.SC_NO_CONTENT).build();
+            } else {
+                generator.writeEndArray();
+                generator.close();
+                result = Response.ok(new String(jsonOutputStream.toByteArray()), MediaType.APPLICATION_JSON_TYPE)
+                        .build();
+            }
+        } catch (IOException e) {
+            logger.warn("There was an error while finishing streaming data", e);
+            result = ApiUtils.serverError(e);
+        } finally {
+            if (result == null) {
+                result = Response.serverError().build();
+            }
+            response.resume(result);
+        }
+    }
+}

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
@@ -26,6 +26,62 @@ import static org.junit.Assert.assertEquals
 class MetricsITest extends RESTTest {
 
   @Test
+  void createAndFindMetrics() {
+    String tenantId = nextTenantId()
+    createMetric(tenantId, [
+        id: 'M1',
+        type: 'gauge',
+        tags: [
+            x: 1,
+            y: 2,
+            z: 3
+        ]
+    ])
+    createMetric(tenantId, [
+        id: 'M2',
+        type: 'gauge',
+        tags: [
+            x: 4,
+            y: 5,
+            z: 6
+        ]
+    ])
+
+    def response = hawkularMetrics.get(path: 'metrics', headers: [(tenantHeaderName): tenantId], query: [type: 'gauge'])
+    assertEquals(200, response.status)
+    printJson(response.data)
+    assertEquals([
+        [
+            id: 'M1',
+            tags: [
+                x: '1',
+                y: '2',
+                z: '3'
+            ],
+            dataRetention: 7,
+            type: 'gauge',
+            tenantId: tenantId
+        ],
+        [
+            id: 'M2',
+            tags: [
+                x: '4',
+                y: '5',
+                z: '6'
+            ],
+            dataRetention: 7,
+            type: 'gauge',
+            tenantId: tenantId
+        ]
+    ], response.data)
+  }
+
+  def createMetric(String tenantId, Map metric) {
+    def response = hawkularMetrics.post(path: 'metrics', headers: [(tenantHeaderName): tenantId], body: metric)
+    assertEquals(201, response.status)
+  }
+
+  @Test
   void addMixedData() {
     String tenantId = nextTenantId()
     DateTime start = DateTime.now().minusMinutes(10)


### PR DESCRIPTION
Update endpoints for fetching metric definitions to chunk responses rather than building the entire response in memory before sending it to the client.