### PR TITLE
[HWKMETRICS-764] fix schema-installer build

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>hawkular-metrics-parent</artifactId>
     <groupId>org.hawkular.metrics</groupId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/AdminFilter.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/jaxrs/filter/AdminFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/servlet/OpenshiftServlet.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/servlet/OpenshiftServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/servlet/rx/ObservableServlet.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/servlet/rx/ObservableServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/servlet/rx/ServletWriteListener.java
+++ b/api/metrics-api-jaxrs/src/main/java/org/hawkular/metrics/api/servlet/rx/ServletWriteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/metrics-api-jaxrs/src/main/webapp/WEB-INF/web.xml
+++ b/api/metrics-api-jaxrs/src/main/webapp/WEB-INF/web.xml
@@ -33,7 +33,7 @@
     </init-param>
   </servlet>
 
-  <servlet>    
+  <servlet>
     <servlet-name>openshiftServlet</servlet-name>
     <servlet-class>org.hawkular.metrics.api.servlet.OpenshiftServlet</servlet-class>
     <async-supported>true</async-supported>

--- a/api/metrics-api-util/pom.xml
+++ b/api/metrics-api-util/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/api/metrics-api-util/pom.xml
+++ b/api/metrics-api-util/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/clients/common/pom.xml
+++ b/clients/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/clients/common/pom.xml
+++ b/clients/common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-clients</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-clients-common</artifactId>

--- a/clients/dropwizard/hawkular-dropwizard-reporter-factory/pom.xml
+++ b/clients/dropwizard/hawkular-dropwizard-reporter-factory/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-dropwizard-reporter-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-dropwizard-reporter-factory</artifactId>

--- a/clients/dropwizard/hawkular-dropwizard-reporter-factory/pom.xml
+++ b/clients/dropwizard/hawkular-dropwizard-reporter-factory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/clients/dropwizard/hawkular-dropwizard-reporter/pom.xml
+++ b/clients/dropwizard/hawkular-dropwizard-reporter/pom.xml
@@ -142,7 +142,7 @@
                 <argument>-Dhawkular.metrics.cassandra.keyspace=${cassandra.keyspace}</argument>
                 <argument>-Dhawkular.metrics.cassandra.resetdb=true</argument>
                 <argument>-jar</argument>
-                <argument>../../../core/schema-installer/target/hawkular-metrics-schema-installer.jar</argument>
+                <argument>../../../core/schema-installer/target/hawkular-metrics-schema-installer-${project.version}.jar</argument>
               </arguments>
             </configuration>
             <dependencies>

--- a/clients/dropwizard/hawkular-dropwizard-reporter/pom.xml
+++ b/clients/dropwizard/hawkular-dropwizard-reporter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-dropwizard-reporter-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-dropwizard-reporter</artifactId>

--- a/clients/dropwizard/pom.xml
+++ b/clients/dropwizard/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/clients/dropwizard/pom.xml
+++ b/clients/dropwizard/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-clients</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-dropwizard-reporter-parent</artifactId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-metrics-parent</artifactId>
     <groupId>org.hawkular.metrics</groupId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-clients</artifactId>

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -253,7 +253,7 @@
                 <argument>-Dhawkular.metrics.cassandra.keyspace=${cassandra.keyspace}</argument>
                 <argument>-Dhawkular.metrics.cassandra.resetdb=true</argument>
                 <argument>-jar</argument>
-                <argument>../../core/schema-installer/target/hawkular-metrics-schema-installer.jar</argument>
+                <argument>../../core/schema-installer/target/hawkular-metrics-schema-installer-${project.version}.jar</argument>
               </arguments>
             </configuration>
             <dependencies>

--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-clients</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ptrans</artifactId>

--- a/containers/hawkular-openshift-security-filter/pom.xml
+++ b/containers/hawkular-openshift-security-filter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-containers</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-openshift-security-filter</artifactId>

--- a/containers/hawkular-openshift-security-filter/pom.xml
+++ b/containers/hawkular-openshift-security-filter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/pom.xml
+++ b/containers/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-containers</artifactId>

