### PR TITLE
Fix MixedMetricsITest and MetricsServiceImpl.deleteMetric()

### DIFF
--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
+++ b/core/metrics-core-service/src/main/java/org/hawkular/metrics/core/service/MetricsServiceImpl.java
@@ -1099,12 +1099,15 @@ public class MetricsServiceImpl implements MetricsService {
                 .defaultIfEmpty(new HashMap<>())
                 .flatMap(map -> dataAccess.deleteFromMetricsTagsIndex(id, map))
                 .map(r -> null);
-        result = result.mergeWith(dataAccess.deleteMetricFromMetricsIndex(id).map(r -> null))
-                .mergeWith(dataAccess.deleteMetricData(id).map(r -> null))
-                .mergeWith(dataAccess.deleteMetricFromRetentionIndex(id).map(r -> null))
-                .mergeWith(dataAccess.deleteFromMetricExpirationIndex(id).map(r -> null));
+        Observable<Void> indexes = Observable.merge(
+                dataAccess.deleteMetricFromMetricsIndex(id),
+                dataAccess.deleteMetricData(id),
+                dataAccess.deleteMetricFromRetentionIndex(id),
+                dataAccess.deleteFromMetricExpirationIndex(id)
+        )
+                .map(r -> null);
 
-        return result;
+        return result.concatWith(indexes);
     }
 
     @Override

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/DataAccessITest.java
@@ -229,9 +229,7 @@ public class DataAccessITest extends BaseITest {
         assertEquals(metrics.size(), 4);
     }
 
-    // Temporarily disabled because of frequent, intermittent failures on travis that hold up PRs
-    // HWKMETRICS-749 was created as a reminder to fix it.
-    @Test(enabled = false)
+    @Test
     void testFindAllDataFromBucket() throws Exception {
         String tenantId = "t1";
         long start = now().getMillis();

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/TestDataAccessFactory.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/TestDataAccessFactory.java
@@ -28,15 +28,7 @@ import org.hawkular.metrics.core.service.log.CoreLogging;
 import org.hawkular.metrics.datetime.DateTimeService;
 import org.joda.time.DateTime;
 
-import com.datastax.driver.core.AggregateMetadata;
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.FunctionMetadata;
-import com.datastax.driver.core.KeyspaceMetadata;
-import com.datastax.driver.core.MaterializedViewMetadata;
-import com.datastax.driver.core.SchemaChangeListener;
 import com.datastax.driver.core.Session;
-import com.datastax.driver.core.TableMetadata;
-import com.datastax.driver.core.UserType;
 
 import rx.schedulers.Schedulers;
 

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/TestDataAccessFactory.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/TestDataAccessFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,10 +23,20 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.hawkular.metrics.core.service.log.CoreLogger;
+import org.hawkular.metrics.core.service.log.CoreLogging;
 import org.hawkular.metrics.datetime.DateTimeService;
 import org.joda.time.DateTime;
 
+import com.datastax.driver.core.AggregateMetadata;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.FunctionMetadata;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.MaterializedViewMetadata;
+import com.datastax.driver.core.SchemaChangeListener;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.UserType;
 
 import rx.schedulers.Schedulers;
 
@@ -35,7 +45,10 @@ import rx.schedulers.Schedulers;
  */
 public class TestDataAccessFactory {
 
+    private static final CoreLogger log = CoreLogging.getCoreLogger(TestDataAccessFactory.class);
+
     public static DataAccess newInstance(Session session) {
+        session.execute(String.format("USE %s", BaseITest.getKeyspace()));
         final CountDownLatch latch = new CountDownLatch(3);
         final CountDownLatch fallBackTable = new CountDownLatch(0);
         DataAccessImpl dataAccess = new DataAccessImpl(session) {
@@ -43,6 +56,7 @@ public class TestDataAccessFactory {
             void prepareTempStatements(String tableName, Long mapKey) {
                 super.prepareTempStatements(tableName, mapKey);
                 if(DataAccessImpl.OUT_OF_ORDER_TABLE_NAME.equals(tableName)) {
+                    log.infof("data_0 statements being prepared");
                     fallBackTable.countDown();
                 }
                 if (latch.getCount() > 0) {
@@ -59,7 +73,6 @@ public class TestDataAccessFactory {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-
         return dataAccess;
     }
 

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
@@ -49,11 +49,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
-import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.TableMetadata;
-import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/BaseMetricsITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.metrics.core.service.metrics;
 
 import static org.testng.Assert.assertEquals;
@@ -50,9 +49,11 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
+import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/MixedMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/MixedMetricsITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/MixedMetricsITest.java
+++ b/core/metrics-core-service/src/test/java/org/hawkular/metrics/core/service/metrics/MixedMetricsITest.java
@@ -58,6 +58,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import rx.Observable;
+import rx.observers.TestSubscriber;
 
 public class MixedMetricsITest extends BaseMetricsITest {
 
@@ -322,7 +323,11 @@ public class MixedMetricsITest extends BaseMetricsITest {
             Map<String, String> actualTags = metricsService.getMetricTags(mId).toBlocking().lastOrDefault(null);
             assertEquals(actualTags, m.getTags());
 
-            metricsService.deleteMetric(mId).toBlocking().lastOrDefault(null);
+            TestSubscriber<Void> deleteSubscriber = new TestSubscriber<>();
+            metricsService.deleteMetric(mId).subscribe(deleteSubscriber);
+            deleteSubscriber.awaitTerminalEvent(10, TimeUnit.SECONDS);
+            deleteSubscriber.assertNoErrors();
+            deleteSubscriber.assertCompleted();
             deletedMetrics.add(m);
 
             for (Metric<T> checkMetric : mList) {
@@ -370,8 +375,6 @@ public class MixedMetricsITest extends BaseMetricsITest {
                     assertEquals(countFromTagIndex, 1);
                 }
             }
-
-            metricsService.deleteMetric(mId).toBlocking().lastOrDefault(null);
         }
     }
 }


### PR DESCRIPTION
deleteMetric() used merge instead of concat which caused the tags deletion to be incomplete in certain concurrency scenarios (execution of commands is in incorrect order).

MixedMetricsITest tried to delete things twice and that way bypass test failures..

Also, add blocking for TestDataAccessFactory to make sure ``data_0`` is correctly prepared.