### PR TITLE
[HWKMETRICS-751] Improve simple tag query performance

### DIFF
--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -118,7 +118,7 @@ public interface DataAccess {
 
     Observable<Row> findMetricsByTagName(String tenantId, String tag);
 
-    Observable<Row> findMetricsByTagNameValue(String tenantId, String tag, String tvalue);
+    Observable<Row> findMetricsByTagNameValue(String tenantId, String tag, String ... tvalues);
 
     Observable<Row> findAllMetricsFromTagsIndex();
 

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/DataAccessImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -688,7 +689,7 @@ public class DataAccessImpl implements DataAccess {
         findMetricsByTagNameValue = session.prepare(
                 "SELECT tenant_id, type, metric, tvalue " +
                 "FROM metrics_tags_idx " +
-                "WHERE tenant_id = ? AND tname = ? AND tvalue = ?");
+                "WHERE tenant_id = ? AND tname = ? AND tvalue IN ?");
 
         updateMetricExpirationIndex = session.prepare(
                 "INSERT INTO metrics_expiration_idx (tenant_id, type, metric, time) VALUES (?, ?, ?, ?)");
@@ -1276,8 +1277,8 @@ public class DataAccessImpl implements DataAccess {
     }
 
     @Override
-    public Observable<Row> findMetricsByTagNameValue(String tenantId, String tag, String tvalue) {
-        return rxSession.executeAndFetch(findMetricsByTagNameValue.bind(tenantId, tag, tvalue));
+    public Observable<Row> findMetricsByTagNameValue(String tenantId, String tag, String ... tvalues) {
+        return rxSession.executeAndFetch(findMetricsByTagNameValue.bind(tenantId, tag, Arrays.asList(tvalues)));
     }
 
     @Override

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -191,6 +191,7 @@ public class MetricsServiceImpl implements MetricsService {
     /**
      * Tools that do tag query parsing and execution
      */
+    private boolean disableACostOptimization;
     private SimpleTagQueryParser tagQueryParser;
     private ExpressionTagQueryParser expresssionTagQueryParser;
 
@@ -271,7 +272,7 @@ public class MetricsServiceImpl implements MetricsService {
 
         verifyAndCreateTempTables();
 
-        tagQueryParser = new SimpleTagQueryParser(this.dataAccess, this);
+        tagQueryParser = new SimpleTagQueryParser(this.dataAccess, this, disableACostOptimization);
         expresssionTagQueryParser = new ExpressionTagQueryParser(this.dataAccess, this);
     }
 
@@ -346,6 +347,7 @@ public class MetricsServiceImpl implements MetricsService {
         log.infoInsertRetryConfig(insertMaxRetries, insertRetryMaxDelay);
 
         defaultPageSize = Integer.parseInt(configuration.get("page-size", "5000"));
+        disableACostOptimization = Boolean.parseBoolean(configuration.get("disable.parser.optimization", "false"));
     }
 
     private void setDefaultTTL(Session session, String keyspace) {

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DelegatingDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -219,8 +219,8 @@ public class DelegatingDataAccess implements DataAccess {
     }
 
     @Override
-    public Observable<Row> findMetricsByTagNameValue(String tenantId, String tag, String tvalue) {
-        return delegate.findMetricsByTagNameValue(tenantId, tag, tvalue);
+    public Observable<Row> findMetricsByTagNameValue(String tenantId, String tag, String ... tvalues) {
+        return delegate.findMetricsByTagNameValue(tenantId, tag, tvalues);
     }
 
     @Override

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/TestDataAccessFactory.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/TestDataAccessFactory.java
@@ -48,7 +48,6 @@ public class TestDataAccessFactory {
             void prepareTempStatements(String tableName, Long mapKey) {
                 super.prepareTempStatements(tableName, mapKey);
                 if(DataAccessImpl.OUT_OF_ORDER_TABLE_NAME.equals(tableName)) {
-                    log.infof("data_0 statements being prepared");
                     fallBackTable.countDown();
                 }
                 if (latch.getCount() > 0) {

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/tags/SimpleTagQueryParserTest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/tags/SimpleTagQueryParserTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.core.service.tags;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+
+/**
+ * Test some SimpleTagQueryParser optimization cases
+ *
+ * @author Michael Burman
+ */
+public class SimpleTagQueryParserTest {
+
+    @Test
+    public void testSomeCommonOpenshiftQueries() {
+        String podQuery1 = "test-container/test-podid/test/metric/A/XYZ";
+        String podQuery2 = "/system.slice/dbus.service//cpu/usage";
+
+        String allMatchCustomQuery = "*";
+        String allMatchProperQuery = ".*";
+        String orQuery = "a|b";
+        String orComplexQuery = "a|!b";
+        String startsWithQuery = "^abc+";
+        String wordMatchQuery = "\\w";
+        String notQuery = "!b";
+
+        assertFalse(SimpleTagQueryParser.QueryOptimizer.isRegExp(podQuery1));
+        assertFalse(SimpleTagQueryParser.QueryOptimizer.isRegExp(podQuery2));
+        assertTrue(SimpleTagQueryParser.QueryOptimizer.isRegExp(orQuery));
+        assertTrue(SimpleTagQueryParser.QueryOptimizer.isRegExp(orComplexQuery));
+        assertTrue(SimpleTagQueryParser.QueryOptimizer.isRegExp(notQuery));
+        assertTrue(SimpleTagQueryParser.QueryOptimizer.isRegExp(allMatchCustomQuery));
+        assertTrue(SimpleTagQueryParser.QueryOptimizer.isRegExp(allMatchProperQuery));
+        assertTrue(SimpleTagQueryParser.QueryOptimizer.isRegExp(startsWithQuery));
+        assertTrue(SimpleTagQueryParser.QueryOptimizer.isRegExp(wordMatchQuery));
+    }
+
+    @Test
+    public void testMultiSingleQueriesMatcher() {
+        String orQuery = "a|b";
+        String orComplexQuery = "a|!b";
+
+        assertEquals(SimpleTagQueryParser.QueryOptimizer.RegExpOptimizer.OR_SINGLE_SEEK, SimpleTagQueryParser
+                .QueryOptimizer.optimalStrategy(orQuery));
+        assertEquals(SimpleTagQueryParser.QueryOptimizer.RegExpOptimizer.NONE, SimpleTagQueryParser
+                .QueryOptimizer.optimalStrategy(orComplexQuery));
+    }
+
+    @Test
+    public void testReOrder() {
+        Map<String, String> tagsQuery = Maps.newHashMap();
+        tagsQuery.put("pod_hit", "norate"); // A
+        tagsQuery.put("pod_id", "pod1|pod2|pod3"); // AOR
+        tagsQuery.put("time", "*"); // B
+        tagsQuery.put("!seek", ""); // C
+        tagsQuery.put("pod_name", "pod1|!pod2"); // B
+
+
+        Map<Long, List<SimpleTagQueryParser.Query>> entries =
+                SimpleTagQueryParser.QueryOptimizer.reOrderTagsQuery(tagsQuery, true);
+
+        assertEquals(1, entries.get(SimpleTagQueryParser.QueryOptimizer.GROUP_A_COST).size());
+        assertEquals(1, entries.get(SimpleTagQueryParser.QueryOptimizer.GROUP_A_OR_COST).size());
+        assertEquals(3, entries.get(SimpleTagQueryParser.QueryOptimizer.GROUP_A_OR_COST).get(0).getTagValues().length);
+        assertEquals(2, entries.get(SimpleTagQueryParser.QueryOptimizer.GROUP_B_COST).size());
+        assertEquals(1, entries.get(SimpleTagQueryParser.QueryOptimizer.GROUP_C_COST).size());
+    }
+}


### PR DESCRIPTION
Enables the A-cost query execution (exact matches). This breaks previous behavior and as such can be disabled with a flag.

However, the advantage with large tags partitions should be huge. Needs a better regexp matching function still.