### PR TITLE
[HWKMETRICS-695] Fix NPE and several other issues

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -97,7 +97,6 @@ import org.hawkular.metrics.core.dropwizard.DropWizardReporter;
 import org.hawkular.metrics.core.dropwizard.HawkularMetricRegistry;
 import org.hawkular.metrics.core.dropwizard.HawkularMetricsRegistryListener;
 import org.hawkular.metrics.core.dropwizard.HawkularObjectNameFactory;
-import org.hawkular.metrics.core.dropwizard.MetaData;
 import org.hawkular.metrics.core.dropwizard.MetricNameService;
 import org.hawkular.metrics.core.jobs.CompressData;
 import org.hawkular.metrics.core.jobs.JobsService;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RESTMetaData.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RESTMetaData.java
@@ -54,16 +54,16 @@ public class RESTMetaData extends MetaData {
     private Type type;
 
 
-    public static RESTMetaData forRead(HTTPMethod method, String uri) {
-        return new RESTMetaData(new RESTMetricName(method, uri), Type.READ);
+    public static RESTMetaData forRead(HTTPMethod method, String uri, String hostname) {
+        return new RESTMetaData(new RESTMetricName(method, uri), Type.READ, hostname);
     }
 
-    public static RESTMetaData forWrite(HTTPMethod method, String uri) {
-        return new RESTMetaData(new RESTMetricName(method, uri), Type.WRITE);
+    public static RESTMetaData forWrite(HTTPMethod method, String uri, String hostname) {
+        return new RESTMetaData(new RESTMetricName(method, uri), Type.WRITE, hostname);
     }
 
-    private RESTMetaData(RESTMetricName name, Type type) {
-        super(name.getName(), SCOPE, type.toString(), null, ImmutableMap.of(
+    private RESTMetaData(RESTMetricName name, Type type, String hostname) {
+        super(name.getName(), SCOPE, type.toString(), hostname, ImmutableMap.of(
                 "method", name.getMethod().toString(),
                 "uri", name.getUri()
         ));

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RESTMetrics.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RESTMetrics.java
@@ -19,12 +19,9 @@ package org.hawkular.metrics.api.jaxrs.dropwizard;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.util.AnnotationLiteral;
@@ -37,17 +34,14 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
-import org.hawkular.metrics.api.jaxrs.handler.template.IMetricsHandler;
 import org.hawkular.metrics.api.jaxrs.util.MetricRegistryProvider;
 import org.hawkular.metrics.core.dropwizard.HawkularMetricRegistry;
 import org.hawkular.metrics.core.dropwizard.MetricNameService;
 import org.jboss.logging.Logger;
 
 import com.codahale.metrics.Timer;
-import com.google.common.reflect.ClassPath;
 
 import rx.Observable;
-import rx.exceptions.Exceptions;
 
 /**
  * Registers metric meta data for REST endpoints. The actual metrics are registered when the end points are invoked for

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RecordMetricsFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RecordMetricsFilter.java
@@ -37,7 +37,6 @@ import javax.ws.rs.ext.Provider;
 import org.jboss.logging.Logger;
 
 import com.codahale.metrics.Timer;
-import com.google.common.base.Stopwatch;
 
 /**
  * This filter records DropWizard metrics for REST endpoints.
@@ -54,11 +53,10 @@ public class RecordMetricsFilter implements ContainerRequestFilter, ContainerRes
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        Stopwatch stopwatch = Stopwatch.createStarted();
         String path = getPath(requestContext.getUriInfo());
         HTTPMethod method = HTTPMethod.fromString(requestContext.getMethod());
         RESTMetricName metricName = new RESTMetricName(method, path);
-        Timer timer = restMetrics.getTimers().get(metricName);
+        Timer timer = restMetrics.getTimer(metricName.getName());
         if (timer != null) {
             Timer.Context context = timer.time();
             requestContext.setProperty("timerContext", context);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RecordMetricsFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RecordMetricsFilter.java
@@ -76,7 +76,7 @@ public class RecordMetricsFilter implements ContainerRequestFilter, ContainerRes
         MultivaluedMap<String, String> pathParameters = uriInfo.getPathParameters(true);
         final Map<String, String> valuesToParams = pathParameters.entrySet().stream()
                 .map(entry -> entry.getValue().stream()
-                        .collect(toMap(Function.identity(), value -> entry.getKey())))
+                        .collect(toMap(Function.identity(), value -> "{" + entry.getKey() + "}")))
                 .reduce(new HashMap<>(), (m1, m2) -> {
                     m1.putAll(m2);
                     return m1;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AdminHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AdminHandler.java
@@ -54,7 +54,7 @@ public class AdminHandler {
     ManifestInformation manifestInformation;
 
     @GET
-    @Path("status")
+    @Path("/status")
     @ApiOperation(value = "Returns the current status for various components.",
             response = Map.class)
     public Response status(@Context ServletContext servletContext) {

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -66,7 +66,7 @@ public enum ConfigurationKey {
     ADMIN_TENANT("hawkular.metrics.admin-tenant", "admin", "ADMIN_TENANT", false),
     METRICS_REPORTING_HOSTNAME("hawkular.metrics.reporting.hostname", null, "METRICS_REPORTING_HOSTNAME", false),
     METRICS_REPORTING_ENABLED("hawkular.metrics.reporting.enabled", null, "METRICS_REPORTING_ENABLED", true),
-    METRICS_REPORTING_COLLECTION_INTERVAL("hawkular.metrics.reporting.collection-interval", "180",
+    METRICS_REPORTING_COLLECTION_INTERVAL("hawkular.metrics.reporting.collection-interval", "300",
             "METRICS_REPORTING_COLLECTION_INTERVAL", false),
 
     //Metric expiration job configuration

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/DropWizardReporter.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/DropWizardReporter.java
@@ -23,10 +23,8 @@ import static org.hawkular.metrics.model.MetricType.GAUGE;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 
 import org.hawkular.metrics.core.service.MetricsService;
 import org.hawkular.metrics.model.DataPoint;

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/HawkularObjectNameFactory.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/HawkularObjectNameFactory.java
@@ -16,9 +16,7 @@
  */
 package org.hawkular.metrics.core.dropwizard;
 
-import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.Map;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/MetaData.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/MetaData.java
@@ -72,6 +72,7 @@ public class MetaData {
         tags.put(NAME_PROPERTY, name);
         tags.put(SCOPE_PROPERTY, scope);
         tags.put(TYPE_PROPERTY, type);
+        tags.put(HOSTNAME_PROPERTY, hostname);
         tags.putAll(optional);
     }
 
@@ -119,10 +120,11 @@ public class MetaData {
                 .filter(e -> !REQUIRED_PROPERTIES.contains(e.getKey()))
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
         return MoreObjects.toStringHelper(this)
-                .add("namespace", tags.get(NAMESPACE_PROPERTY))
-                .add("name", tags.get(NAME_PROPERTY))
-                .add("scope", tags.get(SCOPE_PROPERTY))
-                .add("type", tags.get(TYPE_PROPERTY))
+                .add("namespace", getNamespace())
+                .add("hostname", getHostname())
+                .add("name", getName())
+                .add("scope", getScope())
+                .add("type", getType())
                 .add("optional", optional)
                 .toString();
     }

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -175,21 +175,6 @@ public class MetricsServiceImpl implements MetricsService {
     private Map<MetricType<?>, Func1<Observable<? extends Metric<?>>, Observable<Integer>>> pointsInserter;
 
     /**
-     * Measurements of the throughput of inserting data points.
-     */
-    private Meter dataPointsInserted;
-
-    /**
-     * Raw data read metrics
-     */
-    private Timer rawDataReadLatency;
-
-    /**
-     * Metric tag query metrics
-     */
-    private Timer metricTagsTimer;
-
-    /**
      * Functions used to find metric data points rows.
      */
     private Map<MetricType<?>, Func6<? extends MetricId<?>, Long, Long,
@@ -317,9 +302,30 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     private void initMetrics() {
-        dataPointsInserted = metricRegistry.meter("DataPointsInserted", "Core", "Write");
-        rawDataReadLatency = metricRegistry.timer("RawDataReadLatency", "Core", "Read");
-        metricTagsTimer = metricRegistry.timer("MetricTagsQueryLatency", "Core", "Read");
+        metricRegistry.registerMetaData("DataPointsInserted", "Core", "Write");
+        metricRegistry.registerMetaData("RawDataReadLatency", "Core", "Read");
+        metricRegistry.registerMetaData("MetricTagsQueryLatency", "Core", "Read");
+    }
+
+    /**
+     * Measurements of the throughput of inserting data points.
+     */
+    private Meter getDataPointsInserted() {
+        return metricRegistry.meter("DataPointsInserted");
+    }
+
+    /**
+     * Raw data read metrics
+     */
+    private Timer getRawDataReadLatency() {
+        return metricRegistry.timer("RawDataReadLatency");
+    }
+
+    /**
+     * Metric tag query metrics
+     */
+    private Timer getMetricsTagsQueryLatency() {
+        return metricRegistry.timer("MetricTagsQueryLatency");
     }
 
     private void initConfiguration(Session session) {
@@ -540,7 +546,7 @@ public class MetricsServiceImpl implements MetricsService {
     @SuppressWarnings("unchecked")
     @Override
     public <T> Observable<Metric<T>> findMetricsWithFilters(String tenantId, MetricType<T> metricType, String tags) {
-        Timer.Context context = metricTagsTimer.time();
+        Timer.Context context = getMetricsTagsQueryLatency().time();
         Observable<Metric<T>> results;
         try {
             results = expresssionTagQueryParser
@@ -622,7 +628,7 @@ public class MetricsServiceImpl implements MetricsService {
                 .call(metrics
                         .filter(metric -> !metric.getDataPoints().isEmpty())
                         .doOnNext(insertedDataPointEvents::onNext))
-                .doOnNext(dataPointsInserted::mark)
+                .doOnNext(getDataPointsInserted()::mark)
                 .map(i -> null);
     }
 
@@ -636,7 +642,7 @@ public class MetricsServiceImpl implements MetricsService {
     public <T> Observable<DataPoint<T>> findDataPoints(MetricId<T> metricId, long start, long end, int limit,
                                                        Order order, int pageSize) {
 
-        Timer.Context context = rawDataReadLatency.time();
+        Timer.Context context = getRawDataReadLatency().time();
         checkArgument(isValidTimeRange(start, end), "Invalid time range");
         Order safeOrder = (null == order) ? Order.ASC : order;
         MetricType<T> metricType = metricId.getType();


### PR DESCRIPTION
HawkularObjectNameFactory previously assumed every metric would have meta
data. TokenAuthenticator was registering metrics without meta data. I have
updated TokenAuthenticator so that it creates meta data. I have also
updated HawkularObjectNameFactory to handle the case where there is no
meta data.

There is another important change around the meta data. If a metric does
not have meta data, then its tags and data points will not get persisted.
A warning will get logged by HawkularMetricsRegistryListener about the
lack of meta data.

I have refactored the way in which internal metrics are registered.
Previously everything was done eagerly at start up. Now only meta data
is registered eagerly. Registering meta data will not cause anything to
be persisted in Cassandra. Metrics are registered lazily upon access.