### PR TITLE
[HWKMETRICS-695] Fix NPE and several other issues

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/MetricsServiceLifecycle.java
@@ -97,7 +97,6 @@ import org.hawkular.metrics.core.dropwizard.DropWizardReporter;
 import org.hawkular.metrics.core.dropwizard.HawkularMetricRegistry;
 import org.hawkular.metrics.core.dropwizard.HawkularMetricsRegistryListener;
 import org.hawkular.metrics.core.dropwizard.HawkularObjectNameFactory;
-import org.hawkular.metrics.core.dropwizard.MetaData;
 import org.hawkular.metrics.core.dropwizard.MetricNameService;
 import org.hawkular.metrics.core.jobs.CompressData;
 import org.hawkular.metrics.core.jobs.JobsService;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RESTMetaData.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RESTMetaData.java
@@ -54,16 +54,16 @@ public class RESTMetaData extends MetaData {
     private Type type;
 
 
-    public static RESTMetaData forRead(HTTPMethod method, String uri) {
-        return new RESTMetaData(new RESTMetricName(method, uri), Type.READ);
+    public static RESTMetaData forRead(HTTPMethod method, String uri, String hostname) {
+        return new RESTMetaData(new RESTMetricName(method, uri), Type.READ, hostname);
     }
 
-    public static RESTMetaData forWrite(HTTPMethod method, String uri) {
-        return new RESTMetaData(new RESTMetricName(method, uri), Type.WRITE);
+    public static RESTMetaData forWrite(HTTPMethod method, String uri, String hostname) {
+        return new RESTMetaData(new RESTMetricName(method, uri), Type.WRITE, hostname);
     }
 
-    private RESTMetaData(RESTMetricName name, Type type) {
-        super(name.getName(), SCOPE, type.toString(), null, ImmutableMap.of(
+    private RESTMetaData(RESTMetricName name, Type type, String hostname) {
+        super(name.getName(), SCOPE, type.toString(), hostname, ImmutableMap.of(
                 "method", name.getMethod().toString(),
                 "uri", name.getUri()
         ));

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RESTMetrics.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RESTMetrics.java
@@ -19,12 +19,9 @@ package org.hawkular.metrics.api.jaxrs.dropwizard;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.util.AnnotationLiteral;
@@ -37,17 +34,14 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
-import org.hawkular.metrics.api.jaxrs.handler.template.IMetricsHandler;
 import org.hawkular.metrics.api.jaxrs.util.MetricRegistryProvider;
 import org.hawkular.metrics.core.dropwizard.HawkularMetricRegistry;
 import org.hawkular.metrics.core.dropwizard.MetricNameService;
 import org.jboss.logging.Logger;
 
 import com.codahale.metrics.Timer;
-import com.google.common.reflect.ClassPath;
 
 import rx.Observable;
-import rx.exceptions.Exceptions;
 
 /**
  * Registers metric meta data for REST endpoints. The actual metrics are registered when the end points are invoked for

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RecordMetricsFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RecordMetricsFilter.java
@@ -37,7 +37,6 @@ import javax.ws.rs.ext.Provider;
 import org.jboss.logging.Logger;
 
 import com.codahale.metrics.Timer;
-import com.google.common.base.Stopwatch;
 
 /**
  * This filter records DropWizard metrics for REST endpoints.
@@ -54,11 +53,10 @@ public class RecordMetricsFilter implements ContainerRequestFilter, ContainerRes
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        Stopwatch stopwatch = Stopwatch.createStarted();
         String path = getPath(requestContext.getUriInfo());
         HTTPMethod method = HTTPMethod.fromString(requestContext.getMethod());
         RESTMetricName metricName = new RESTMetricName(method, path);
-        Timer timer = restMetrics.getTimers().get(metricName);
+        Timer timer = restMetrics.getTimer(metricName.getName());
         if (timer != null) {
             Timer.Context context = timer.time();
             requestContext.setProperty("timerContext", context);

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RecordMetricsFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/dropwizard/RecordMetricsFilter.java
@@ -76,7 +76,7 @@ public class RecordMetricsFilter implements ContainerRequestFilter, ContainerRes
         MultivaluedMap<String, String> pathParameters = uriInfo.getPathParameters(true);
         final Map<String, String> valuesToParams = pathParameters.entrySet().stream()
                 .map(entry -> entry.getValue().stream()
-                        .collect(toMap(Function.identity(), value -> entry.getKey())))
+                        .collect(toMap(Function.identity(), value -> "{" + entry.getKey() + "}")))
                 .reduce(new HashMap<>(), (m1, m2) -> {
                     m1.putAll(m2);
                     return m1;

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AdminHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/AdminHandler.java
@@ -54,7 +54,7 @@ public class AdminHandler {
     ManifestInformation manifestInformation;
 
     @GET
-    @Path("status")
+    @Path("/status")
     @ApiOperation(value = "Returns the current status for various components.",
             response = Map.class)
     public Response status(@Context ServletContext servletContext) {

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -66,7 +66,7 @@ public enum ConfigurationKey {
     ADMIN_TENANT("hawkular.metrics.admin-tenant", "admin", "ADMIN_TENANT", false),
     METRICS_REPORTING_HOSTNAME("hawkular.metrics.reporting.hostname", null, "METRICS_REPORTING_HOSTNAME", false),
     METRICS_REPORTING_ENABLED("hawkular.metrics.reporting.enabled", null, "METRICS_REPORTING_ENABLED", true),
-    METRICS_REPORTING_COLLECTION_INTERVAL("hawkular.metrics.reporting.collection-interval", "180",
+    METRICS_REPORTING_COLLECTION_INTERVAL("hawkular.metrics.reporting.collection-interval", "300",
             "METRICS_REPORTING_COLLECTION_INTERVAL", false),
 
     //Metric expiration job configuration

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/DropWizardReporter.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/DropWizardReporter.java
@@ -46,7 +46,7 @@ import rx.Observable;
 /**
  * A scheduled reporter that persists internally collected metrics. Several of the DropWizard metric types are complex
  * types having multiple values, and they do not map directly to metric types in Hawkular Metrics. Numeric gauges and
- * counters map directly, but meters, times, and histograms do not.
+ * counters map directly, but meters, times, and histograms do not. Only metrics having meta data will be persisted.
  *
  * @author jsanda
  */
@@ -75,105 +75,122 @@ public class DropWizardReporter extends ScheduledReporter {
             SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters, SortedMap<String, Timer> timers) {
         long timestamp = System.currentTimeMillis();
 
-        Observable<Metric<Double>> gaugeObservable = Observable.from(gauges.entrySet())
-                .map(entry -> new Metric<>(getMetricId(entry.getKey(), GAUGE), singletonList(
-                        new DataPoint<>(timestamp, (Double) entry.getValue().getValue()))));
-
         List<Metric<Long>> countersList = new ArrayList<>();
         List<Metric<Double>> gaugesList = new ArrayList<>();
 
-        meters.entrySet().forEach(entry -> {
-            MetricId<Double> gaugeId = getMetricId(entry.getKey(), GAUGE);
-            MetricId<Long> counterId = getMetricId(entry.getKey(), COUNTER);
+        meters.entrySet()
+                .stream()
+                .filter(entry -> metricRegistry.getMetaData(entry.getKey()) != null)
+                .forEach(entry -> {
+                    MetricId<Double> gaugeId = getMetricId(entry.getKey(), GAUGE);
+                    MetricId<Long> counterId = getMetricId(entry.getKey(), COUNTER);
 
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-1min"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getOneMinuteRate()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-5min"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getFiveMinuteRate()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-15min"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getFifteenMinuteRate()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-mean"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getMeanRate()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-5min"), singletonList(new DataPoint<>(timestamp, entry.getValue().getFiveMinuteRate()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-15min"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getFifteenMinuteRate()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-mean"), singletonList(new DataPoint<>(timestamp, entry.getValue().getMeanRate()))));
 
-            countersList.add(new Metric<>(counterId, singletonList(new DataPoint<>(timestamp,
-                    entry.getValue().getCount()))));
-        });
+                    countersList.add(new Metric<>(counterId, singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getCount()))));
+                });
 
-        timers.entrySet().forEach(entry -> {
-            MetricId<Double> gaugeId = getMetricId(entry.getKey(), GAUGE);
-            MetricId<Long> counterId = getMetricId(entry.getKey(), COUNTER);
+        timers.entrySet()
+                .stream()
+                .filter(entry -> metricRegistry.getMetaData(entry.getKey()) != null)
+                .forEach(entry -> {
+                    MetricId<Double> gaugeId = getMetricId(entry.getKey(), GAUGE);
+                    MetricId<Long> counterId = getMetricId(entry.getKey(), COUNTER);
 
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-1min"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getOneMinuteRate()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-5min"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getFiveMinuteRate()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-15min"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getFifteenMinuteRate()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-mean"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getMeanRate()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-5min"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getFiveMinuteRate()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-15min"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getFifteenMinuteRate()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-mean"), singletonList(new DataPoint<>(timestamp, entry.getValue().getMeanRate()))));
 
-            countersList.add(new Metric<>(counterId, singletonList(new DataPoint<>(timestamp,
-                    entry.getValue().getCount()))));
+                    countersList.add(new Metric<>(counterId, singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getCount()))));
 
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-median"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().getMedian()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-max"),
-                    singletonList(new DataPoint<>(timestamp, (double) entry.getValue().getSnapshot().getMax())
-                    )));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-min"),
-                    singletonList(new DataPoint<>(timestamp, (double) entry.getValue().getSnapshot().getMin()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-stdDev"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().getStdDev()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-75p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get75thPercentile()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-95p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get95thPercentile()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-98p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get98thPercentile()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-99p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get99thPercentile()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-999p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get999thPercentile()))));
-        });
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-median"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().getMedian()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-max"), singletonList(new DataPoint<>(timestamp,
+                            (double) entry.getValue().getSnapshot().getMax()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-min"), singletonList(new DataPoint<>(timestamp,
+                            (double) entry.getValue().getSnapshot().getMin()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-75p"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().get75thPercentile()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-95p"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().get95thPercentile()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-99p"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().get99thPercentile()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-999p"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().get999thPercentile()))));
+                });
 
