### PR TITLE
HWKALERTS-240 Add Metrics Group Trigger support in the metrics alerter

### DIFF
--- a/alerting/alerter-war/pom.xml
+++ b/alerting/alerter-war/pom.xml
@@ -111,6 +111,18 @@
       <version>1.5</version>
     </dependency>
 
+    <!-- documentation -->
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Tests -->
     <dependency>
       <groupId>junit</groupId>

--- a/alerting/alerter-war/src/main/java/org/hawkular/metrics/alerter/ConditionManager.java
+++ b/alerting/alerter-war/src/main/java/org/hawkular/metrics/alerter/ConditionManager.java
@@ -81,7 +81,19 @@ public class ConditionManager {
     private static final String TAG_EXTERNAL_CONDITION_NAME = "HawkularMetrics";
     private static final String TAG_EXTERNAL_CONDITION_VALUE = "MetricsCondition";
 
-    private static final Integer THREAD_POOL_SIZE = 20;
+    private static final Integer THREAD_POOL_SIZE;
+    private static final String THREAD_POOL_SIZE_DEFAULT = "20";
+    private static final String THREAD_POOL_SIZE_PROPERTY = "hawkular-metrics.alerter.condition-pool-size";
+
+    static {
+        int v;
+        try {
+            v = Integer.valueOf(System.getProperty(THREAD_POOL_SIZE_PROPERTY, THREAD_POOL_SIZE_DEFAULT));
+        } catch (Exception e) {
+            v = Integer.valueOf(THREAD_POOL_SIZE_DEFAULT);
+        }
+        THREAD_POOL_SIZE = v;
+    }
 
     ScheduledThreadPoolExecutor expressionExecutor;
     Map<ExternalCondition, ScheduledFuture<?>> expressionFutures = new HashMap<>();

--- a/alerting/alerter-war/src/main/java/org/hawkular/metrics/alerter/groups/GroupTriggerManager.java
+++ b/alerting/alerter-war/src/main/java/org/hawkular/metrics/alerter/groups/GroupTriggerManager.java
@@ -1,0 +1,593 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.alerter.groups;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.inject.Inject;
+
+import org.hawkular.alerts.api.json.GroupMemberInfo;
+import org.hawkular.alerts.api.model.condition.CompareCondition;
+import org.hawkular.alerts.api.model.condition.Condition;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.alerts.api.services.DefinitionsEvent;
+import org.hawkular.alerts.api.services.DefinitionsListener;
+import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.metrics.core.service.MetricsService;
+import org.hawkular.metrics.model.Metric;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
+import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
+import org.jboss.logging.Logger;
+
+/**
+ * Another feature of the Metrics Alerter is an ability to manage a Metrics Group Trigger.  A Metrics Group Trigger
+ * is an hAlerting group trigger that has a member trigger for each metric is a set scoped by a metrics tag query.
+ * The concept is similar to data-driven triggers but because metrics does not lend itself to the required
+ * source+dataId approach used by data-driven triggers, we use this approach.
+ * <p>
+ * We interact with hAlerting to pull properly tagged group triggers.  We set up a job for each to query for
+ * metrics, and maintain member triggers for each.
+ * </p><p>
+ * Each Metrics Group Trigger has several tags to guide its handling:
+ * </p><pre>
+ *   "HawkularMetrics" : "GroupTrigger"       // Required to be processed as Metrics Group Trigger
+ *   "DataIds"         : DataId1..DataIdN     // The DataIds used in the trigger conditions, required
+ *   DataId1           : tag query            // Metrics tag query for dataId1 metrics
+ *     ...
+ *   DataIdN           : tag query            // Metrics tag query for dataIdN metrics
+ *   "SourceBy"        : TagName1..TagNameN   // *see below*
+ * </pre>
+ * <h4>SourceBy</h4>
+ * The SourceBy tag specifies the metric tag names used to determine the member trigger population.  As an example,
+ * consider a group trigger with one CompareCondition:  HeapUsed > 80% HeapMax.  We want to compare HeapUsed to HeapMax
+ * but of course each comparison should be done on metrics from the same machine.  We don't want to compare all
+ * HeapUsed to all HeapMax for every machine in the data center.  We'd want a group trigger tagged something like this:
+ * <pre>
+ *   "HawkularMetrics" : "GroupTrigger"
+ *   "DataIds"         : "HeapUsed,HeapMax"
+ *   "HeapUsed"        : name = "HeapUsed"
+ *   "HeapMax"         : name = "HeapMax"
+ *   "SourceBy"        : Machine
+ * </pre>
+ * This would result in one member trigger per machine, for machine names common to HeapUsed and HeapMax metrics. So,
+ * if we had the following metrics in the database, tagged as specified:
+ * <pre>
+ *   /machine0/HeapUsed    {name=HeapUsed, Machine=machine0}
+ *   /machine0/HeapMax     {name=HeapMax, Machine=machine0}
+ *   /machine1/HeapUsed    {name=HeapUsed, Machine=machine1}
+ *   /machine1/HeapMax     {name=HeapMax, Machine=machine1}
+ *   /machine2/HeapUsed    {name=HeapUsed}
+ *   /machine2/HeapMax     {name=HeapMax}
+ *   /machine3/HeapUsed    {name=HeapUsed, Machine=machine3}
+ *   /machine4/HeapMax     {name=HeapMax, Machine=machine4}
+
+ * </pre>
+ * Then we would get two member triggers, one each testing:
+ * <pre>
+ *   /machine0/HeapUsed < 80% /machine0/HeapMax
+ *   /machine1/HeapUsed < 80% /machine1/HeapMax
+ * </pre><p>
+ * We would not have a 3rd member trigger because machine2 metrics don't have the necessary tags, machine3 does not
+ * have the HeapMax metric, and machine4 does not have the HeapUsed metric.
+ * </p><p>
+ * SourceBy is required, but can be set to '*' to generate member triggers for all value combinations (not recommended
+ * when multiple dataIds are involved).
+ * </p>
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Startup
+@Singleton
+public class GroupTriggerManager {
+    private final Logger log = Logger.getLogger(GroupTriggerManager.class);
+
+    private static final String TAG_DATA_IDS = "DataIds";
+    private static final String TAG_GROUP_TRIGGER = "HawkularMetrics";
+    private static final String TAG_GROUP_TRIGGER_VALUE = "GroupTrigger";
+    private static final String TAG_SOURCE_BY = "SourceBy";
+
+    private static final Integer THREAD_POOL_SIZE;
+    private static final String THREAD_POOL_SIZE_DEFAULT = "20";
+    private static final String THREAD_POOL_SIZE_PROPERTY = "hawkular-metrics.alerter.mgt.pool-size";
+    private static final Integer JOB_PERIOD;
+    private static final String JOB_PERIOD_DEFAULT = String.valueOf(60 * 60); // 1 hour
+    private static final String JOB_PERIOD_PROPERTY = "hawkular-metrics.alerter.mgt.job-period-seconds";
+
+    static {
+        int v;
+        try {
+            v = Integer.valueOf(System.getProperty(THREAD_POOL_SIZE_PROPERTY, THREAD_POOL_SIZE_DEFAULT));
+        } catch (Exception e) {
+            v = Integer.valueOf(THREAD_POOL_SIZE_DEFAULT);
+        }
+        THREAD_POOL_SIZE = v;
+
+        try {
+            v = Integer.valueOf(System.getProperty(JOB_PERIOD_PROPERTY, JOB_PERIOD_DEFAULT));
+        } catch (Exception e) {
+            v = Integer.valueOf(JOB_PERIOD_DEFAULT);
+        }
+        JOB_PERIOD = v;
+    }
+
+    ScheduledThreadPoolExecutor mgtExecutor;
+    Map<Trigger, ScheduledFuture<?>> mgtFutures = new HashMap<>();
+
+    /**
+     * Indicate if the deployment is on a clustering scenario and if so if this is the coordinator node
+     */
+    private boolean distributed = false;
+    private boolean coordinator = false;
+    private TopologyChangeListener topologyChangeListener = null;
+    private DefinitionsListener definitionsListener = null;
+
+    @Inject
+    private MetricsService metrics;
+
+    @Inject
+    private DefinitionsService definitions;
+
+    /**
+     * Access to the manager of the caches used for the partition services.  This is used to inspect cluster
+     * topology and ensure we only run the external alerter on one node (the coordinator). Otherwise
+     * each node would execute the same work, resulting in duplicate alerts.
+     */
+    @Resource(lookup = "java:jboss/infinispan/container/hawkular-alerts")
+    private EmbeddedCacheManager cacheManager;
+
+    @PostConstruct
+    public void init() {
+        // Cache manager has an active transport (i.e. jgroups) when is configured on distributed mode
+        distributed = cacheManager.getTransport() != null;
+
+        if (distributed) {
+            topologyChangeListener = new TopologyChangeListener();
+            cacheManager.addListener(topologyChangeListener);
+        }
+
+        processTopologyChange();
+    }
+
+    // When a node is joining/leaving the cluster the coordinator node could change
+    @Listener
+    public class TopologyChangeListener {
+        @ViewChanged
+        public void onTopologyChange(ViewChangedEvent cacheEvent) {
+            processTopologyChange();
+        }
+    }
+
+    private void processTopologyChange() {
+        boolean currentCoordinator = coordinator;
+        coordinator = distributed ? cacheManager.isCoordinator() : true;
+
+        if (coordinator && !currentCoordinator) {
+            start();
+
+        } else if (!coordinator && currentCoordinator) {
+            stop();
+        }
+    }
+
+    public void start() {
+        log.infof("Starting Hawkular Metrics Group Trigger Manager, distributed=%s", distributed);
+
+        mgtExecutor = new ScheduledThreadPoolExecutor(THREAD_POOL_SIZE);
+
+        refresh();
+
+        if (null == definitionsListener) {
+            log.info("Registering Trigger UPDATE/REMOVE listener");
+            definitionsListener = new DefinitionsListener() {
+                @Override
+                public void onChange(Set<DefinitionsEvent> event) {
+                    if (coordinator) {
+                        log.debugf("Refreshing due to change event %s", event);
+                        refresh();
+                    }
+                }
+            };
+            definitions.registerListener(definitionsListener, DefinitionsEvent.Type.TRIGGER_CONDITION_CHANGE,
+                    DefinitionsEvent.Type.TRIGGER_REMOVE);
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (coordinator) {
+            stop();
+        }
+
+        if (distributed) {
+            cacheManager.removeListener(topologyChangeListener);
+            cacheManager.stop();
+        }
+    }
+
+    public void stop() {
+        log.infof("Stopping Hawkular Metrics Group Trigger Manager, distributed=%s", distributed);
+
+        if (null != mgtFutures) {
+            mgtFutures.values().forEach(f -> f.cancel(true));
+        }
+        if (null != mgtExecutor) {
+            mgtExecutor.shutdown();
+            mgtExecutor = null;
+        }
+    }
+
+    public void cancel(Trigger mgt) {
+        ScheduledFuture<?> f = mgtFutures.get(mgt);
+        if (null != f) {
+            log.debugf("Canceling Hawkular Metrics Group Trigger Job for %s", mgt);
+            try {
+                f.cancel(true);
+                mgtFutures.remove(mgt);
+            } catch (Exception e) {
+                log.warnf("Failed to cancel Hawkular Metrics Group Trigger Job for %s: %s", mgt, e.getMessage());
+            }
+        }
+    }
+
+    private void refresh() {
+        try {
+            // get all of the metrics group triggers (tagged for hawkular metrics)
+            Collection<Trigger> taggedMgts = definitions.getAllTriggersByTag(
+                    TAG_GROUP_TRIGGER,
+                    TAG_GROUP_TRIGGER_VALUE);
+            log.debugf("Refreshing [%s] Metrics Group Triggers!", taggedMgts.size());
+
+            // generate valid set of metrics group trigger ids
+            Set<Trigger> mgts = taggedMgts.stream()
+                    .filter(t -> {
+                        if (!t.isGroup()) {
+                            log.warnf("Tagged as Metrics Group Trigger is not a group trigger, skipping %s", t);
+                            return false;
+                        }
+                        return true;
+                    })
+                    .collect(Collectors.toSet());
+
+            // for each metrics group trigger run a job to manage its member trigger set
+            for (Trigger mgt : mgts) {
+                if (mgtFutures.containsKey(mgt)) {
+                    log.debugf("Already running job for MGT %s", mgt);
+
+                } else {
+                    try {
+                        // start the job.
+                        log.infof("Adding MGT runner for %s with job period %d seconds", mgt, JOB_PERIOD);
+
+                        MGTRunner runner = new MGTRunner(metrics, definitions, mgt);
+                        mgtFutures.put(
+                                mgt,
+                                mgtExecutor.scheduleAtFixedRate(runner, 0L, JOB_PERIOD, TimeUnit.SECONDS));
+                    } catch (Exception e) {
+                        log.errorf("Failed to schedule metrics group trigger %s: %s ", mgt, e.getMessage());
+                    }
+                }
+            }
+
+            // cancel any job for an mgt not in the current set
+            Set<Trigger> doomedJobs = mgtFutures.keySet().stream()
+                    .filter(k -> !mgts.contains(k))
+                    .collect(Collectors.toSet());
+            doomedJobs.stream().forEach(k -> {
+                log.infof("Canceling obsolete MGT runner for %s", k);
+                cancel(k);
+            });
+
+        } catch (Exception e) {
+            log.error("Failed to refresh Metrics Group Triggers.", e);
+        }
+    }
+
+    static class MGTRunner implements Runnable {
+        private final Logger log = Logger.getLogger(GroupTriggerManager.MGTRunner.class);
+
+        private MetricsService metricsService;
+        private DefinitionsService definitionsService;
+        private Trigger metricsGroupTrigger;
+        private Integer dataIdMapHash;
+
+        public MGTRunner(MetricsService metrics, DefinitionsService definitionsService, Trigger metricsGroupTrigger) {
+            super();
+            this.metricsService = metrics;
+            this.definitionsService = definitionsService;
+            this.metricsGroupTrigger = metricsGroupTrigger;
+        }
+
+        @Override
+        public void run() {
+            try {
+                log.debugf("Running job for MGT %s", metricsGroupTrigger);
+
+                // fetch the trigger to make sure it still exists and is tagged appropriately
+                Trigger mgt = definitionsService.getTrigger(metricsGroupTrigger.getTenantId(),
+                        metricsGroupTrigger.getId());
+
+                if (null == mgt) {
+                    log.warnf("Metrics Group Trigger not found. Skipping %s", mgt);
+                    return;
+                }
+                if (!mgt.isGroup()) {
+                    log.warnf("Metrics Group Trigger is not a group trigger, skipping %s", mgt);
+                    return;
+                }
+                Map<String, String> tags = mgt.getTags();
+                if (isEmpty(tags.getOrDefault(TAG_DATA_IDS, ""))) {
+                    log.warnf("Required Metrics Group Trigger tag [%s] missing or null, skipping %s",
+                            TAG_DATA_IDS, mgt);
+                    return;
+                }
+                if (isEmpty(tags.getOrDefault(TAG_SOURCE_BY, ""))) {
+                    log.warnf("Required Metrics Group Trigger tag [%s] missing or null, skipping %s",
+                            TAG_SOURCE_BY, mgt);
+                    return;
+                }
+                // check to make sure each declared dataId has a tag of the same name
+                Set<String> dataIds = Arrays.asList(tags.get(TAG_DATA_IDS).split(",")).stream()
+                        .map(s -> s.trim())
+                        .collect(Collectors.toSet());
+                if (dataIds.stream().anyMatch(s -> tags.getOrDefault(s, "").trim().isEmpty())) {
+                    log.warnf(
+                            "Metrics Group Trigger dataId tag missing or invalid. DataIds %s, Tags %s, skipping %s",
+                            dataIds, tags, mgt);
+                    return;
+                }
+                // get dataId set from conditions and ensure they are the same as declared
+                Set<String> conditionDataIds = new HashSet<>();
+                try {
+                    Collection<Condition> conditions = definitionsService.getTriggerConditions(mgt.getTenantId(),
+                            mgt.getId(), null);
+                    conditionDataIds
+                            .addAll(conditions.stream().map(c -> c.getDataId()).collect(Collectors.toSet()));
+                    conditionDataIds.addAll(conditions.stream()
+                            .filter(c -> c instanceof CompareCondition)
+                            .map(c -> ((CompareCondition) c).getDataId()).collect(Collectors.toSet()));
+                } catch (Exception e) {
+                    log.error("Failed to fetch Conditions when refreshing Metrics Group Trigger " + mgt, e);
+                    return;
+                }
+                if (!dataIds.equals(conditionDataIds)) {
+                    log.warnf("Metrics Group Trigger dataId mismatch. In Tag: %s, In Conditions: %s. Skipping %s",
+                            dataIds, conditionDataIds, mgt);
+                    return;
+                }
+
+                // fetch the metric set for each dataId
+                Map<String, Set<Metric<?>>> dataIdMap = new HashMap<>();
+                for (String dataId : dataIds) {
+                    String tagQuery = tags.get(dataId);
+                    List<Metric<Object>> dataIdMetrics = metricsService
+                            .findMetricsWithFilters(mgt.getTenantId(), null, tagQuery)
+                            .toList()
+                            .toBlocking().firstOrDefault(Collections.emptyList());
+                    dataIdMap.put(dataId, new HashSet<>(dataIdMetrics));
+                }
+
+                // if there is no change in the dataIdMap since the last run we can stop here because the
+                // member set remains the same.
+                Integer hash = dataIdMap.hashCode();
+                if (hash.equals(dataIdMapHash)) {
+                    log.debugf("Metrics Group Trigger has no changes to member set, skipping %s", mgt);
+                    return;
+                }
+                dataIdMapHash = hash;
+
+                // Generate the member triggers.
+                // build a map of source->map<dataId, list<metricName>>
+                Map<List<String>, Map<String, List<String>>> sourceMap = generateSourceMap(tags.get(TAG_SOURCE_BY),
+                        dataIdMap);
+
+                // using the sourceMap generate the memberTriggers. Every tuple for every source is a valid member
+                // as long as it has a metricName for each dataId.
+                Set<GroupMemberInfo> members = generateMembers(mgt, dataIds, sourceMap);
+
+                // now fetch the existing members and synchronize
+                Collection<Trigger> existingMembers = definitionsService.getMemberTriggers(mgt.getTenantId(),
+                        mgt.getId(), true);
+                Set<String> memberIds = members.stream()
+                        .map(m -> m.getMemberId())
+                        .collect(Collectors.toSet());
+                Set<String> existingMemberIds = existingMembers.stream()
+                        .map(t -> t.getId())
+                        .collect(Collectors.toSet());
+                log.tracef("members: %s", members);
+                log.tracef("memberIds        : %s", memberIds);
+                log.tracef("existingMemberIds: %s", existingMemberIds);
+                for (GroupMemberInfo member : members) {
+                    if (existingMemberIds.contains(member.getMemberId())) {
+                        log.tracef("Member already exists, skipping %s", member);
+                        continue;
+                    }
+                    try {
+                        log.debugf("Adding Member %s", member);
+                        definitionsService.addMemberTrigger(mgt.getTenantId(), mgt.getId(),
+                                member.getMemberId(),
+                                member.getMemberName(),
+                                member.getMemberDescription(),
+                                member.getMemberContext(),
+                                member.getMemberTags(),
+                                member.getDataIdMap());
+                    } catch (Exception e) {
+                        log.warnf("Failed creating member %s: %s", member, e.getMessage());
+                    }
+                }
+                existingMemberIds.removeAll(memberIds);
+                for (String doomedMemberId : existingMemberIds) {
+                    try {
+                        log.debugf("Removing trigger %s", doomedMemberId);
+                        definitionsService.removeTrigger(mgt.getTenantId(), doomedMemberId);
+                    } catch (Exception e) {
+                        log.warnf("Failed to delete member %s: %s", doomedMemberId, e.getMessage());
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Failed to fetch Triggers for scheduling metrics conditions.", e);
+            }
+        }
+
+        // generate the dataId tuples for the member trigger set. Each member will use dataIds with the same
+        // sourceBy tag values. For example:
+        //   member1:
+        //     HeapUsed /dc1/m1/HeapUsed   tags:{datacenter:dc1,machine:m1}
+        //     HeapMax  /dc1/m1/HeapMax    tags:{datacenter:dc1,machine:m1}
+        //   member2:
+        //     HeapUsed /dc1/m2/HeapUsed   tags:{datacenter:dc1,machine:m2}
+        //     HeapMax  /dc1/m2/HeapMax    tags:{datacenter:dc1,machine:m2}
+        //
+        // To do this, first build a map of source->map<dataId, list<metricName>> and then
+        // use it to generate the member tuples
+        static Map<List<String>, Map<String, List<String>>> generateSourceMap(String sourceByTag,
+                Map<String, Set<Metric<?>>> dataIdMap) {
+
+            // sourceBy is the ordered list of tag names used to group the members
+            List<String> sourceBy = Arrays.asList(sourceByTag.split(",")).stream()
+                    .map(s -> s.trim())
+                    .collect(Collectors.toList());
+            boolean isStarSourceBy = ("*".equals(sourceBy.get(0)));
+            List<String> starSource = isStarSourceBy ? Arrays.asList("*") : null;
+
+            // sourceMap is the result, mapping a source to the dataId substitutions for that source
+            // In the example above, for:
+            //   sourceBy=["datacenter","machine"].
+            // One mapping in sourceMap would be:
+            //   {["dc1","m1"] => {"HeapUsed" => ["/dc1/m1/HeapUsed"],"HeapMax" => ["/dc1/m1/HeapMax"]}}
+            Map<List<String>, Map<String, List<String>>> sourceMap = new HashMap<>();
+
+            // dataIdMap maps the declared dataIds to the metrics in the db resulting from the tagQuery. loop
+            // through the entries and construct the sourceMap
+            for (Entry<String, Set<Metric<?>>> entry : dataIdMap.entrySet()) {
+                String dataId = entry.getKey();
+                Set<Metric<?>> metrics = entry.getValue();
+
+                for (Metric<?> metric : metrics) {
+                    // determine the source for this metric
+                    List<String> source = isStarSourceBy ? starSource : sourceBy.stream()
+                            .map(s -> metric.getTags().get(s))
+                            .filter(s -> null != s)
+                            .collect(Collectors.toList());
+                    // ignore metrics that don't have a tag for each sourceBy entry
+                    if (source.size() < sourceBy.size()) {
+                        continue;
+                    }
+
+                    Map<String, List<String>> metricsMap = sourceMap.get(source);
+                    if (null == metricsMap) {
+                        metricsMap = new HashMap<>();
+                    }
+                    List<String> metricNames = metricsMap.get(dataId);
+                    if (null == metricNames) {
+                        metricNames = new ArrayList<>();
+                    }
+                    metricNames.add(metric.getId());
+                    metricsMap.put(dataId, metricNames);
+                    sourceMap.put(source, metricsMap);
+                }
+            }
+
+            return sourceMap;
+        }
+
+        static Set<GroupMemberInfo> generateMembers(Trigger mgt, Set<String> dataIds,
+                Map<List<String>, Map<String, List<String>>> sourceMap) {
+
+            // Because member triggers inherit the group triggers tags, we override the HawkularMetrics tag to
+            // reflect that this is a member trigger and not an MGT (preventing it from being fetched on refresh)
+            Map<String, String> memberTags = new HashMap<>();
+            memberTags.put("HawkularMetrics", "MemberTrigger");
+
+            Set<GroupMemberInfo> members = new HashSet<>();
+            for (Entry<List<String>, Map<String, List<String>>> sourceMapEntry : sourceMap.entrySet()) {
+                List<String> source = sourceMapEntry.getKey();
+                Map<String, List<String>> metricsMap = sourceMapEntry.getValue();
+
+                // If we can't form a tuple because 1 or more required dataIds have no metrics, then continue
+                if (metricsMap.size() < dataIds.size()) {
+                    Logger log = Logger.getLogger(GroupTriggerManager.MGTRunner.class);
+                    log.warnf("No MGT members: source: %s tags: %s dataIds: %s", source, metricsMap.keySet(),
+                            dataIds);
+                    continue;
+                }
+
+                List<Map<String, String>> memberDataIdMaps = new ArrayList<>();
+
+                for (Entry<String, List<String>> metricsMapEntry : metricsMap.entrySet()) {
+                    String dataId = metricsMapEntry.getKey();
+                    List<String> metricNames = metricsMapEntry.getValue();
+
+                    if (memberDataIdMaps.isEmpty()) {
+                        for (String metricName : metricNames) {
+                            Map<String, String> memberDataIdMap = new HashMap<>();
+                            memberDataIdMap.put(dataId, metricName);
+                            memberDataIdMaps.add(memberDataIdMap);
+                        }
+                    } else {
+                        List<Map<String, String>> prevMemberDataIdMaps = memberDataIdMaps;
+                        memberDataIdMaps = new ArrayList<>();
+                        for (Map<String, String> prevMemberDataIdMap : prevMemberDataIdMaps) {
+                            for (String metricName : metricNames) {
+                                Map<String, String> memberDataIdMap = new HashMap<>();
+                                memberDataIdMap.putAll(prevMemberDataIdMap);
+                                memberDataIdMap.put(dataId, metricName);
+                                memberDataIdMaps.add(memberDataIdMap);
+                            }
+                        }
+                    }
+                }
+
+                Map<String, String> memberContext = new HashMap<>();
+                memberContext.put("source", source.toString());
+
+                for (Map<String, String> memberDataIdMap : memberDataIdMaps) {
+                    // use the memberDataIdMap hashcode as the member trigger id. We'll use this id to
+                    // determine whether the member already exists.
+                    GroupMemberInfo member = new GroupMemberInfo(mgt.getId(),
+                            String.valueOf(memberDataIdMap.hashCode()), null, null, memberContext,
+                            memberTags, memberDataIdMap);
+                    members.add(member);
+                }
+            }
+            return members;
+        }
+
+        private boolean isEmpty(String s) {
+            return null == s || s.trim().isEmpty();
+        }
+    }
+}

--- a/alerting/alerter-war/src/test/java/org/hawkular/metrics/alerter/groups/GroupTriggerManagerTest.java
+++ b/alerting/alerter-war/src/test/java/org/hawkular/metrics/alerter/groups/GroupTriggerManagerTest.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.alerter.groups;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+//import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.json.GroupMemberInfo;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.metrics.model.Metric;
+import org.hawkular.metrics.model.MetricId;
+import org.hawkular.metrics.model.MetricType;
+import org.junit.Test;
+
+public class GroupTriggerManagerTest {
+
+    @Test
+    public void generateSourceMapSingleSourceTest() {
+        String sourceBy = "m";
+
+        Map<String, String> tags = new HashMap<>();
+        tags.put("m", "m0");
+        tags.put("name", "HeapUsed");
+        Metric<?> m0HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m0/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("m", "m0");
+        tags.put("name", "HeapMax");
+        Metric<?> m0HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m0/HeapMax"), tags);
+
+        tags = new HashMap<>();
+        tags.put("m", "m1");
+        tags.put("name", "HeapUsed");
+        Metric<?> m1HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m1/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("m", "m1");
+        tags.put("name", "HeapMax");
+        Metric<?> m1HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m1/HeapMax"), tags);
+
+        Map<String, Set<Metric<?>>> dataIdMap = new HashMap<>();
+        dataIdMap.put("HeapUsed", new HashSet<Metric<?>>(Arrays.asList(m0HU, m1HU)));
+        dataIdMap.put("HeapMax", new HashSet<Metric<?>>(Arrays.asList(m0HM, m1HM)));
+
+        Map<List<String>, Map<String, List<String>>> sourceMap = GroupTriggerManager.MGTRunner.generateSourceMap(
+                sourceBy,
+                dataIdMap);
+        assertEquals(2, sourceMap.keySet().size());
+        List<String> sourceM0 = Arrays.asList("m0");
+        List<String> sourceM1 = Arrays.asList("m1");
+        assertTrue(sourceMap.keySet().contains(sourceM0));
+        assertTrue(sourceMap.keySet().contains(sourceM1));
+        assertEquals(2, sourceMap.get(sourceM0).size());
+        assertTrue(sourceMap.get(sourceM0).keySet().contains("HeapUsed"));
+        assertTrue(sourceMap.get(sourceM0).keySet().contains("HeapMax"));
+        assertTrue(sourceMap.get(sourceM0).get("HeapUsed").contains(m0HU.getId()));
+        assertTrue(sourceMap.get(sourceM0).get("HeapMax").contains(m0HM.getId()));
+        assertEquals(2, sourceMap.get(sourceM1).size());
+        assertTrue(sourceMap.get(sourceM1).keySet().contains("HeapUsed"));
+        assertTrue(sourceMap.get(sourceM1).keySet().contains("HeapMax"));
+        assertTrue(sourceMap.get(sourceM1).get("HeapUsed").contains(m1HU.getId()));
+        assertTrue(sourceMap.get(sourceM1).get("HeapMax").contains(m1HM.getId()));
+    }
+
+    @Test
+    public void generateSourceMapStarSourceTest() {
+        String sourceBy = "*";
+
+        Map<String, String> tags = new HashMap<>();
+        tags.put("m", "m0");
+        tags.put("name", "HeapUsed");
+        Metric<?> m0HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m0/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("m", "m0");
+        tags.put("name", "HeapMax");
+        Metric<?> m0HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m0/HeapMax"), tags);
+
+        tags = new HashMap<>();
+        tags.put("m", "m1");
+        tags.put("name", "HeapUsed");
+        Metric<?> m1HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m1/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("m", "m1");
+        tags.put("name", "HeapMax");
+        Metric<?> m1HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m1/HeapMax"), tags);
+
+        Map<String, Set<Metric<?>>> dataIdMap = new HashMap<>();
+        dataIdMap.put("HeapUsed", new HashSet<Metric<?>>(Arrays.asList(m0HU, m1HU)));
+        dataIdMap.put("HeapMax", new HashSet<Metric<?>>(Arrays.asList(m0HM, m1HM)));
+
+        Map<List<String>, Map<String, List<String>>> sourceMap = GroupTriggerManager.MGTRunner.generateSourceMap(
+                sourceBy,
+                dataIdMap);
+        assertEquals(1, sourceMap.keySet().size());
+        List<String> sourceStar = Arrays.asList("*");
+        assertTrue(sourceMap.keySet().contains(sourceStar));
+        assertEquals(2, sourceMap.get(sourceStar).size());
+        assertTrue(sourceMap.get(sourceStar).keySet().contains("HeapUsed"));
+        assertTrue(sourceMap.get(sourceStar).keySet().contains("HeapMax"));
+        assertTrue(sourceMap.get(sourceStar).get("HeapUsed").contains(m0HU.getId()));
+        assertTrue(sourceMap.get(sourceStar).get("HeapMax").contains(m0HM.getId()));
+        assertTrue(sourceMap.get(sourceStar).get("HeapUsed").contains(m1HU.getId()));
+        assertTrue(sourceMap.get(sourceStar).get("HeapMax").contains(m1HM.getId()));
+    }
+
+    @Test
+    public void generateSourceMapMissingSourceTest() {
+        String sourceBy = "m";
+
+        Map<String, String> tags = new HashMap<>();
+        tags.put("m", "m0");
+        tags.put("name", "HeapUsed");
+        Metric<?> m0HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m0/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("m", "m0");
+        tags.put("name", "HeapMax");
+        Metric<?> m0HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m0/HeapMax"), tags);
+
+        tags = new HashMap<>();
+        tags.put("name", "HeapUsed");
+        Metric<?> m1HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m1/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("name", "HeapMax");
+        Metric<?> m1HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/m1/HeapMax"), tags);
+
+        Map<String, Set<Metric<?>>> dataIdMap = new HashMap<>();
+        dataIdMap.put("HeapUsed", new HashSet<Metric<?>>(Arrays.asList(m0HU, m1HU)));
+        dataIdMap.put("HeapMax", new HashSet<Metric<?>>(Arrays.asList(m0HM, m1HM)));
+
+        Map<List<String>, Map<String, List<String>>> sourceMap = GroupTriggerManager.MGTRunner.generateSourceMap(
+                sourceBy,
+                dataIdMap);
+        assertEquals(1, sourceMap.keySet().size());
+        List<String> sourceM0 = Arrays.asList("m0");
+        assertTrue(sourceMap.keySet().contains(sourceM0));
+        assertEquals(2, sourceMap.get(sourceM0).size());
+        assertTrue(sourceMap.get(sourceM0).keySet().contains("HeapUsed"));
+        assertTrue(sourceMap.get(sourceM0).keySet().contains("HeapMax"));
+        assertTrue(sourceMap.get(sourceM0).get("HeapUsed").contains(m0HU.getId()));
+        assertTrue(sourceMap.get(sourceM0).get("HeapMax").contains(m0HM.getId()));
+    }
+
+    @Test
+    public void generateSourceMapDoubleSourceTest() {
+        String sourceBy = " dc , m "; // for fun, add some extraneous spaces
+
+        Map<String, String> tags = new HashMap<>();
+        tags.put("dc", "dc0");
+        tags.put("m", "m0");
+        tags.put("name", "HeapUsed");
+        Metric<?> dc0m0HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc0/m0/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc0");
+        tags.put("m", "m0");
+        tags.put("name", "HeapMax");
+        Metric<?> dc0m0HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc0/m0/HeapMax"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc0");
+        tags.put("m", "m1");
+        tags.put("name", "HeapUsed");
+        Metric<?> dc0m1HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc0/m1/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc0");
+        tags.put("m", "m1");
+        tags.put("name", "HeapMax");
+        Metric<?> dc0m1HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc0/m1/HeapMax"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc1");
+        tags.put("m", "m0");
+        tags.put("name", "HeapUsed");
+        Metric<?> dc1m0HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc1/m0/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc1");
+        tags.put("m", "m0");
+        tags.put("name", "HeapMax");
+        Metric<?> dc1m0HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc1/m0/HeapMax"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc1");
+        tags.put("m", "m1");
+        tags.put("name", "HeapUsed");
+        Metric<?> dc1m1HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc1/m1/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc1");
+        tags.put("m", "m1");
+        tags.put("name", "HeapMax");
+        Metric<?> dc1m1HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc1/m1/HeapMax"), tags);
+
+        Map<String, Set<Metric<?>>> dataIdMap = new HashMap<>();
+        dataIdMap.put("HeapUsed", new HashSet<Metric<?>>(Arrays.asList(dc0m0HU, dc0m1HU, dc1m0HU, dc1m1HU)));
+        dataIdMap.put("HeapMax", new HashSet<Metric<?>>(Arrays.asList(dc0m0HM, dc0m1HM, dc1m0HM, dc1m1HM)));
+
+        Map<List<String>, Map<String, List<String>>> sourceMap = GroupTriggerManager.MGTRunner.generateSourceMap(
+                sourceBy,
+                dataIdMap);
+        assertEquals(4, sourceMap.keySet().size());
+        List<String> sourceDC0M0 = Arrays.asList("dc0", "m0");
+        List<String> sourceDC0M1 = Arrays.asList("dc0", "m1");
+        List<String> sourceDC1M0 = Arrays.asList("dc1", "m0");
+        List<String> sourceDC1M1 = Arrays.asList("dc1", "m1");
+        assertTrue(sourceMap.keySet().contains(sourceDC0M0));
+        assertTrue(sourceMap.keySet().contains(sourceDC0M1));
+        assertTrue(sourceMap.keySet().contains(sourceDC1M0));
+        assertTrue(sourceMap.keySet().contains(sourceDC1M1));
+        assertEquals(2, sourceMap.get(sourceDC0M0).size());
+        assertTrue(sourceMap.get(sourceDC0M0).keySet().contains("HeapUsed"));
+        assertTrue(sourceMap.get(sourceDC0M0).keySet().contains("HeapMax"));
+        assertTrue(sourceMap.get(sourceDC0M0).get("HeapUsed").contains(dc0m0HU.getId()));
+        assertTrue(sourceMap.get(sourceDC0M0).get("HeapMax").contains(dc0m0HM.getId()));
+        assertEquals(2, sourceMap.get(sourceDC0M1).size());
+        assertTrue(sourceMap.get(sourceDC0M1).keySet().contains("HeapUsed"));
+        assertTrue(sourceMap.get(sourceDC0M1).keySet().contains("HeapMax"));
+        assertTrue(sourceMap.get(sourceDC0M1).get("HeapUsed").contains(dc0m1HU.getId()));
+        assertTrue(sourceMap.get(sourceDC0M1).get("HeapMax").contains(dc0m1HM.getId()));
+        assertEquals(2, sourceMap.get(sourceDC1M0).size());
+        assertTrue(sourceMap.get(sourceDC1M0).keySet().contains("HeapUsed"));
+        assertTrue(sourceMap.get(sourceDC1M0).keySet().contains("HeapMax"));
+        assertTrue(sourceMap.get(sourceDC1M0).get("HeapUsed").contains(dc1m0HU.getId()));
+        assertTrue(sourceMap.get(sourceDC1M0).get("HeapMax").contains(dc1m0HM.getId()));
+        assertEquals(2, sourceMap.get(sourceDC1M1).size());
+        assertTrue(sourceMap.get(sourceDC1M1).keySet().contains("HeapUsed"));
+        assertTrue(sourceMap.get(sourceDC1M1).keySet().contains("HeapMax"));
+        assertTrue(sourceMap.get(sourceDC1M1).get("HeapUsed").contains(dc1m1HU.getId()));
+        assertTrue(sourceMap.get(sourceDC1M1).get("HeapMax").contains(dc1m1HM.getId()));
+    }
+
+    @Test
+    public void generateMembersDoubleSourceTest() {
+        String sourceBy = " dc,m";
+
+        // Same sourceMap as in "generateSourceMapDoubleSourceTest" but remove dc1m1HM metric to test
+        // that we don't get a member for source dc1m1.
+        Map<String, String> tags = new HashMap<>();
+        tags.put("dc", "dc0");
+        tags.put("m", "m0");
+        tags.put("name", "HeapUsed");
+        Metric<?> dc0m0HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc0/m0/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc0");
+        tags.put("m", "m0");
+        tags.put("name", "HeapMax");
+        Metric<?> dc0m0HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc0/m0/HeapMax"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc0");
+        tags.put("m", "m1");
+        tags.put("name", "HeapUsed");
+        Metric<?> dc0m1HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc0/m1/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc0");
+        tags.put("m", "m1");
+        tags.put("name", "HeapMax");
+        Metric<?> dc0m1HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc0/m1/HeapMax"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc1");
+        tags.put("m", "m0");
+        tags.put("name", "HeapUsed");
+        Metric<?> dc1m0HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc1/m0/HeapUsed"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc1");
+        tags.put("m", "m0");
+        tags.put("name", "HeapMax");
+        Metric<?> dc1m0HM = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc1/m0/HeapMax"), tags);
+
+        tags = new HashMap<>();
+        tags.put("dc", "dc1");
+        tags.put("m", "m1");
+        tags.put("name", "HeapUsed");
+        Metric<?> dc1m1HU = new Metric<>(new MetricId<>("tenant", MetricType.GAUGE, "/dc1/m1/HeapUsed"), tags);
+
+        // deliberately missing dc1m1HM to ensure we don't get a dc1,m1 member
+
+        Map<String, Set<Metric<?>>> dataIdMap = new HashMap<>();
+        dataIdMap.put("HeapUsed", new HashSet<Metric<?>>(Arrays.asList(dc0m0HU, dc0m1HU, dc1m0HU, dc1m1HU)));
+        dataIdMap.put("HeapMax", new HashSet<Metric<?>>(Arrays.asList(dc0m0HM, dc0m1HM, dc1m0HM)));
+
+        Map<List<String>, Map<String, List<String>>> sourceMap = GroupTriggerManager.MGTRunner.generateSourceMap(
+                sourceBy,
+                dataIdMap);
+
+        Trigger mgt = new Trigger("tenantId", "mgtId");
+        Set<String> dataIds = new HashSet<>(Arrays.asList("HeapUsed", "HeapMax"));
+        Set<GroupMemberInfo> members = GroupTriggerManager.MGTRunner.generateMembers(mgt, dataIds, sourceMap);
+        assertEquals(4, sourceMap.keySet().size());
+        assertEquals(3, members.size());
+        assertFalse(members.stream()
+                .anyMatch(m -> null == m.getMemberContext() || null == m.getMemberContext().get("source")));
+        List<GroupMemberInfo> membersList = new ArrayList<>(members);
+        Collections.sort(membersList, new Comparator<GroupMemberInfo>() {
+            @Override
+            public int compare(GroupMemberInfo o1, GroupMemberInfo o2) {
+                return o1.getMemberContext().get("source").compareTo(o2.getMemberContext().get("source"));
+            }
+        });
+        System.out.println("Members=" + membersList);
+        assertEquals("[dc0, m0]", membersList.get(0).getMemberContext().get("source"));
+        assertEquals("[dc0, m1]", membersList.get(1).getMemberContext().get("source"));
+        assertEquals("[dc1, m0]", membersList.get(2).getMemberContext().get("source"));
+    }
+
+}

