### PR TITLE
[HWKMETRICS-692] Remove unnecessary calls to findMetric

### DIFF
--- a/alerting/alerter-war/src/main/java/org/hawkular/metrics/alerter/ConditionManager.java
+++ b/alerting/alerter-war/src/main/java/org/hawkular/metrics/alerter/ConditionManager.java
@@ -53,7 +53,6 @@ import org.hawkular.metrics.alerter.ConditionExpression.Query;
 import org.hawkular.metrics.core.service.MetricsService;
 import org.hawkular.metrics.model.BucketPoint;
 import org.hawkular.metrics.model.Buckets;
-import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 import org.hawkular.metrics.model.Percentile;
@@ -591,8 +590,7 @@ public class ConditionManager {
             }
 
             // Tags case
-            return metricsService.findMetricsWithFilters(tenantId, type, tags)
-                    .map(Metric::getMetricId);
+            return metricsService.findMetricIdentifiersWithFilters(tenantId, type, tags);
         }
     }
 

--- a/alerting/alerter-war/src/main/java/org/hawkular/metrics/alerter/groups/GroupTriggerManager.java
+++ b/alerting/alerter-war/src/main/java/org/hawkular/metrics/alerter/groups/GroupTriggerManager.java
@@ -394,7 +394,8 @@ public class GroupTriggerManager {
                 for (String dataId : dataIds) {
                     String tagQuery = tags.get(dataId);
                     List<Metric<Object>> dataIdMetrics = metricsService
-                            .findMetricsWithFilters(mgt.getTenantId(), null, tagQuery)
+                            .findMetricIdentifiersWithFilters(mgt.getTenantId(), null, tagQuery)
+                            .flatMap(metricsService::findMetric)
                             .toList()
                             .toBlocking().firstOrDefault(Collections.emptyList());
                     dataIdMap.put(dataId, new HashSet<>(dataIdMetrics));

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AvailabilityHandler.java
@@ -146,7 +146,8 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
 
         Observable<Metric<AvailabilityType>> metricObservable = null;
         if (tags != null) {
-            metricObservable = metricsService.findMetricsWithFilters(getTenant(), AVAILABILITY, tags);
+            metricObservable = metricsService.findMetricIdentifiersWithFilters(getTenant(), AVAILABILITY, tags)
+                    .flatMap(metricsService::findMetric);
         } else {
             metricObservable = metricsService.findMetrics(getTenant(), AVAILABILITY);
         }
@@ -509,8 +510,7 @@ public class AvailabilityHandler extends MetricsServiceHandler implements IMetri
             @ApiParam(value = "Limit the number of data points returned") @QueryParam("limit") Integer limit,
             @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
     ) {
-        metricsService.findMetricsWithFilters(getTenant(), AVAILABILITY, tags)
-                .map(Metric::getMetricId)
+        metricsService.findMetricIdentifiersWithFilters(getTenant(), AVAILABILITY, tags)
                 .toList()
                 .flatMap(metricIds -> TimeAndSortParams.<AvailabilityType>deferredBuilder(start, end)
                         .fromEarliest(fromEarliest, metricIds, this::findTimeRange)

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/CounterHandler.java
@@ -152,7 +152,8 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
 
         Observable<Metric<Long>> metricObservable = null;
         if (tags != null) {
-            metricObservable = metricsService.findMetricsWithFilters(getTenant(), COUNTER, tags);
+            metricObservable = metricsService.findMetricIdentifiersWithFilters(getTenant(), COUNTER, tags)
+                    .flatMap(metricsService::findMetric);
         } else {
             metricObservable = metricsService.findMetrics(getTenant(), COUNTER);
         }
@@ -898,8 +899,7 @@ public class CounterHandler extends MetricsServiceHandler implements IMetricsHan
             @ApiParam(value = "Limit the number of data points returned") @QueryParam("limit") Integer limit,
             @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
     ) {
-        metricsService.findMetricsWithFilters(getTenant(), COUNTER, tags)
-                .map(Metric::getMetricId)
+        metricsService.findMetricIdentifiersWithFilters(getTenant(), COUNTER, tags)
                 .toList()
                 .flatMap(metricIds -> TimeAndSortParams.<Long>deferredBuilder(start, end)
                         .fromEarliest(fromEarliest, metricIds, this::findTimeRange)

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/GaugeHandler.java
@@ -149,7 +149,8 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
 
         Observable<Metric<Double>> metricObservable = null;
         if (tags != null) {
-            metricObservable = metricsService.findMetricsWithFilters(getTenant(), GAUGE, tags);
+            metricObservable = metricsService.findMetricIdentifiersWithFilters(getTenant(), GAUGE, tags)
+                    .flatMap(metricsService::findMetric);
         } else {
             metricObservable = metricsService.findMetrics(getTenant(), GAUGE);
         }
@@ -907,8 +908,7 @@ public class GaugeHandler extends MetricsServiceHandler implements IMetricsHandl
             @ApiParam(value = "Limit the number of data points returned") @QueryParam("limit") Integer limit,
             @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
     ) {
-        metricsService.findMetricsWithFilters(getTenant(), GAUGE, tags)
-                .map(Metric::getMetricId)
+        metricsService.findMetricIdentifiersWithFilters(getTenant(), GAUGE, tags)
                 .toList()
                 .flatMap(metricIds -> TimeAndSortParams.<Double>deferredBuilder(start, end)
                         .fromEarliest(fromEarliest, metricIds, this::findTimeRange)

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricsServiceHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/MetricsServiceHandler.java
@@ -73,8 +73,7 @@ abstract class MetricsServiceHandler {
                     .map(id -> new MetricId<>(getTenant(), type, id));
         }
 
-        return metricsService.findMetricsWithFilters(getTenant(), type, tags)
-                .map(Metric::getMetricId);
+        return metricsService.findMetricIdentifiersWithFilters(getTenant(), type, tags);
     }
 
     <T> Observable<TimeRange> findTimeRange(String start, String end, Boolean fromEarliest,

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/StringHandler.java
@@ -135,7 +135,8 @@ public class StringHandler extends MetricsServiceHandler implements IMetricsHand
 
         Observable<Metric<String>> metricObservable = null;
         if (tags != null) {
-            metricObservable = metricsService.findMetricsWithFilters(getTenant(), STRING, tags);
+            metricObservable = metricsService.findMetricIdentifiersWithFilters(getTenant(), STRING, tags)
+                    .flatMap(metricsService::findMetric);
         } else {
             metricObservable = metricsService.findMetrics(getTenant(), STRING);
         }
@@ -371,8 +372,7 @@ public class StringHandler extends MetricsServiceHandler implements IMetricsHand
             @ApiParam(value = "Limit the number of data points returned") @QueryParam("limit") Integer limit,
             @ApiParam(value = "Data point sort order, based on timestamp") @QueryParam("order") Order order
     ) {
-        metricsService.findMetricsWithFilters(getTenant(), STRING, tags)
-                .map(Metric::getMetricId)
+        metricsService.findMetricIdentifiersWithFilters(getTenant(), STRING, tags)
                 .toList()
                 .flatMap(metricIds -> TimeAndSortParams.<String>deferredBuilder(start, end)
                         .fromEarliest(fromEarliest, metricIds, this::findTimeRange)

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/CompressData.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/jobs/CompressData.java
@@ -121,8 +121,7 @@ public class CompressData implements Func1<JobDetails, Completable> {
         Stopwatch stopwatch = Stopwatch.createStarted();
         logger.info("Starting compression of timestamps (UTC) between " + startOfSlice + " - " + endOfSlice);
 
-        Observable<? extends MetricId<?>> metricIds = metricsService.findAllMetrics()
-                .map(Metric::getMetricId)
+        Observable<? extends MetricId<?>> metricIds = metricsService.findAllMetricIdentifiers()
                 .filter(m -> (m.getType() == GAUGE || m.getType() == COUNTER || m.getType() == AVAILABILITY));
 
         PublishSubject<Metric<?>> subject = PublishSubject.create();

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -78,7 +78,7 @@ public interface DataAccess {
 
     Observable<ResultSet> dropTempTable(long timestamp);
 
-    Observable<Row> findAllMetricsInData();
+    Observable<Row> findAllMetricIdentifiersInData();
 
     <T> Observable<Integer> insertData(Observable<Metric<T>> metrics);
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
@@ -881,7 +881,7 @@ public class DataAccessImpl implements DataAccess {
     }
 
     @Override
-    public Observable<Row> findAllMetricsInData() {
+    public Observable<Row> findAllMetricIdentifiersInData() {
         return getPrepForAllTempTables(TempStatement.LIST_ALL_METRICS_FROM_TABLE)
                 .map(PreparedStatement::bind)
                 .flatMap(b -> rxSession.executeAndFetch(b))

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsService.java
@@ -98,7 +98,7 @@ public interface MetricsService {
      */
     Observable<Void> createMetric(Metric<?> metric, boolean overwrite);
 
-    Observable<Metric<?>> findAllMetrics();
+    Observable<MetricId<?>> findAllMetricIdentifiers();
 
     <T> Observable<Metric<T>> findMetric(MetricId<T> id);
 
@@ -125,9 +125,9 @@ public interface MetricsService {
      * @param tenantId The id of the tenant to which the metrics belong
      * @param type If type is null, no type filtering is used
      * @param tagsQuery If tagsQueries is empty, empty Observable is returned, use findMetrics(tenantId, type) instead
-     * @return Metric's that are filtered with given conditions
+     * @return MetricIds that are filtered with given conditions
      */
-    <T> Observable<Metric<T>> findMetricsWithFilters(String tenantId, MetricType<T> type, String tags);
+    <T> Observable<MetricId<T>> findMetricIdentifiersWithFilters(String tenantId, MetricType<T> type, String tags);
 
     /**
      * Returns distinct tag values for a given tag query (using the same query format as {@link
@@ -366,7 +366,7 @@ public interface MetricsService {
      */
     Observable<Metric<?>> insertedDataEvents();
 
-    <T> Func1<Metric<T>, Boolean> idFilter(String regexp);
+    <T> Func1<MetricId<T>, Boolean> idFilter(String regexp);
 
     <T> Observable<Void> updateMetricExpiration(MetricId<T> metric);
 }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -195,6 +195,7 @@ public class MetricsServiceImpl implements MetricsService {
     private ExpressionTagQueryParser expresssionTagQueryParser;
 
     private int defaultTTL = Duration.standardDays(7).toStandardSeconds().getSeconds();
+    private int DEFAULT_RETENTION = (int) Duration.standardSeconds(defaultTTL).getStandardDays();
 
     private int maxStringSize;
 
@@ -533,8 +534,7 @@ public class MetricsServiceImpl implements MetricsService {
                 .filter(row -> tenantId.equals(row.getString(0)))
                 .compose(new MetricIdentifierFromFullDataRowTransformer(defaultTTL))
                 .distinct()
-                .flatMap(this::findMetric)
-                .map(m -> (Metric<T>) m);
+                .map(m -> new Metric(m, DEFAULT_RETENTION));
 
         if (metricType == null) {
             setFromMetricsIndex = Observable.from(MetricType.userTypes())
@@ -545,7 +545,7 @@ public class MetricsServiceImpl implements MetricsService {
             setFromMetricsIndex = dataAccess.findMetricsInMetricsIndex(tenantId, metricType)
                     .compose(new MetricsIndexRowTransformer<>(tenantId, metricType, defaultTTL));
 
-            setFromData = setFromData.filter(m -> metricType.equals(m.getMetricId().getType()));
+            setFromData = setFromData.filter(m -> metricType.equals(m.getType()));
         }
 
         return setFromMetricsIndex.concatWith(setFromData).distinct(Metric::getMetricId);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/tags/ExpressionTagQueryParser.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/tags/ExpressionTagQueryParser.java
@@ -42,7 +42,6 @@ import org.hawkular.metrics.core.service.tags.parser.TagQueryParser.PairContext;
 import org.hawkular.metrics.core.service.tags.parser.TagQueryParser.ValueContext;
 import org.hawkular.metrics.core.service.transformers.MetricIdFromMetricIndexRowTransformer;
 import org.hawkular.metrics.core.service.transformers.TagsIndexRowTransformerFilter;
-import org.hawkular.metrics.model.Metric;
 import org.hawkular.metrics.model.MetricId;
 import org.hawkular.metrics.model.MetricType;
 
@@ -61,7 +60,7 @@ public class ExpressionTagQueryParser {
         this.metricsService = metricsService;
     }
 
-    public <T> Observable<Metric<T>> parse(String tenantId, MetricType<T> metricType, String expression) {
+    public <T> Observable<MetricId<T>> parse(String tenantId, MetricType<T> metricType, String expression) {
         ANTLRInputStream input = new ANTLRInputStream(expression);
         TagQueryLexer tql = new TagQueryLexer(input);
         tql.removeErrorListeners();
@@ -102,10 +101,10 @@ public class ExpressionTagQueryParser {
             this.metricType = metricType;
         }
 
-        public Observable<Metric<T>> getResult() {
+        public Observable<MetricId<T>> getResult() {
             if (observables.size() == 1) {
-                return observables.values().iterator().next().get(0)
-                    .flatMap(metricsService::findMetric);
+                return observables.values().iterator().next().get(0);
+//                    .flatMap(metricsService::findMetric);
             }
 
             return Observable.empty();

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricIdentifierFromFullDataRowTransformer.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/transformers/MetricIdentifierFromFullDataRowTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.metrics.core.service.transformers;
 
 import org.hawkular.metrics.model.Metric;
@@ -33,19 +32,16 @@ import rx.Observable.Transformer;
  *
  * @author Thomas Segismont
  */
-public class MetricFromFullDataRowTransformer implements Transformer<Row, Metric<?>> {
+public class MetricIdentifierFromFullDataRowTransformer implements Transformer<Row, MetricId<?>> {
     private final int defaultDataRetention;
 
-    public MetricFromFullDataRowTransformer(int defaultTTL) {
+    public MetricIdentifierFromFullDataRowTransformer(int defaultTTL) {
         this.defaultDataRetention = (int) Duration.standardSeconds(defaultTTL).getStandardDays();
     }
 
     @Override
-    public Observable<Metric<?>> call(Observable<Row> rows) {
-        return rows.map(row -> {
-            MetricId<?> metricId = new MetricId<>(row.getString(0), MetricType.fromCode(row.getByte(1)),
-                    row.getString(2));
-            return new Metric<>(metricId, defaultDataRetention);
-        });
+    public Observable<MetricId<?>> call(Observable<Row> rows) {
+        return rows.map(row -> new MetricId<>(row.getString(0), MetricType.fromCode(row.getByte(1)),
+                row.getString(2)));
     }
 }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
@@ -29,7 +29,7 @@ import static org.testng.Assert.assertFalse;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.hawkular.metrics.core.service.transformers.MetricFromFullDataRowTransformer;
+import org.hawkular.metrics.core.service.transformers.MetricIdentifierFromFullDataRowTransformer;
 import org.hawkular.metrics.model.AvailabilityType;
 import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
@@ -218,12 +218,11 @@ public class DataAccessITest extends BaseITest {
                 .toBlocking().lastOrDefault(null);
 
         @SuppressWarnings("unchecked")
-        List<Metric<Double>> metrics = toList(dataAccess.findAllMetricsInData()
+        List<MetricId<Double>> metrics = toList(dataAccess.findAllMetricIdentifiersInData()
                 .doOnError(Throwable::printStackTrace)
-                .compose(new MetricFromFullDataRowTransformer(Duration.standardDays(7).toStandardSeconds().getSeconds
+                .compose(new MetricIdentifierFromFullDataRowTransformer(Duration.standardDays(7).toStandardSeconds().getSeconds
                         ())).doOnError(Throwable::printStackTrace)
-                .map(m -> (Metric<Double>) m)
-        .doOnNext(m -> m.getMetricId().toString()));
+                .map(m -> (MetricId<Double>) m));
 
         assertEquals(metrics.size(), 4);
     }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -130,8 +130,8 @@ public class DelegatingDataAccess implements DataAccess {
 //    }
 
     @Override
-    public Observable<Row> findAllMetricsInData() {
-        return delegate.findAllMetricsInData();
+    public Observable<Row> findAllMetricIdentifiersInData() {
+        return delegate.findAllMetricIdentifiersInData();
     }
 
     @Override

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/CounterITest.java
@@ -353,8 +353,7 @@ public class CounterITest extends BaseMetricsITest {
 
         //Test simple counter stats
         List<List<NumericBucketPoint>> actualCounterStatsByTag = getOnNextEvents(
-                () -> metricsService.findMetricsWithFilters(tenantId, COUNTER, tagFilters)
-                        .map(Metric::getMetricId)
+                () -> metricsService.findMetricIdentifiersWithFilters(tenantId, COUNTER, tagFilters)
                         .toList()
                         .flatMap(ids -> metricsService.findNumericStats(ids, start.getMillis(),
                         start.plusMinutes(5).getMillis(), buckets, emptyList(), false, false)));
@@ -374,8 +373,7 @@ public class CounterITest extends BaseMetricsITest {
 
         //Test stacked counter stats
         List<List<NumericBucketPoint>> actualStackedCounterStatsByTag = getOnNextEvents(
-                () -> metricsService.findMetricsWithFilters(tenantId, COUNTER, tagFilters)
-                        .map(Metric::getMetricId)
+                () -> metricsService.findMetricIdentifiersWithFilters(tenantId, COUNTER, tagFilters)
                         .toList()
                         .flatMap(ids -> metricsService.findNumericStats(ids, start.getMillis(),
                             start.plusMinutes(5).getMillis(), buckets, emptyList(), true, false)));
@@ -418,8 +416,7 @@ public class CounterITest extends BaseMetricsITest {
 
         //Test simple counter rate stats
         List<List<NumericBucketPoint>> actualCounterRateStatsByTag = getOnNextEvents(
-                () -> metricsService.findMetricsWithFilters(tenantId, COUNTER, tagFilters)
-                        .map(Metric::getMetricId)
+                () -> metricsService.findMetricIdentifiersWithFilters(tenantId, COUNTER, tagFilters)
                         .toList()
                         .flatMap(ids -> metricsService.findNumericStats(ids, start.getMillis(),
                             start.plusMinutes(5).getMillis(), buckets, emptyList(), false, true)));
@@ -439,8 +436,7 @@ public class CounterITest extends BaseMetricsITest {
 
         //Test stacked counter rate stats
         List<List<NumericBucketPoint>> actualStackedCounterRateStatsByTag = getOnNextEvents(
-                () -> metricsService.findMetricsWithFilters(tenantId, COUNTER, tagFilters)
-                        .map(Metric::getMetricId)
+                () -> metricsService.findMetricIdentifiersWithFilters(tenantId, COUNTER, tagFilters)
                         .toList()
                         .flatMap(ids -> metricsService.findNumericStats(ids, start.getMillis(),
                             start.plusMinutes(5).getMillis(), buckets, emptyList(), true, true)));

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/ExpressionTagQueryITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/ExpressionTagQueryITest.java
@@ -55,7 +55,7 @@ public class ExpressionTagQueryITest extends BaseMetricsITest {
 
         ExpressionTagQueryParser test = new ExpressionTagQueryParser(dataAccess, metricsService);
 
-        List<Metric<Double>> gauges = test.parse(tenantId, GAUGE, "a1 ='abc'").toList().toBlocking()
+        List<MetricId<Double>> gauges = test.parse(tenantId, GAUGE, "a1 ='abc'").toList().toBlocking()
                 .lastOrDefault(null);
         assertMetricListById(gauges, "m1");
 
@@ -131,7 +131,7 @@ public class ExpressionTagQueryITest extends BaseMetricsITest {
 
         ExpressionTagQueryParser test = new ExpressionTagQueryParser(dataAccess, metricsService);
 
-        List<Metric<Long>> counters = test.parse(tenantId, COUNTER, "a2.label1 =5").toList().toBlocking()
+        List<MetricId<Long>> counters = test.parse(tenantId, COUNTER, "a2.label1 =5").toList().toBlocking()
                 .lastOrDefault(null);
         assertMetricListById(counters, "c2");
 
@@ -161,10 +161,10 @@ public class ExpressionTagQueryITest extends BaseMetricsITest {
         String tenantId = "jsonT2Tag";
         createTagMetrics(tenantId);
 
-        List<Metric<Double>> gauges = null;
+        List<MetricId<Double>> gauges = null;
 
         try {
-            gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a1 == abc'").toList()
+            gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a1 == abc'").toList()
                 .toBlocking()
                 .lastOrDefault(null);
             fail("Expected error");
@@ -172,18 +172,18 @@ public class ExpressionTagQueryITest extends BaseMetricsITest {
             assertEquals(e.getClass(), RuntimeApiError.class);
         }
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a1:*").toList()
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a1:*").toList()
                 .toBlocking()
                 .lastOrDefault(null);
         assertMetricListById(gauges, "m1", "m2", "m3", "m4", "m5");
     }
 
-    private <T> void assertMetricListById(List<Metric<T>> actualMetrics, String... expectedMetricIds) {
+    private <T> void assertMetricListById(List<MetricId<T>> actualMetrics, String... expectedMetricIds) {
         assertEquals(actualMetrics.size(), expectedMetricIds.length);
         for (String expectedMetricId : expectedMetricIds) {
             boolean found = false;
-            for (Metric<T> actualMetric : actualMetrics) {
-                if (actualMetric.getId().equals(expectedMetricId)) {
+            for (MetricId<T> actualMetric : actualMetrics) {
+                if (actualMetric.getName().equals(expectedMetricId)) {
                     found = true;
                     break;
                 }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/GaugeITest.java
@@ -286,8 +286,7 @@ public class GaugeITest extends BaseMetricsITest {
         String tagFilters = "type:cpu_usage,node:server1|server2";
 
         List<List<NumericBucketPoint>> actual = getOnNextEvents(
-                () -> metricsService.findMetricsWithFilters(tenantId, GAUGE, tagFilters)
-                        .map(Metric::getMetricId)
+                () -> metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, tagFilters)
                         .toList()
                         .flatMap(metrics -> metricsService.findNumericStats(metrics, start.getMillis(), start
                                 .plusMinutes(5).getMillis(), buckets, emptyList(), true, false)));

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/MixedMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/MixedMetricsITest.java
@@ -351,14 +351,14 @@ public class MixedMetricsITest extends BaseMetricsITest {
                 }
 
                 String testTagName = "test0";
-                Metric<T> taggedMetric = metricsService.findMetricsWithFilters(checkMetric.getTenantId(),
+                MetricId<T> taggedMetric = metricsService.findMetricIdentifiersWithFilters(checkMetric.getTenantId(),
                         checkMetric.getType(), testTagName + "= '" + checkMetric.getTags().get(testTagName) + "'")
                         .toBlocking()
                         .firstOrDefault(null);
                 if (deletedMetrics.contains(checkMetric)) {
                     assertEquals(taggedMetric, null);
                 } else {
-                    assertEquals(taggedMetric.getMetricId(), checkMetric.getMetricId());
+                    assertEquals(taggedMetric, checkMetric.getMetricId());
                 }
 
                 int countFromTagIndex = dataAccess.findMetricsByTagNameValue(checkMetric.getTenantId(), testTagName,

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/TagsITest.java
@@ -79,95 +79,95 @@ public class TagsITest extends BaseMetricsITest {
         List<Metric<?>> metricsToAdd = createTagMetrics(tenantId);
 
         // Check different scenarios..
-        List<Metric<Double>> gauges = metricsService
-                .findMetricsWithFilters(tenantId, GAUGE, "a1:*")
+        List<MetricId<Double>> gauges = metricsService
+                .findMetricIdentifiersWithFilters(tenantId, GAUGE, "a1:*")
                 .toList()
                 .toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 5, "Metrics m1-m5 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a1:*,a2:2")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a1:*,a2:2")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 1, "Only metric m3 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a1:*,a2:2|3")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a1:*,a2:2|3")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Metrics m3-m4 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a2:2|3")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a2:2|3")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Metrics m3-m4 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a1:*,a2:*")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a1:*,a2:*")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 3, "Metrics m3-m5 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a1:*,a5:*")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a1:*,a5:*")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 0, "No gauges should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a4:*,a5:none")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a4:*,a5:none")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 0, "No gauges should have been returned");
 
-        List<Metric<Object>> metrics = metricsService.findMetricsWithFilters(tenantId, null, "a1:*")
+        List<MetricId<Object>> metrics = metricsService.findMetricIdentifiersWithFilters(tenantId, null, "a1:*")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(metrics.size(), 6, "Metrics m1-m5 and a1 should have been returned");
 
         // Test that we actually get correct gauges also, not just correct size
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a1:2,a2:2")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a1:2,a2:2")
                 .toList().toBlocking().lastOrDefault(null);
-        Metric m3 = metricsToAdd.get(2);
+        MetricId m3 = metricsToAdd.get(2).getMetricId();
         assertEquals(gauges.size(), 1, "Only metric m3 should have been returned");
         assertEquals(gauges.get(0), m3, "m3 did not match the original inserted metric");
 
         // Test for NOT operator
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a2:!4")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a2:!4")
                 .toList().toBlocking().lastOrDefault(null);
         System.out.println(gauges);
         assertEquals(gauges.size(), 2, "Only gauges m3-m4 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a1:2,a2:!4")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a1:2,a2:!4")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only gauges m3-m4 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "a2:!4|3")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a2:!4|3")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 1, "Only gauges m3 should have been returned");
         assertEquals(gauges.get(0), m3, "m3 did not match the original inserted metric");
 
         // What about incorrect query?
         try {
-            metricsService.findMetricsWithFilters(tenantId, GAUGE, "a2:**")
+            metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "a2:**")
                     .toList().toBlocking().lastOrDefault(null);
             fail("Should have thrown an PatternSyntaxException");
         } catch (PatternSyntaxException ignored) {
         }
 
         // More regexp tests
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "hostname:web.*")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "hostname:web.*")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only websrv01 and websrv02 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "hostname:.*01")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "hostname:.*01")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only websrv01 and backend01 should have been returned");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "owner:h[e|a]de(s?)")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "owner:h[e|a]de(s?)")
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Both hede and hades should have been returned, but not 'had'");
 
-        gauges = metricsService.findMetricsWithFilters(tenantId, GAUGE, "owner:h[e|a]de(s?)")
+        gauges = metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, "owner:h[e|a]de(s?)")
                 .filter(metricsService.idFilter(".F"))
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 1, "Only hades should have been returned");
 
         // Not existing tags
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, "!a2:*,a1:*")
+        gauges = metricsService.<Double>findMetricIdentifiersWithFilters(tenantId, GAUGE, "!a2:*,a1:*")
                 .doOnError(Throwable::printStackTrace)
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 2, "Only metrics with a1, but without a2 and type GAUGE should have been found");
 
-        gauges = metricsService.<Double> findMetricsWithFilters(tenantId, GAUGE, "!a1:*")
+        gauges = metricsService.<Double>findMetricIdentifiersWithFilters(tenantId, GAUGE, "!a1:*")
                 .doOnError(Throwable::printStackTrace)
                 .toList().toBlocking().lastOrDefault(null);
         assertEquals(gauges.size(), 8, "Only metrics without a1 and type GAUGE should have been found");
@@ -571,8 +571,7 @@ public class TagsITest extends BaseMetricsITest {
         String tagFilters = "type:cpu_usage,node:server1|server2";
 
         List<List<NumericBucketPoint>> actual = getOnNextEvents(
-                () -> metricsService.findMetricsWithFilters(tenantId, GAUGE, tagFilters)
-                        .map(Metric::getMetricId)
+                () -> metricsService.findMetricIdentifiersWithFilters(tenantId, GAUGE, tagFilters)
                         .toList()
                         .flatMap(ids -> metricsService.findNumericStats(ids, start.getMillis(), start.plusMinutes(5)
                                         .getMillis(), buckets, emptyList(), false, false)));


### PR DESCRIPTION
This PR requires PR #818 to be merged first. This removes the calls to ``metricsService.findMetric()`` in cases where it's not needed. This reduces the amount of Cassandra calls in read requests that use tags (other than fetching full metric definition).