### PR TITLE
HWKMETRICS-638 Add Elasticsearch alerter to Metrics deployments

### DIFF
--- a/dist/component/component-ear/pom.xml
+++ b/dist/component/component-ear/pom.xml
@@ -55,6 +55,12 @@
     </dependency>
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-actions-elasticsearch-metrics</artifactId>
+      <version>${version.org.hawkular.alerts}</version>
+      <type>war</type>
+    </dependency>
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerts-actions-email-metrics</artifactId>
       <version>${version.org.hawkular.alerts}</version>
       <type>war</type>
@@ -62,6 +68,12 @@
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerts-actions-webhook-metrics</artifactId>
+      <version>${version.org.hawkular.alerts}</version>
+      <type>war</type>
+    </dependency>
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-elasticsearch-alerter-metrics</artifactId>
       <version>${version.org.hawkular.alerts}</version>
       <type>war</type>
     </dependency>
@@ -122,6 +134,12 @@
             </webModule>
             <webModule>
               <groupId>org.hawkular.alerts</groupId>
+              <artifactId>hawkular-alerts-actions-elasticsearch-metrics</artifactId>
+              <bundleFileName>hawkular-alerts-action-elasticsearch.war</bundleFileName>
+              <contextRoot>/hawkular/actions/elasticsearch</contextRoot>
+            </webModule>
+            <webModule>
+              <groupId>org.hawkular.alerts</groupId>
               <artifactId>hawkular-alerts-actions-email-metrics</artifactId>
               <bundleFileName>hawkular-alerts-action-email.war</bundleFileName>
               <contextRoot>/hawkular/actions/email</contextRoot>
@@ -131,6 +149,12 @@
               <artifactId>hawkular-alerts-actions-webhook-metrics</artifactId>
               <bundleFileName>hawkular-alerts-action-webhook.war</bundleFileName>
               <contextRoot>/hawkular/actions/webhook</contextRoot>
+            </webModule>
+            <webModule>
+              <groupId>org.hawkular.alerts</groupId>
+              <artifactId>hawkular-elasticsearch-alerter-metrics</artifactId>
+              <bundleFileName>hawkular-elasticsearch-alerter.war</bundleFileName>
+              <contextRoot>/hawkular/__alerter-elasticsearch</contextRoot>
             </webModule>
             <webModule>
               <groupId>org.hawkular.metrics</groupId>

--- a/dist/component/component-ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/dist/component/component-ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,12 @@
     </dependencies>
   </sub-deployment>
 
+  <sub-deployment name="hawkular-alerts-action-elasticsearch.war">
+    <dependencies>
+      <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
+    </dependencies>
+  </sub-deployment>
+
   <sub-deployment name="hawkular-alerts-action-email.war">
     <dependencies>
       <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
@@ -40,6 +46,12 @@
   </sub-deployment>
 
   <sub-deployment name="hawkular-alerts-action-webhook.war">
+    <dependencies>
+      <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
+    </dependencies>
+  </sub-deployment>
+
+  <sub-deployment name="hawkular-elasticsearch-alerter.war">
     <dependencies>
       <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
     </dependencies>

--- a/dist/containers/hawkular-metrics-openshift-dist/pom.xml
+++ b/dist/containers/hawkular-metrics-openshift-dist/pom.xml
@@ -55,6 +55,12 @@
     </dependency>
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-actions-elasticsearch-metrics</artifactId>
+      <version>${version.org.hawkular.alerts}</version>
+      <type>war</type>
+    </dependency>
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerts-actions-email-metrics</artifactId>
       <version>${version.org.hawkular.alerts}</version>
       <type>war</type>
@@ -62,6 +68,12 @@
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerts-actions-webhook-metrics</artifactId>
+      <version>${version.org.hawkular.alerts}</version>
+      <type>war</type>
+    </dependency>
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-elasticsearch-alerter-metrics</artifactId>
       <version>${version.org.hawkular.alerts}</version>
       <type>war</type>
     </dependency>
@@ -127,6 +139,12 @@
             </webModule>
             <webModule>
               <groupId>org.hawkular.alerts</groupId>
+              <artifactId>hawkular-alerts-actions-elasticsearch-metrics</artifactId>
+              <bundleFileName>hawkular-alerts-action-elasticsearch.war</bundleFileName>
+              <contextRoot>/hawkular/actions/elasticsearch</contextRoot>
+            </webModule>
+            <webModule>
+              <groupId>org.hawkular.alerts</groupId>
               <artifactId>hawkular-alerts-actions-email-metrics</artifactId>
               <bundleFileName>hawkular-alerts-action-email.war</bundleFileName>
               <contextRoot>/hawkular/actions/email</contextRoot>
@@ -136,6 +154,12 @@
               <artifactId>hawkular-alerts-actions-webhook-metrics</artifactId>
               <bundleFileName>hawkular-alerts-action-webhook.war</bundleFileName>
               <contextRoot>/hawkular/actions/webhook</contextRoot>
