### PR TITLE
[HWKMETRICS-700] [HWKMETRICS-701] Fixes BufferUnderflow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <version.org.codehaus.groovy.modules.http-builder>0.7</version.org.codehaus.groovy.modules.http-builder>
     <version.org.codehaus.mojo.dashboard-maven-plugin>1.0.0-beta-1</version.org.codehaus.mojo.dashboard-maven-plugin>
     <version.org.jmxtrans.embedded.embedded-jmxtrans>1.0.15</version.org.jmxtrans.embedded.embedded-jmxtrans>
-    <version.fi.iki.yak.compression-gorilla>2.0.2</version.fi.iki.yak.compression-gorilla>
+    <version.fi.iki.yak.compression-gorilla>2.0.3</version.fi.iki.yak.compression-gorilla>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Updates compression-gorilla to 2.0.3 and fixes the regression in Gorilla V1