### PR TITLE
[HWKMETRICS-740] Change Alerts Version to 1.6.3.Final 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <nodes>127.0.0.1</nodes>
     <!-- Dependencies versions -->
     <version.org.cassalog>0.4.2</version.org.cassalog>
-    <version.org.hawkular.alerts>1.6.2.Final</version.org.hawkular.alerts>
+    <version.org.hawkular.alerts>1.6.3.Final</version.org.hawkular.alerts>
     <version.org.hawkular.commons>0.9.2.Final</version.org.hawkular.commons>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
     <version.joda-time>2.9.5</version.joda-time>


### PR DESCRIPTION
Hello @stefannegrea.

I created this PR to include this correction (htps://issues.jboss.org/browse/HWKALERTS-275) on next Hawkular Services release.

This correction prevent the ManageIQ to query for too much events. It might cause a  BusyPoolDriverException on Cassandra

From 1.6.2 to 1.6.3, there only code change was this code related to that fix. 
All the libraries still on the same version.
Best Regards,
Guilherme Baufaker Rêgo