### PR TITLE
[HWKMETRICS-597] Add backpressure to the RxSession scheduling

### DIFF
--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -45,7 +45,7 @@ public enum ConfigurationKey {
     CASSANDRA_USESSL("hawkular.metrics.cassandra.use-ssl", "false", "CASSANDRA_USESSL", false),
     CASSANDRA_MAX_CONN_HOST("hawkular.metrics.cassandra.max-connections-per-host", "10", "CASSANDRA_MAX_CONN_HOST",
             false),
-    CASSANDRA_MAX_REQUEST_CONN("hawkular.metrics.cassandra.max-requests-per-connection", "5000",
+    CASSANDRA_MAX_REQUEST_CONN("hawkular.metrics.cassandra.max-requests-per-connection", "1024",
             "CASSANDRA_MAX_REQUEST_CONN", false),
     CASSANDRA_MAX_QUEUE_SIZE("hawkular.metrics.cassandra.max-queue-size", "256", "CASSANDRA_MAX_QUEUE_SIZE", false),
     CASSANDRA_REQUEST_TIMEOUT("hawkular.metrics.cassandra.request-timeout", "12000", "CASSANDRA_REQUEST_TIMEOUT",

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertFalse;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hawkular.metrics.core.service.transformers.MetricFromFullDataRowTransformer;
 import org.hawkular.metrics.model.AvailabilityType;
@@ -49,8 +50,9 @@ import com.datastax.driver.core.TableMetadata;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import rx.Emitter;
 import rx.Observable;
+import rx.Observer;
+import rx.observables.SyncOnSubscribe;
 import rx.observers.TestSubscriber;
 
 /**
@@ -233,30 +235,31 @@ public class DataAccessITest extends BaseITest {
         String tenantId = "t1";
         long start = now().getMillis();
 
-        int amountOfMetrics = 1000;
-        int datapointsPerMetric = 10;
+        int amountOfMetrics = 10_000;
 
-        for (int j = 0; j < datapointsPerMetric; j++) {
-            final int dpAdd = j;
-            Observable<Metric<Double>> metrics = Observable.create(emitter -> {
-                for (int i = 0; i < amountOfMetrics; i++) {
-                    String metricName = String.format("m%d", i);
-                    MetricId<Double> mId = new MetricId<>(tenantId, GAUGE, metricName);
-                    emitter.onNext(new Metric<>(mId, asList(new DataPoint<>(start + dpAdd, 1.1))));
-                }
-                emitter.onCompleted();
-            }, Emitter.BackpressureMode.BUFFER);
+        Observable<Metric<Double>> metrics =
+                Observable.create(new SyncOnSubscribe<AtomicInteger, Metric<Double>>() {
+                    @Override protected AtomicInteger generateState() {
+                        return new AtomicInteger(0);
+                    }
 
-            TestSubscriber<Integer> subscriber = new TestSubscriber<>();
-            Observable<Integer> observable = dataAccess.insertData(metrics);
-            observable.subscribe(subscriber);
-            subscriber.awaitTerminalEvent(20, TimeUnit.SECONDS); // For Travis..
-            for (Throwable throwable : subscriber.getOnErrorEvents()) {
-                throwable.printStackTrace();
-            }
-            subscriber.assertNoErrors();
-            subscriber.assertCompleted();
+                    @Override protected AtomicInteger next(AtomicInteger previous, Observer<? super Metric<Double>> observer) {
+                        String metricName = String.format("m%d", previous.incrementAndGet());
+                        MetricId<Double> mId = new MetricId<>(tenantId, GAUGE, metricName);
+                        observer.onNext(new Metric<>(mId, asList(new DataPoint<>(start + previous.get(), 1.1))));
+                        return previous;
+                    }
+                });
+
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+        Observable<Integer> observable = dataAccess.insertData(metrics.take(amountOfMetrics));
+        observable.subscribe(subscriber);
+        subscriber.awaitTerminalEvent(20, TimeUnit.SECONDS); // For Travis..
+        for (Throwable throwable : subscriber.getOnErrorEvents()) {
+            throwable.printStackTrace();
         }
+        subscriber.assertNoErrors();
+        subscriber.assertCompleted();
 
         Observable<Row> rowObservable = dataAccess.findAllDataFromBucket(start, DEFAULT_PAGE_SIZE, 2)
                 .flatMap(r -> r);
@@ -266,6 +269,6 @@ public class DataAccessITest extends BaseITest {
         tsr.awaitTerminalEvent(100, TimeUnit.SECONDS); // Travis again
         tsr.assertCompleted();
         tsr.assertNoErrors();
-        tsr.assertValueCount(amountOfMetrics * datapointsPerMetric);
+        tsr.assertValueCount(amountOfMetrics);
     }
 }


### PR DESCRIPTION
 If there are more than 1024 inflight requests on any connected host, wait until scheduling more statements.