-        gauges.entrySet().forEach(entry -> {
-            MetricId<Double> gaugeId = getMetricId(entry.getKey(), GAUGE);
-            gaugesList.add(new Metric<>(gaugeId, singletonList(new DataPoint<>(timestamp,
-                    Double.parseDouble(entry.getValue().getValue().toString())))));
-        });
+        gauges.entrySet()
+                .stream()
+                .filter(entry -> metricRegistry.getMetaData(entry.getKey()) != null)
+                .forEach(entry -> {
+                    MetricId<Double> gaugeId = getMetricId(entry.getKey(), GAUGE);
+                    gaugesList.add(new Metric<>(gaugeId, singletonList(new DataPoint<>(timestamp,
+                            Double.parseDouble(entry.getValue().getValue().toString())))));
+                });
 
-        counters.entrySet().forEach(entry -> {
-            MetricId<Long> counterId = getMetricId(entry.getKey(), COUNTER);
-            countersList.add(new Metric<>(counterId, singletonList(new DataPoint<>(timestamp,
-                    entry.getValue().getCount()))));
-        });
+        counters.entrySet()
+                .stream()
+                .filter(entry -> metricRegistry.getMetaData(entry.getKey()) != null)
+                .forEach(entry -> {
+                    MetricId<Long> counterId = getMetricId(entry.getKey(), COUNTER);
+                    countersList.add(new Metric<>(counterId, singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getCount()))));
+                });
 