+            </webModule>
+            <webModule>
+              <groupId>org.hawkular.alerts</groupId>
+              <artifactId>hawkular-elasticsearch-alerter-metrics</artifactId>
+              <bundleFileName>hawkular-elasticsearch-alerter.war</bundleFileName>
+              <contextRoot>/hawkular/__alerter-elasticsearch</contextRoot>
             </webModule>
             <webModule>
               <groupId>org.hawkular.metrics</groupId>

--- a/dist/containers/hawkular-metrics-openshift-dist/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/dist/containers/hawkular-metrics-openshift-dist/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +32,12 @@
     </dependencies>
   </sub-deployment>
 
+  <sub-deployment name="hawkular-alerts-action-elasticsearch.war">
+    <dependencies>
+      <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
+    </dependencies>
+  </sub-deployment>
+
   <sub-deployment name="hawkular-alerts-action-email.war">
     <dependencies>
       <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
@@ -39,6 +45,12 @@
   </sub-deployment>
 
   <sub-deployment name="hawkular-alerts-action-webhook.war">
+    <dependencies>
+      <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
+    </dependencies>
+  </sub-deployment>
+
+  <sub-deployment name="hawkular-elasticsearch-alerter.war">
     <dependencies>
       <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
     </dependencies>

--- a/dist/standalone/standalone-ear/pom.xml
+++ b/dist/standalone/standalone-ear/pom.xml
@@ -55,6 +55,12 @@
     </dependency>
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-actions-elasticsearch-metrics</artifactId>
+      <version>${version.org.hawkular.alerts}</version>
+      <type>war</type>
+    </dependency>
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerts-actions-email-metrics</artifactId>
       <version>${version.org.hawkular.alerts}</version>
       <type>war</type>
@@ -62,6 +68,12 @@
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerts-actions-webhook-metrics</artifactId>
+      <version>${version.org.hawkular.alerts}</version>
+      <type>war</type>
+    </dependency>
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-elasticsearch-alerter-metrics</artifactId>
       <version>${version.org.hawkular.alerts}</version>
       <type>war</type>
     </dependency>
@@ -130,6 +142,12 @@
             </webModule>
             <webModule>
               <groupId>org.hawkular.alerts</groupId>
+              <artifactId>hawkular-alerts-actions-elasticsearch-metrics</artifactId>
+              <bundleFileName>hawkular-alerts-action-elasticsearch.war</bundleFileName>
+              <contextRoot>/hawkular/actions/elasticsearch</contextRoot>
+            </webModule>
+            <webModule>
+              <groupId>org.hawkular.alerts</groupId>
               <artifactId>hawkular-alerts-actions-email-metrics</artifactId>
               <bundleFileName>hawkular-alerts-action-email.war</bundleFileName>
               <contextRoot>/hawkular/actions/email</contextRoot>
@@ -139,6 +157,12 @@
               <artifactId>hawkular-alerts-actions-webhook-metrics</artifactId>
               <bundleFileName>hawkular-alerts-action-webhook.war</bundleFileName>
               <contextRoot>/hawkular/actions/webhook</contextRoot>
+            </webModule>
+            <webModule>
+              <groupId>org.hawkular.alerts</groupId>
+              <artifactId>hawkular-elasticsearch-alerter-metrics</artifactId>
+              <bundleFileName>hawkular-elasticsearch-alerter.war</bundleFileName>
+              <contextRoot>/hawkular/__alerter-elasticsearch</contextRoot>
             </webModule>
             <webModule>
               <groupId>org.hawkular.metrics</groupId>

--- a/dist/standalone/standalone-ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/dist/standalone/standalone-ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,12 @@
     </dependencies>
   </sub-deployment>
 
+  <sub-deployment name="hawkular-alerts-action-elasticsearch.war">
+    <dependencies>
+      <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
+    </dependencies>
+  </sub-deployment>
+
   <sub-deployment name="hawkular-alerts-action-email.war">
     <dependencies>
       <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
@@ -38,6 +44,12 @@
   </sub-deployment>
 
   <sub-deployment name="hawkular-alerts-action-webhook.war">
+    <dependencies>
+      <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
+    </dependencies>
+  </sub-deployment>
+
+  <sub-deployment name="hawkular-elasticsearch-alerter.war">
     <dependencies>
       <module name="deployment.hawkular-metrics.ear.hawkular-alerts.war" />
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <nodes>127.0.0.1</nodes>
     <!-- Dependencies versions -->
     <version.org.cassalog>0.4.2</version.org.cassalog>
-    <version.org.hawkular.alerts>1.6.0.Final-SRC-revision-33904b61e094f0d04513d9021c01746305a7e17b</version.org.hawkular.alerts>
+    <version.org.hawkular.alerts>1.6.0.Final</version.org.hawkular.alerts>
     <version.org.hawkular.commons>0.9.1.Final</version.org.hawkular.commons>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
     <version.joda-time>2.9.5</version.joda-time>


### PR DESCRIPTION
@lucasponce This PR adds the elasticsearch stuff into the ear deployment.  It should be sanity checked using the most recent alerting master (or, actually https://github.com/hawkular/hawkular-alerts/pull/314 if it hs not yet been merged).

We'll hold the merge until we update this PR with the 1.6 release.