### PR TITLE
HWKMETRICS-736 (openshift) add explicit Cache-Control header

### DIFF
--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/CacheControlFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/CacheControlFilter.java
@@ -37,8 +37,6 @@ import org.hawkular.metrics.api.jaxrs.config.ConfigurationProperty;
 @Provider
 public class CacheControlFilter implements ContainerResponseFilter {
 
-    public static final String HEADER_KEY = "Cache-Control";
-
     @Inject
     @Configurable
     @ConfigurationProperty(CACHE_CONTROL_HEADER)
@@ -50,7 +48,8 @@ public class CacheControlFilter implements ContainerResponseFilter {
 
         if (cacheControl != null) {
             MultivaluedMap<String, Object> responseHeaders = responseContext.getHeaders();
-            responseHeaders.add(HEADER_KEY, cacheControl);
+            responseHeaders.add("Cache-Control", cacheControl);
+            responseHeaders.add("Vary", "Origin,Accept-Encoding");
         }
     }
 }

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/CacheControlFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/CacheControlFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.filter;
+
+import static org.hawkular.metrics.api.jaxrs.config.ConfigurationKey.CACHE_CONTROL_HEADER;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.hawkular.metrics.api.jaxrs.config.Configurable;
+import org.hawkular.metrics.api.jaxrs.config.ConfigurationProperty;
+
+/**
+ * Class for registering Cache-Control header on responses (BZ 1492011)
+ * @author Joel Takvorian
+ */
+@Provider
+public class CacheControlFilter implements ContainerResponseFilter {
+
+    public static final String HEADER_KEY = "Cache-Control";
+
+    @Inject
+    @Configurable
+    @ConfigurationProperty(CACHE_CONTROL_HEADER)
+    String cacheControl;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+
+        if (cacheControl != null) {
+            MultivaluedMap<String, Object> responseHeaders = responseContext.getHeaders();
+            responseHeaders.add(HEADER_KEY, cacheControl);
+        }
+    }
+}

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/BaseHandler.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/handler/BaseHandler.java
@@ -39,7 +39,6 @@ import javax.ws.rs.core.Response;
 import org.hawkular.jaxrs.filter.cors.Headers;
 import org.hawkular.metrics.api.jaxrs.config.Configurable;
 import org.hawkular.metrics.api.jaxrs.config.ConfigurationProperty;
-import org.hawkular.metrics.api.jaxrs.filter.CacheControlFilter;
 import org.hawkular.metrics.api.jaxrs.util.ManifestInformation;
 import org.jboss.resteasy.annotations.GZIP;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
@@ -85,7 +84,8 @@ public class BaseHandler {
     }
 
     private void addHeaders(HttpServletResponse response) {
-        response.addHeader(CacheControlFilter.HEADER_KEY, STATIC_CACHE_CONTROL);
+        response.addHeader("Cache-Control", STATIC_CACHE_CONTROL);
+        response.addHeader("Vary", "Origin,Accept-Encoding");
 
         String requestOrigin = ResteasyProviderFactory.getContextData(HttpServletRequest.class).getHeader(Headers.ORIGIN);
         if (requestOrigin == null) {

--- a/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
+++ b/api/metrics-api-util/src/main/java/org/hawkular/metrics/api/jaxrs/config/ConfigurationKey.java
@@ -31,6 +31,9 @@ public enum ConfigurationKey {
     ALLOWED_CORS_ACCESS_CONTROL_ALLOW_HEADERS("hawkular.metrics.allowed-cors-access-control-allow-headers",
                     null, " ALLOWED_CORS_ACCESS_CONTROL_ALLOW_HEADERS", false),
 
+    //Response cache-control header
+    CACHE_CONTROL_HEADER("hawkular.metrics.cache-control-header", "no-cache", " CACHE_CONTROL_HEADER", false),
+
     //Cassandra
     CASSANDRA_NODES("hawkular.metrics.cassandra.nodes", "127.0.0.1", "CASSANDRA_NODES", false),
     CASSANDRA_CQL_PORT("hawkular.metrics.cassandra.cql-port", "9042", "CASSANDRA_CQL_PORT", false),


### PR DESCRIPTION
- Default to no-cache, but also add a config key to possibly override it
- For static HTML, use "private, max-age=86400"
- Explicitly add headers before redirect in BaseHandler on "/" when serving static html
- Add also "Vary" header for Origin and Accept-encoding