### PR TITLE
[HWKMETRICS-744] upgrade hawkular-commons 0.9.2->0.9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <!-- Dependencies versions -->
     <version.org.cassalog>0.4.2</version.org.cassalog>
     <version.org.hawkular.alerts>1.6.3.Final</version.org.hawkular.alerts>
-    <version.org.hawkular.commons>0.9.2.Final</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.9.7.Final</version.org.hawkular.commons>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
     <version.joda-time>2.9.5</version.joda-time>
     <version.logback>1.1.3</version.logback>


### PR DESCRIPTION
This brings the hawkular commons version in sync with current hawkular agent
and hawkular services.