### PR TITLE
Add infinispan module to hawkular-metrics-openshift

### DIFF
--- a/dist/containers/hawkular-metrics-openshift/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/dist/containers/hawkular-metrics-openshift/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2016 Red Hat, Inc. and/or its affiliates
+    Copyright 2014-2018 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@
       <module name="org.jboss.resteasy.resteasy-jettison-provider"/>
     </exclusions>
     <dependencies>
+      <module name="org.infinispan"/>
       <module name="org.jboss.resteasy.resteasy-jackson2-provider" services="import"/>
       <module name="org.jboss.xnio"/>
       <module name="org.jboss.xnio.nio"/>


### PR DESCRIPTION
@jsanda I forgot to include this module on the OpenShift war. So now is when you try to deploy that war Wildfly throws an error about infinispan.Cache class not found.

Please review. 