### PR TITLE
HWKMETRICS-482 Query by tag the restful way

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -487,4 +487,38 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
                 .map(ApiUtils::collectionToResponse)
                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
     }
+
+    @GET
+    @Path("/tags/{tags}/raw")
+    @ApiOperation(value = "Retrieve availability data on multiple metrics by tags.", response = DataPoint.class,
+            responseContainer = "List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully fetched metric data points."),
+            @ApiResponse(code = 204, message = "Query was successful, but no data was found."),
+            @ApiResponse(code = 400, message = "No metric ids are specified", response = ApiError.class),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
+                    response = ApiError.class)
+    })
+    public void getRawDataByTag(
+            @Suspended AsyncResponse asyncResponse,
+            @PathParam("tags") String tags,
+            @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") String start,
+            @ApiParam(value = "Defaults to now") @QueryParam("end") String end,
+            @ApiParam(value = "Use data from earliest received, subject to retention period")
+            @QueryParam("fromEarliest") Boolean fromEarliest,
+            @ApiParam(value = "Limit the number of data points returned") @QueryParam("limit") Integer limit,
+            @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
+    ) {
+        metricsService.findMetricsWithFilters(getTenant(), AVAILABILITY, tags)
+                .map(Metric::getMetricId)
+                .toList()
+                .flatMap(metricIds -> TimeAndSortParams.<AvailabilityType>deferredBuilder(start, end)
+                        .fromEarliest(fromEarliest, metricIds, this::findTimeRange)
+                        .sortOptions(limit, order)
+                        .toObservable()
+                        .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
+                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+                                .observeOn(Schedulers.io())))
+                .subscribe(createNamedDataPointObserver(asyncResponse, AVAILABILITY));
+    }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -885,4 +885,38 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
                 .map(ApiUtils::collectionToResponse)
                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
     }
+
+    @GET
+    @Path("/tags/{tags}/raw")
+    @ApiOperation(value = "Retrieve raw gauge data on multiple metrics by tags.", response = DataPoint.class,
+            responseContainer = "List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully fetched metric data points."),
+            @ApiResponse(code = 204, message = "Query was successful, but no data was found."),
+            @ApiResponse(code = 400, message = "No metric ids are specified", response = ApiError.class),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
+                    response = ApiError.class)
+    })
+    public void getRawDataByTag(
+            @Suspended AsyncResponse asyncResponse,
+            @PathParam("tags") String tags,
+            @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") String start,
+            @ApiParam(value = "Defaults to now") @QueryParam("end") String end,
+            @ApiParam(value = "Use data from earliest received, subject to retention period")
+            @QueryParam("fromEarliest") Boolean fromEarliest,
+            @ApiParam(value = "Limit the number of data points returned") @QueryParam("limit") Integer limit,
+            @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
+    ) {
+        metricsService.findMetricsWithFilters(getTenant(), GAUGE, tags)
+                .map(Metric::getMetricId)
+                .toList()
+                .flatMap(metricIds -> TimeAndSortParams.<Double>deferredBuilder(start, end)
+                        .fromEarliest(fromEarliest, metricIds, this::findTimeRange)
+                        .sortOptions(limit, order)
+                        .toObservable()
+                        .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
+                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+                                .observeOn(Schedulers.io())))
+                .subscribe(createNamedDataPointObserver(asyncResponse, GAUGE));
+    }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
@@ -350,4 +350,38 @@ public class StringHandler extends MetricsServiceHandler implements IMetricsHand
                 .subscribe(asyncResponse::resume, t -> asyncResponse.resume(ApiUtils.error(t)));
     }
 
+    @GET
+    @Path("/tags/{tags}/raw")
+    @ApiOperation(value = "Retrieve string data on multiple metrics by tags.", response = DataPoint.class,
+            responseContainer = "List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully fetched metric data points."),
+            @ApiResponse(code = 204, message = "Query was successful, but no data was found."),
+            @ApiResponse(code = 400, message = "No metric ids are specified", response = ApiError.class),
+            @ApiResponse(code = 500, message = "Unexpected error occurred while fetching metric data.",
+                    response = ApiError.class)
+    })
+    public void getRawDataByTag(
+            @Suspended AsyncResponse asyncResponse,
+            @PathParam("tags") String tags,
+            @ApiParam(value = "Defaults to now - 8 hours") @QueryParam("start") String start,
+            @ApiParam(value = "Defaults to now") @QueryParam("end") String end,
+            @ApiParam(value = "Use data from earliest received, subject to retention period")
+            @QueryParam("fromEarliest") Boolean fromEarliest,
+            @ApiParam(value = "Limit the number of data points returned") @QueryParam("limit") Integer limit,
+            @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
+    ) {
+        metricsService.findMetricsWithFilters(getTenant(), STRING, tags)
+                .map(Metric::getMetricId)
+                .toList()
+                .flatMap(metricIds -> TimeAndSortParams.<String>deferredBuilder(start, end)
+                        .fromEarliest(fromEarliest, metricIds, this::findTimeRange)
+                        .sortOptions(limit, order)
+                        .forString()
+                        .toObservable()
+                        .flatMap(p -> metricsService.findDataPoints(metricIds, p.getTimeRange().getStart(),
+                                p.getTimeRange().getEnd(), p.getLimit(), p.getOrder())
+                                .observeOn(Schedulers.io())))
+                .subscribe(createNamedDataPointObserver(asyncResponse, STRING));
+    }
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/AvailabilityITest.groovy
@@ -508,6 +508,20 @@ class AvailabilityITest extends RESTTest {
             ]
     ]))
 