--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -202,6 +202,7 @@
                     <javaOpt>-Dhawkular.metrics.allowed-cors-access-control-allow-headers=random-header1,random-header2</javaOpt>
                     <javaOpt>-Dhawkular.metrics.admin-token=${admin-token}</javaOpt>
                     <javaOpt>-Dhawkular.metrics.cassandra.schema.refresh-interval=0</javaOpt>
+                    <javaOpt>-Dhawkular-metrics.alerter.mgt.job-period-seconds=5</javaOpt>
                     <javaOpt>-Xdebug</javaOpt>
                     <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
                     <javaOpt>-Dhawkular-alerts.engine-period=50</javaOpt>

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/alerting/AlertingITestBase.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/alerting/AlertingITestBase.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,6 +35,7 @@ class AlertingITestBase {
     static metricsBaseURI = System.getProperty('hawkular-metrics.base-uri') ?: 'http://127.0.0.1:8080/hawkular/metrics'
     static RESTClient client
     static RESTClient metricsClient
+    static String tenantId = "hawkular"
 
     @BeforeClass
     static void initClient() {
@@ -52,8 +53,8 @@ class AlertingITestBase {
             .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
          */
         // client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-        client.defaultRequestHeaders.'Hawkular-Tenant' = "hawkular"
+        client.defaultRequestHeaders.'Hawkular-Tenant' = tenantId
         // metricsClient.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-        metricsClient.defaultRequestHeaders.'Hawkular-Tenant' = "hawkular"
+        metricsClient.defaultRequestHeaders.'Hawkular-Tenant' = tenantId
     }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/alerting/GroupTriggerAlerterITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/alerting/GroupTriggerAlerterITest.groovy
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.alerting
+
+import groovy.json.JsonOutput
+import org.hawkular.alerts.api.json.GroupConditionsInfo
+import org.hawkular.alerts.api.model.condition.Condition
+import org.hawkular.alerts.api.model.condition.ThresholdCondition
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.hawkular.alerts.api.model.trigger.TriggerType
+import org.hawkular.metrics.alerter.ConditionExpression
+import org.hawkular.metrics.alerter.ConditionExpression.EvalType
+import org.hawkular.metrics.alerter.ConditionExpression.Function
+import org.hawkular.metrics.alerter.ConditionExpression.Query
+import org.hawkular.metrics.model.MetricType
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.Ignore
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+import static org.junit.runners.MethodSorters.NAME_ASCENDING
+
+/**
+ * Tests Metrics Group Trigger support in the Alerter.
+ *
+ * @author Jay Shaughnessy
+ */
+@FixMethodOrder(NAME_ASCENDING)
+class GroupTriggerAlerterITest extends AlertingITestBase {
+
+    static start = String.valueOf(System.currentTimeMillis())
+
+    @Test
+    void t01_mgtTest() {
+        // Create an MGT for HeapUsed > 80.  Start with two metrics, one tagged to monitored by a member trigger,
+        // and the other not.  Then update the tagging to swap the relevant metric and validate that the
+        // job updates the member trigger set appropriately.
+
+        // send some gauge data to automatically create metrics /<ts>/machine0/HeapUsed and /<ts>/machine1/HeapUsed
+        // The <ts> in the name just prevents conflicts from older test runs
+        long now = System.currentTimeMillis();
+        String metric0 = "|" + now + "|machine0|HeapUsed"
+        String metric1 = "|" + now + "|machine1|HeapUsed"
+        DataPoint dp1 = new DataPoint( metric0, 50.0, now - 30000 );  // 30 seconds ago
+        DataPoint dp2 = new DataPoint( metric1, 50.0, now - 30000 );  // 30 seconds ago
+        sendGaugeDataViaRest( tenantId, dp1, dp2);
+
+        // update metric0 to have the necessary tags
+        Map<String, String> tags = new HashMap<>();
+        tags.put("name", "HeapUsed");
+        tags.put("machine", "machine0");
+        addGaugeTagsViaRest(metric0, tags);
+
+        // update metric1 to have the name tag but not the machine tag
+        tags = new HashMap<>();
+        tags.put("name", "HeapUsed");
+        addGaugeTagsViaRest(metric1, tags)
+
+        // remove test MGT if it exists
+        def resp = client.delete(path: "triggers/groups/mgt")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // CREATE the MGT
+        Trigger mgt = new Trigger("mgt", "mgt");
+        mgt.addTag("HawkularMetrics","GroupTrigger");
+        mgt.addTag("DataIds","HeapUsed");
+        mgt.addTag("HeapUsed","name = HeapUsed");
+        mgt.addTag("SourceBy","machine");
+        mgt.setType(TriggerType.GROUP);
+        mgt.setEnabled(true);
+        mgt.setAutoDisable(true);
+
+        resp = client.post(path: "triggers/groups", body: mgt)
+        assertEquals(200, resp.status)
+
+        ThresholdCondition condition = new ThresholdCondition("mgt", Mode.FIRING, "HeapUsed",
+            ThresholdCondition.Operator.GT, 80.0)
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( condition );
+        GroupConditionsInfo groupConditionsInfo = new GroupConditionsInfo( conditions, null );
+        resp = client.put(path: "triggers/groups/mgt/conditions/firing", body: groupConditionsInfo)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // FETCH group trigger to validate
+        resp = client.get(path: "triggers/mgt");
+        assertEquals(200, resp.status)
+        mgt = (Trigger)resp.data;
+        assertEquals("mgt", mgt.getName())
+        assertTrue(mgt.isGroup());
+        assertTrue(mgt.isEnabled());
+        assertTrue(mgt.isAutoDisable());
+
+        // It should not take long to generate the member but give it a few seconds
+        for ( int i=0; i < 10; ++i ) {
+            Thread.sleep(500);
+
+            resp = client.get(path: "triggers/groups/mgt/members" )
+            if ( resp.status == 200 && resp.data.size() >= 1 ) {
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        Trigger member = (Trigger)resp.data;
+        assertEquals("mgt", mgt.getName())
+        assertFalse(member.isGroup());
+        assertTrue(member.isEnabled());
+        assertTrue(member.isAutoDisable());
+        def memberId = member.getId();
+
+        resp = client.get(path: "triggers/" + memberId + "/conditions")
+        assertEquals(200, resp.status);
+        assertEquals(1, resp.data.size());
+        ThresholdCondition mtc = (ThresholdCondition)resp.data[0];
+        assertEquals(metric0, mtc.getDataId());
+
+        // remove tag from metric0 to remove it as a member
+        deleteGaugeTagsViaRest(metric0, "machine");
+
+        // add tag to metric1 to add it as a member
+        tags = new HashMap<>();
+        tags.put("name", "HeapUsed");
+        tags.put("machine", "machine1");
+        addGaugeTagsViaRest(metric1, tags)
+
+        // It should not take more than about 5s to reprocess, let's wait 10
+        Thread.sleep(10000);
+        resp = client.get(path: "triggers/groups/mgt/members" )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        member = (Trigger)resp.data;
+        assertEquals("mgt", mgt.getName())
+        assertFalse(member.isGroup());
+        assertTrue(member.isEnabled());
+        assertTrue(member.isAutoDisable());
+        memberId = member.getId();
+
+        resp = client.get(path: "triggers/" + memberId + "/conditions")
+        assertEquals(200, resp.status);
+        assertEquals(1, resp.data.size());
+        mtc = (ThresholdCondition)resp.data[0];
+        assertEquals(metric1, mtc.getDataId());
+    }
+
+    @Test
+    void t09_cleanupTriggers() {
+        // stop the external alerter from processing these test triggers...
+        def resp = client.delete(path: "triggers/groups/mgt")
+    }
+
+    private void sendGaugeDataViaRest(String tenantId, DataPoint... dataPoints) {
+
+                List<Map<String, Object>> mMetrics = new ArrayList<>();
+
+                for( DataPoint dp : dataPoints ) {
+                    addDataItem(mMetrics, dp.metricId, dp.time, dp.value);
+                }
+
+                // Send it to metrics via rest
+                def resp = metricsClient.post(path:"gauges/raw", body:mMetrics, headers:['Hawkular-Tenant':tenantId]);
+                assertEquals(200, resp.status)
+            }
+
+    private void sendCounterDataViaRest(String tenantId, DataPoint... dataPoints) {
+       List<Map<String, Object>> mMetrics = new ArrayList<>();
+
+       for( DataPoint dp : dataPoints ) {
+           addDataItem(mMetrics, dp.metricId, dp.time, dp.value);
+       }
+
+       // Send it to metrics via rest
+       def resp = metricsClient.post(path:"counters/raw", body:mMetrics, headers:['Hawkular-Tenant':tenantId]);
+       assertEquals(200, resp.status)
+   }
+
+    private void addGaugeTagsViaRest(String metricName, HashMap<String,String> tags) {
+        def resp = metricsClient.put(path:"gauges/" + metricName + "/tags", body:tags);
+        assertEquals(200, resp.status)
+    }
+
+    private void deleteGaugeTagsViaRest(String metricName, String tags) {
+        def resp = metricsClient.delete(path:"gauges/" + metricName + "/tags/" + tags);
+        assertEquals(200, resp.status)
+    }
+
+    private static void addDataItem(List<Map<String, Object>> mMetrics, String metricId, Long timestamp, Number value) {
+        Map<String, Number> dataMap = new HashMap<>(2);
+        dataMap.put("timestamp", timestamp);
+        dataMap.put("value", value);
+        List<Map<String, Number>> data = new ArrayList<>(1);
+        data.add(dataMap);
+        Map<String, Object> outer = new HashMap<>(2);
+        outer.put("id", metricId);
+        outer.put("data", data);
+        mMetrics.add(outer);
+    }
+
+    private static class DataPoint {
+        String metricId;
+        Double value;
+        long time;
+
+        public DataPoint( String metricId, Double value, long time ) {
+            this.metricId = metricId;
+            this.value = value;
+            this.time = time;
+        }
+    }
+}


### PR DESCRIPTION
MGT support allows users to define a group trigger whose member triggers are
managed automatically by the alerter.

@lucasponce This is ready for review although it is marked DNM while I continue testing and I need to dial back some logging.