### PR TITLE
Move to 0.31.2.Final-SNAPSHOT

### DIFF
--- a/api/metrics-api-jaxrs/pom.xml
+++ b/api/metrics-api-jaxrs/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>hawkular-metrics-parent</artifactId>
     <groupId>org.hawkular.metrics</groupId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/api/metrics-api-util/pom.xml
+++ b/api/metrics-api-util/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/containers/hawkular-openshift-security-filter/pom.xml
+++ b/containers/hawkular-openshift-security-filter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-containers</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-openshift-security-filter</artifactId>

--- a/containers/pom.xml
+++ b/containers/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-containers</artifactId>

--- a/core/configuration-service/pom.xml
+++ b/core/configuration-service/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/datetime-service/pom.xml
+++ b/core/datetime-service/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/metrics-core-service/pom.xml
+++ b/core/metrics-core-service/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/metrics-model/pom.xml
+++ b/core/metrics-model/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/rx-java-driver/pom.xml
+++ b/core/rx-java-driver/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/schema-installer/pom.xml
+++ b/core/schema-installer/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/schema/pom.xml
+++ b/core/schema/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/data-generator/pom.xml
+++ b/data-generator/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-data-generator</artifactId>

--- a/dist/containers/hawkular-metrics-openshift/pom.xml
+++ b/dist/containers/hawkular-metrics-openshift/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-dist</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-dist</artifactId>

--- a/integration-tests/jmh-benchmark/pom.xml
+++ b/integration-tests/jmh-benchmark/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-integration-tests</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/load-tests/pom.xml
+++ b/integration-tests/load-tests/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-integration-tests</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-load-tests</artifactId>

--- a/integration-tests/metrics-api-jaxrs-test/pom.xml
+++ b/integration-tests/metrics-api-jaxrs-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-integration-tests</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-api-jaxrs-test</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-integration-tests</artifactId>

--- a/integration-tests/rest-tests-jaxrs/pom.xml
+++ b/integration-tests/rest-tests-jaxrs/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-integration-tests</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-rest-tests-jaxrs</artifactId>

--- a/job-scheduler/pom.xml
+++ b/job-scheduler/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.hawkular.metrics</groupId>
     <artifactId>hawkular-metrics-parent</artifactId>
-    <version>0.31.1.Final</version>
+    <version>0.31.2.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-metrics-job-scheduler</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.hawkular.metrics</groupId>
   <artifactId>hawkular-metrics-parent</artifactId>
-  <version>0.31.1.Final</version>
+  <version>0.31.2.Final-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Hawkular Metrics</name>


### PR DESCRIPTION
Should we start doing this, @rubenvp8510 ? It's quite a usual thing to do after releasing a version, I noticed Hawkular Metrics doesn't do that though. If it's for some reason an issue (for example for building development OpenShift images or so), we don't have to do this...