-        histograms.entrySet().forEach(entry -> {
-            MetricId<Double> gaugeId = getMetricId(entry.getKey(), GAUGE);
-            MetricId<Long> counterId = getMetricId(entry.getKey(), COUNTER);
+        histograms.entrySet()
+                .stream()
+                .filter(entry -> metricRegistry.getMetaData(entry.getKey()) != null)
+                .forEach(entry -> {
+                    MetricId<Double> gaugeId = getMetricId(entry.getKey(), GAUGE);
+                    MetricId<Long> counterId = getMetricId(entry.getKey(), COUNTER);
 
-            countersList.add(new Metric<>(counterId, singletonList(new DataPoint<>(timestamp,
-                    entry.getValue().getCount()))));
+                    countersList.add(new Metric<>(counterId, singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getCount()))));
 
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-median"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().getMedian()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-max"),
-                    singletonList(new DataPoint<>(timestamp, (double) entry.getValue().getSnapshot().getMax())
-                    )));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-min"),
-                    singletonList(new DataPoint<>(timestamp, (double) entry.getValue().getSnapshot().getMin()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-stdDev"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().getStdDev()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-75p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get75thPercentile()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-95p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get95thPercentile()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-98p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get98thPercentile()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-99p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get99thPercentile()))));
-            gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() + "-999p"),
-                    singletonList(new DataPoint<>(timestamp, entry.getValue().getSnapshot().get999thPercentile()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-mean"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().getMean()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-median"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().getMedian()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-max"), singletonList(new DataPoint<>(timestamp,
+                            (double) entry.getValue().getSnapshot().getMax()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-min"), singletonList(new DataPoint<>(timestamp,
+                            (double) entry.getValue().getSnapshot().getMin()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-75p"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().get75thPercentile()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-95p"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().get95thPercentile()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-99p"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().get99thPercentile()))));
+                    gaugesList.add(new Metric<>(new MetricId<>(gaugeId.getTenantId(), GAUGE, gaugeId.getName() +
+                            "-999p"), singletonList(new DataPoint<>(timestamp,
+                            entry.getValue().getSnapshot().get999thPercentile()))));
         });
 
         // TODO add failover support

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/HawkularObjectNameFactory.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/HawkularObjectNameFactory.java
@@ -16,9 +16,7 @@
  */
 package org.hawkular.metrics.core.dropwizard;
 
-import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.Map;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -33,10 +31,11 @@ import com.codahale.metrics.ObjectNameFactory;
  */
 public class HawkularObjectNameFactory implements ObjectNameFactory {
     private static final CoreLogger LOGGER = CoreLogging.getCoreLogger(HawkularObjectNameFactory.class);
-    private Map<String, MetaData> metaDataMap = new HashMap<>();
 
-    public HawkularObjectNameFactory(Map<String, MetaData> map) {
-        this.metaDataMap = map;
+    private HawkularMetricRegistry metricRegistry;
+
+    public HawkularObjectNameFactory(HawkularMetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
     }
 
     private boolean needsQuote(String propertyValue){
@@ -51,9 +50,15 @@ public class HawkularObjectNameFactory implements ObjectNameFactory {
     public ObjectName createName(String type, String domain, String name) {
         try {
             Hashtable<String, String> table = new Hashtable<>();
-            table.putAll(metaDataMap.get(name).getTags());
-            table.replaceAll((k,v) -> needsQuote(v) ? ObjectName.quote(v): v );
-            return new ObjectName(domain, table);
+            MetaData metaData = metricRegistry.getMetaData(name);
+            if (metaData == null) {
+                LOGGER.warnf("No meta data found for %s", name);
+                return new ObjectName(domain, type, name);
+            } else {
+                table.putAll(metricRegistry.getMetaData(name).getTags());
+                table.replaceAll((k,v) -> needsQuote(v) ? ObjectName.quote(v): v );
+                return new ObjectName(domain, table);
+            }
         } catch (MalformedObjectNameException e) {
             LOGGER.warn("Unable to register {" + type + "} {" + name + "}", e);
             throw new RuntimeException(e);

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/MetaData.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/dropwizard/MetaData.java
@@ -72,6 +72,7 @@ public class MetaData {
         tags.put(NAME_PROPERTY, name);
         tags.put(SCOPE_PROPERTY, scope);
         tags.put(TYPE_PROPERTY, type);
+        tags.put(HOSTNAME_PROPERTY, hostname);
         tags.putAll(optional);
     }
 
@@ -119,10 +120,11 @@ public class MetaData {
                 .filter(e -> !REQUIRED_PROPERTIES.contains(e.getKey()))
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
         return MoreObjects.toStringHelper(this)
-                .add("namespace", tags.get(NAMESPACE_PROPERTY))
-                .add("name", tags.get(NAME_PROPERTY))
-                .add("scope", tags.get(SCOPE_PROPERTY))
-                .add("type", tags.get(TYPE_PROPERTY))
+                .add("namespace", getNamespace())
+                .add("hostname", getHostname())
+                .add("name", getName())
+                .add("scope", getScope())
+                .add("type", getType())
                 .add("optional", optional)
                 .toString();
     }


### PR DESCRIPTION
HawkularObjectNameFactory previously assumed every metric would have meta
data. TokenAuthenticator was registering metrics without meta data. I have
updated TokenAuthenticator so that it creates meta data. I have also
updated HawkularObjectNameFactory to handle the case where there is no
meta data.

There is another important change around the meta data. If a metric does
not have meta data, then its tags and data points will not get persisted.
A warning will get logged by HawkularMetricsRegistryListener about the
lack of meta data.

I have refactored the way in which internal metrics are registered.
Previously everything was done eagerly at start up. Now only meta data
is registered eagerly. Registering meta data will not cause anything to
be persisted in Cassandra. Metrics are registered lazily upon access.