+    // Make sure the same request on GET endpoint gives the same result
+    def responseGET = hawkularMetrics.get(
+        path: "availability/tags/letter:A/raw",
+        query: [
+            start: start.plusHours(1).millis,
+            end: start.plusHours(4).millis,
+            limit: 2,
+            order: 'desc'
+        ],
+        headers: [(tenantHeaderName): tenantId],
+    )
+    assertEquals(200, responseGET.status)
+    assertEquals(response.data.sort(), responseGET.data.sort())
+
     response = hawkularMetrics.post(
             path: "availability/raw/query",
             headers: [(tenantHeaderName): tenantId],
@@ -530,6 +544,20 @@ class AvailabilityITest extends RESTTest {
                     [timestamp: start.plusHours(2).millis, value: 'down']
             ]
     ]))
+
+    // Make sure the same request on GET endpoint gives the same result
+    responseGET = hawkularMetrics.get(
+        path: "availability/tags/letter:A,number:1/raw",
+        query: [
+            start: start.plusHours(1).millis,
+            end: start.plusHours(4).millis,
+            limit: 2,
+            order: 'desc'
+        ],
+        headers: [(tenantHeaderName): tenantId],
+    )
+    assertEquals(200, responseGET.status)
+    assertEquals(response.data.sort(), responseGET.data.sort())
   }
 
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/CountersITest.groovy
@@ -2207,6 +2207,20 @@ Actual:   ${response.data}
             ]
     ]))
 
+    // Make sure the same request on GET endpoint gives the same result
+    def responseGET = hawkularMetrics.get(
+        path: "counters/tags/letter:A/raw",
+        query: [
+            start: start.plusHours(1).millis,
+            end: start.plusHours(4).millis,
+            limit: 2,
+            order: 'desc'
+        ],
+        headers: [(tenantHeaderName): tenantId],
+    )
+    assertEquals(200, responseGET.status)
+    assertEquals(response.data.sort(), responseGET.data.sort())
+
     response = hawkularMetrics.post(
             path: "counters/raw/query",
             headers: [(tenantHeaderName): tenantId],
@@ -2229,6 +2243,20 @@ Actual:   ${response.data}
                     [timestamp: start.plusHours(2).millis, value: 30]
             ]
     ]))
+
+    // Make sure the same request on GET endpoint gives the same result
+    responseGET = hawkularMetrics.get(
+        path: "counters/tags/letter:A,number:1/raw",
+        query: [
+            start: start.plusHours(1).millis,
+            end: start.plusHours(4).millis,
+            limit: 2,
+            order: 'desc'
+        ],
+        headers: [(tenantHeaderName): tenantId],
+    )
+    assertEquals(200, responseGET.status)
+    assertEquals(response.data.sort(), responseGET.data.sort())
   }
 
 }

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/GaugesITest.groovy
@@ -923,6 +923,20 @@ Actual:   ${response.data}
             ]
     ]))
 
+    // Make sure the same request on GET endpoint gives the same result
+    def responseGET = hawkularMetrics.get(
+        path: "gauges/tags/letter:A/raw",
+        query: [
+            start: start.plusHours(1).millis,
+            end: start.plusHours(4).millis,
+            limit: 2,
+            order: 'desc'
+        ],
+        headers: [(tenantHeaderName): tenantId],
+    )
+    assertEquals(200, responseGET.status)
+    assertEquals(response.data.sort(), responseGET.data.sort())
+
     response = hawkularMetrics.post(
             path: "gauges/raw/query",
             headers: [(tenantHeaderName): tenantId],
@@ -945,6 +959,20 @@ Actual:   ${response.data}
                     [timestamp: start.plusHours(2).millis, value: 30.0]
             ]
     ]))
+
+    // Make sure the same request on GET endpoint gives the same result
+    responseGET = hawkularMetrics.get(
+        path: "gauges/tags/letter:A,number:1/raw",
+        query: [
+            start: start.plusHours(1).millis,
+            end: start.plusHours(4).millis,
+            limit: 2,
+            order: 'desc'
+        ],
+        headers: [(tenantHeaderName): tenantId],
+    )
+    assertEquals(200, responseGET.status)
+    assertEquals(response.data.sort(), responseGET.data.sort())
   }
 
   @Test

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StringITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/StringITest.groovy
@@ -575,6 +575,20 @@ class StringITest extends RESTTest {
                 ]
         ]))
 
+        // Make sure the same request on GET endpoint gives the same result
+        def responseGET = hawkularMetrics.get(
+            path: "strings/tags/letter:A/raw",
+            query: [
+                start: start.plusHours(1).millis,
+                end: start.plusHours(4).millis,
+                limit: 2,
+                order: 'desc'
+            ],
+            headers: [(tenantHeaderName): tenantId],
+        )
+        assertEquals(200, responseGET.status)
+        assertEquals(response.data.sort(), responseGET.data.sort())
+
         response = hawkularMetrics.post(
                 path: "strings/raw/query",
                 headers: [(tenantHeaderName): tenantId],
@@ -597,6 +611,20 @@ class StringITest extends RESTTest {
                         [timestamp: start.plusHours(2).millis, value: 'green']
                 ]
         ]))
+
+        // Make sure the same request on GET endpoint gives the same result
+        responseGET = hawkularMetrics.get(
+            path: "strings/tags/letter:A,number:1/raw",
+            query: [
+                start: start.plusHours(1).millis,
+                end: start.plusHours(4).millis,
+                limit: 2,
+                order: 'desc'
+            ],
+            headers: [(tenantHeaderName): tenantId],
+        )
+        assertEquals(200, responseGET.status)
+        assertEquals(response.data.sort(), responseGET.data.sort())
     }
 
 }


### PR DESCRIPTION
Adds endpoints GET /*/tags/{tags}/raw
where * is gauges|counters|strings|availability

Performs the same as POST /*/raw/query, restricted to querying by tag