### PR TITLE
Add missing DataAccess.shutdown() requests

### DIFF
--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/CompressDataJobITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/CompressDataJobITest.java
@@ -57,6 +57,7 @@ import org.jboss.logging.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -180,6 +181,11 @@ public class CompressDataJobITest extends BaseITest {
 
     @AfterMethod(alwaysRun = true)
     public void tearDown() {
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void shutdown() {
+        dataAccess.shutdown();
     }
 
     @Test(priority = 1)

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/DeleteExpiredMetricsJobITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/DeleteExpiredMetricsJobITest.java
@@ -33,8 +33,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hawkular.metrics.core.service.BaseITest;
 import org.hawkular.metrics.core.service.DataAccess;
-import org.hawkular.metrics.core.service.DataAccessImpl;
 import org.hawkular.metrics.core.service.MetricsServiceImpl;
+import org.hawkular.metrics.core.service.TestDataAccessFactory;
 import org.hawkular.metrics.datetime.DateTimeService;
 import org.hawkular.metrics.model.DataPoint;
 import org.hawkular.metrics.model.Metric;
@@ -44,6 +44,7 @@ import org.hawkular.metrics.scheduler.impl.TestScheduler;
 import org.hawkular.metrics.sysconfig.ConfigurationService;
 import org.jboss.logging.Logger;
 import org.joda.time.DateTime;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -75,7 +76,7 @@ public class DeleteExpiredMetricsJobITest extends BaseITest {
 
     @BeforeClass
     public void initClass() {
-        dataAccess = new DataAccessImpl(session);
+        dataAccess = TestDataAccessFactory.newInstance(session);
 
         resetConfig = session.prepare("DELETE FROM sys_config WHERE config_id = 'org.hawkular.metrics.jobs." +
                 DeleteExpiredMetrics.JOB_NAME + "'");
@@ -115,6 +116,11 @@ public class DeleteExpiredMetricsJobITest extends BaseITest {
     @AfterMethod(alwaysRun = true)
     public void tearDown() {
         jobsService.shutdown();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void shutdown() {
+        dataAccess.shutdown();
     }
 
     @Test

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/DeleteTenantITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/jobs/DeleteTenantITest.java
@@ -49,6 +49,7 @@ import org.hawkular.metrics.scheduler.impl.TestScheduler;
 import org.hawkular.metrics.sysconfig.ConfigurationService;
 import org.jboss.logging.Logger;
 import org.joda.time.DateTime;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -67,6 +68,7 @@ public class DeleteTenantITest extends BaseITest {
 
     private static Logger logger = Logger.getLogger(DeleteTenantITest.class);
 
+    private DataAccess dataAccess;
     private MetricsServiceImpl metricsService;
 
     private ConfigurationService configurationService;
@@ -91,7 +93,7 @@ public class DeleteTenantITest extends BaseITest {
                 "SELECT tvalue, type, metric FROM metrics_tags_idx WHERE tenant_id = ? AND tname = ?");
         getRetentions = session.prepare("SELECT metric FROM retentions_idx WHERE tenant_id = ? AND type = ?");
 
-        DataAccess dataAccess = TestDataAccessFactory.newInstance(session);
+        dataAccess = TestDataAccessFactory.newInstance(session);
 
         configurationService = new ConfigurationService() ;
         configurationService.init(rxSession);
@@ -122,6 +124,11 @@ public class DeleteTenantITest extends BaseITest {
     @AfterMethod(alwaysRun = true)
     public void tearDown() {
         jobsService.shutdown();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void shutdown() {
+        dataAccess.shutdown();
     }
 
     @Test

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
@@ -268,15 +268,4 @@ public class DataAccessITest extends BaseITest {
         tsr.assertNoErrors();
         tsr.assertValueCount(amountOfMetrics * datapointsPerMetric);
     }
-
-//    @Test
-//    public void testBucketIndexes() throws Exception {
-//        ZonedDateTime of = ZonedDateTime.of(2017, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-//        ZonedDateTime limit = ZonedDateTime.of(2017, 1, 1, 23, 59, 0, 0, ZoneOffset.UTC);
-//        int bucketIndex = dataAccess.getBucketIndex(of.toInstant().toEpochMilli());
-//        assertEquals(0, bucketIndex);
-//
-//        bucketIndex = dataAccess.getBucketIndex(limit.toInstant().toEpochMilli());
-//        assertEquals(11, bucketIndex);
-//    }
 }

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/TestDataAccessFactory.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/TestDataAccessFactory.java
@@ -62,7 +62,7 @@ public class TestDataAccessFactory {
      * Create few temporary tables for tests
      */
     static Set<Long> tableListForTesting() {
-        Set<Long> tempTables = new HashSet<>(2);
+        Set<Long> tempTables = new HashSet<>(3);
         DateTime now = DateTimeService.now.get();
         tempTables.add(now.getMillis());
         tempTables.add(now.minusHours(2).getMillis());


### PR DESCRIPTION
For tests only, avoids multiple SchemaChangeListeners at the same time