### PR TITLE
[HWKMETRICS-724] update data table to use TWCS - release/0.27.0 branch

### DIFF
--- a/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
+++ b/core/schema/src/main/java/org/hawkular/metrics/schema/SchemaService.java
@@ -62,7 +62,7 @@ public class SchemaService {
         // For now, I am just hard coding the version tag, but a more robust solution would be
         // to calculate the tags using the current version stored in the sys_config table
         // and the new version which we can extract from any of our JAR manifest files.
-        List<String> tags = asList("0.15.x", "0.18.x", "0.19.x", "0.20.x", "0.21.x", "0.23.x", "0.26.x");
+        List<String> tags = asList("0.15.x", "0.18.x", "0.19.x", "0.20.x", "0.21.x", "0.23.x", "0.26.x", "0.27.x");
         URI script = getScript();
         cassalog.execute(script, tags, vars);
 

--- a/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.27.0.groovy
+++ b/core/schema/src/main/resources/org/hawkular/schema/updates/schema-0.27.0.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+schemaChange {
+    version '8.0'
+    author 'jsanda'
+    tags '0.27.x'
+    cql """
+ALTER TABLE data WITH compaction = {
+  'class': 'TimeWindowCompactionStrategy',
+  'compaction_window_unit': 'DAYS',
+  'compaction_window_size': '1'
+}
+"""
+}


### PR DESCRIPTION
The change is done with the 0.27.x tag since we want this change on the 0.27.0
branch as well.