### PR TITLE
Change Cassandra settings for Travis for faster tests

### DIFF
--- a/.travis.install.cassandra.sh
+++ b/.travis.install.cassandra.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+# Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,8 +52,8 @@ mkdir "${CASSANDRA_HOME}/logs"
 export HEAP_NEWSIZE="100M"
 export MAX_HEAP_SIZE="1G"
 
+echo 'JVM_OPTS="$JVM_OPTS -Dcassandra.unsafesystem=true"' >> ${CASSANDRA_HOME}/conf/cassandra-env.sh
 nohup sh ${CASSANDRA_HOME}/bin/cassandra -f -p ${HOME}/cassandra.pid > ${CASSANDRA_HOME}/logs/stdout.log 2>&1 &
-
 
 CASSANDRA_STATUS="undecided"
 TOTAL_WAIT=0;

--- a/core/configuration-service/src/test/java/org/hawkular/metrics/sysconfig/ConfigurationServiceTest.java
+++ b/core/configuration-service/src/test/java/org/hawkular/metrics/sysconfig/ConfigurationServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +55,8 @@ public class ConfigurationServiceTest {
         session = cluster.connect();
 
         SchemaService schemaService = new SchemaService();
-        schemaService.run(session, "hawkulartest", true);
+        String keyspace = System.getProperty("keyspace", "hawkulartest");
+        schemaService.run(session, keyspace, true);
 
         configurationService = new ConfigurationService();
         configurationService.init(new RxSessionImpl(session));

--- a/core/schema/src/main/resources/org/hawkular/schema/bootstrap.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/bootstrap.groovy
@@ -48,8 +48,14 @@ if (reset) {
   executeCQL("DROP KEYSPACE IF EXISTS $keyspace", 20000)
 }
 
-executeCQL("CREATE KEYSPACE IF NOT EXISTS $keyspace WITH replication = {'class': 'SimpleStrategy', " +
-    "'replication_factor': $replicationFactor}")
+def keyspaceCreate = "CREATE KEYSPACE IF NOT EXISTS $keyspace WITH replication = {'class': 'SimpleStrategy', " +
+    "'replication_factor': $replicationFactor}"
+
+if (keyspace.equals("hawkulartest") || keyspace.equals("hawkular_metrics_rest_tests")) {
+  keyspaceCreate = "$keyspaceCreate AND DURABLE_WRITES = 'false'"
+}
+
+executeCQL(keyspaceCreate)
 executeCQL("USE $keyspace")
 
 // The retentions map entries are {metric type, retention} key/value paris where


### PR DESCRIPTION
This removes the fsync from the schema changes, so it speeds up the Cassandra's operation in the testing environment considerably.