--- a/containers/pom.xml
+++ b/containers/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/configuration-service/pom.xml
+++ b/core/configuration-service/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/configuration-service/pom.xml
+++ b/core/configuration-service/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/datetime-service/pom.xml
+++ b/core/datetime-service/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/datetime-service/pom.xml
+++ b/core/datetime-service/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/metrics-core-service/pom.xml
+++ b/core/metrics-core-service/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/metrics-model/pom.xml
+++ b/core/metrics-model/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/metrics-model/pom.xml
+++ b/core/metrics-model/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/rx-java-driver/pom.xml
+++ b/core/rx-java-driver/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/rx-java-driver/pom.xml
+++ b/core/rx-java-driver/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/schema-installer/README.adoc
+++ b/core/schema-installer/README.adoc
@@ -14,7 +14,7 @@ In its simplest form the installer can be run as:
 
 [source,bash]
 ----
-[jsanda@localhost schema-installer]$ java -jar target/hawkular-metrics-schema-installer.jar
+[jsanda@localhost schema-installer]$ java -jar target/hawkular-metrics-schema-installer-<version>.jar
 INFO  2018-03-08 15:26:48,783 [main] org.hawkular.metrics.schema.Installer:logVersion:104 - Hawkular Metrics Schema Installer v0.29.0-SNAPSHOT+12ad36d504
 INFO  2018-03-08 15:26:48,786 [main] org.hawkular.metrics.schema.Installer:logInstallerProperties:109 - Configured installer properties:
   cqlPort = 9042
@@ -94,7 +94,7 @@ Here is an example of overriding some of the default settings:
     -Dhawkular.metrics.cassandra.nodes=node1.com,node2.com \
     -Dhawkular.metrics.cassandra.keyspace=hawkulartest \
     -Dhawkular.metrics.version-update.delay=10 \
-    -jar target/hawkular-metrics-schema-installer.jar
+    -jar target/hawkular-metrics-schema-installer-<version>.jar
 ----
 
 == Logging

--- a/core/schema-installer/pom.xml
+++ b/core/schema-installer/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/schema-installer/pom.xml
+++ b/core/schema-installer/pom.xml
@@ -89,7 +89,6 @@
             </goals>
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
-              <finalName>hawkular-metrics-schema-installer</finalName>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.hawkular.metrics.schema.Installer</mainClass>

--- a/core/schema/pom.xml
+++ b/core/schema/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/data-generator/pom.xml
+++ b/data-generator/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-data-generator</artifactId>

--- a/data-generator/pom.xml
+++ b/data-generator/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/dist/containers/hawkular-metrics-openshift/pom.xml
+++ b/dist/containers/hawkular-metrics-openshift/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-dist</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-dist</artifactId>

--- a/integration-tests/jmh-benchmark/pom.xml
+++ b/integration-tests/jmh-benchmark/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration-tests/jmh-benchmark/pom.xml
+++ b/integration-tests/jmh-benchmark/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-integration-tests</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/load-tests/pom.xml
+++ b/integration-tests/load-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration-tests/load-tests/pom.xml
+++ b/integration-tests/load-tests/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-integration-tests</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-load-tests</artifactId>

--- a/integration-tests/metrics-api-jaxrs-test/pom.xml
+++ b/integration-tests/metrics-api-jaxrs-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-integration-tests</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-api-jaxrs-test</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-integration-tests</artifactId>

--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-integration-tests</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-rest-tests-jaxrs</artifactId>

--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -166,7 +166,7 @@
                 <argument>-Dhawkular.metrics.cassandra.keyspace=${cassandra.keyspace}</argument>
                 <argument>-Dhawkular.metrics.cassandra.resetdb=true</argument>
                 <argument>-jar</argument>
-                <argument>../../core/schema-installer/target/hawkular-metrics-schema-installer.jar</argument>
+                <argument>../../core/schema-installer/target/hawkular-metrics-schema-installer-${project.version}.jar</argument>
               </arguments>
             </configuration>
             <dependencies>

--- a/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
+++ b/integration-tests/rest-tests-jaxrs/src/test/groovy/org/hawkular/metrics/rest/MetricsITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/job-scheduler/pom.xml
+++ b/job-scheduler/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.29.0-SNAPSHOT</version>
+    <version>0.31.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-job-scheduler</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.hawkular.metrics</groupId>
   <artifactId>hawkular-metrics-parent</artifactId>
-  <version>0.29.0-SNAPSHOT</version>
+  <version>0.31.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Hawkular Metrics</name>


### PR DESCRIPTION
This PR fixes the installer build so that the shaded (i.e., fat) JAR is published.